### PR TITLE
[HeroSystem6eHeroic] Maneuver and color accessibility improvements. Bug fixes

### DIFF
--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1253,14 +1253,11 @@
 		color: white;
 	}
 	
-	.item-characteristics-perception input[type=number] {
-		text-align: right;
-		padding-right: 0px;
-		border: solid 1px palegoldenrod;
-		margin: 0px;
-		margin-bottom: 3px;
-		background-color: white;
-		max-width: 40px;
+	.subitem-characteristics-perception-row-container {
+		display: flex;
+		justify-content: space-between;
+		flex-direction: row;
+		margin-top: 2px;
 	}
 	
 	.subitem-characteristics-perception-stat-container {
@@ -1286,29 +1283,36 @@
 		display: flex;
 		justify-content: space-between;
 		flex-direction: column;
-		background-color: #cce8f8;
-		padding: 2px;
+		padding: 1px;
+		padding-bottom: 3px;
 		align-items: center;
 		border-radius: 5px;
-		border: solid #eef7fc 2px;
+		width: 55px;
+		background-color: #cce8f8;
+		border: solid #bbe1f6 2px;
+	}
+	
+	.item-characteristics-perception input[type=number] {
+		text-align: right;
+		font-weight: bold;
+		margin: 0px;
+		margin-bottom: 2px;
+		padding: 0px;
+		max-width: 40px;
+		background-color: white;
+		border: solid 1px #88caef;
 	}
 	
 	.subitem-characteristics-perception-column-container input[type=text] {
 		font-size: 13px;
-		max-width: 32px;
-		line-height: 1.3;
-		text-align: center;
-		background-color: #cce8f8;
-		padding: 0px;
-		color: black;
 		font-weight: bold;
-	}
-	
-	.subitem-characteristics-perception-row-container {
-		display: flex;
-		justify-content: space-between;
-		flex-direction: row;
-		margin-top: 2px;
+		text-align: center;
+		padding: 0px;
+		margin: 0px;
+		margin-bottom: 2px;
+		max-width: 32px;
+		color: black;
+		background-color: #cce8f8;
 	}
 	
 	/* --------------------------------------------------- */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -240,7 +240,7 @@
 	}
 	
 	.custom-select-alternate-skill::after {
-		background-color: #CC79A7;
+		background-color: #66c4ab;
 	}
 	
 	.custom-select-option::after  {
@@ -780,7 +780,7 @@
 	}
 	
 	.item-characteristics-combat-attributes h1 {
-		background: #f4ec7a;
+		background: #f2cf7f;
 		padding-left: 5px;
 		padding-right: 6px;
 		padding-top: 2px;
@@ -2771,7 +2771,8 @@
 		padding-top: 6px;
 		margin-bottom: 0px;
 		font-size: 16px;
-		background-color: #f2cf7f;
+		/* background-color: #f2cf7f; */
+		background-color: #f0c566;
 		border: 3px solid #f6ee8d;
 		border-radius: 5px;
 		justify-content: middle;
@@ -3117,7 +3118,7 @@
 	
 	.subitem-skillsTab-flex-container-combat-skills-costs input[readonly] {
 		text-align: center;
-		background-color: #f6ee8d;
+		background-color: transparent;
 		max-width: 30px;
 		margin-left: 5px;
 	}
@@ -3186,10 +3187,10 @@
 	
 	.subitem-skillsTab-flex-container-language input[readonly] {
 		text-align: center;
-		background-color: #f6ee8d;
+		background-color: transparent;
 		max-width: 22px;
-		margin-right: 0px;
-		margin-left: 3px;
+		margin-right: 3px;
+		margin-left: 0px;
 		border: transparent;
 	}
 	
@@ -3226,7 +3227,7 @@
 	}
 	
 	.item-skillsTab-grid-container-skill-enhancers input[readonly]{
-		background-color: #f6ee8d;
+		background-color: transparent;
 		text-align: center;
 		height: 18px;
 		max-width: 30px;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1,5352 +1,5377 @@
-	/* --------------------------------------------------- */
-	/* Roll20-specific styling                             */
-	/* --------------------------------------------------- */
+		/* --------------------------------------------------- */
+/* Roll20-specific styling                             */
+/* --------------------------------------------------- */
+
+.charsheet {
+	background: white;
+}
+
+body.sheet-darkmode .charsheet {
+	background: #1f1f1f;
+}
+
+/* Roll20 Roll Button re-styling, Thanks to Scott C. */
+
+button[type=roll] {
+	/* Override Roll20 default styling */
+	border: none;
+	text-shadow: none;
+	line-height: 14px;
+	background-image: none;
+	box-shadow: none;
 	
-	.charsheet {
-		background: white;
-	}
+	/* Set global border radius of 'Roll' buttons here. */
+	border-radius: 3px;
 	
-	body.sheet-darkmode .charsheet {
-		background: #1f1f1f;
-	}
+	/* Set global font weight and size here. */
+	font-style: normal;
+	font-weight: bold;
+	font-size: 13px !important;
+}
+
+button[type=roll]::before{
+	/* Remove Roll20 d20 */
+	content: "" !important;
+}
+
+/* --------------------------------------------------- */
+/* Browser-specific Styling                            */
+/* --------------------------------------------------- */
+
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+	/* CSS Statements that only apply on webkit-based browsers (Chrome, Safari, etc.) */
 	
-	/* Roll20 Roll Button re-styling, Thanks to Scott C. */
-	
-	button[type=roll] {
-		/* Override Roll20 default styling */
-		border: none;
-		text-shadow: none;
-		line-height: 14px;
-		background-image: none;
-		box-shadow: none;
-		
-		/* Set global border radius of 'Roll' buttons here. */
-		border-radius: 3px;
-		
-		/* Set global font weight and size here. */
-		font-style: normal;
-		font-weight: bold;
-		font-size: 13px !important;
-	}
-	
-	button[type=roll]::before{
-		/* Remove Roll20 d20 */
-		content: "" !important;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Browser-specific Styling                            */
-	/* --------------------------------------------------- */
-	
-	@media screen and (-webkit-min-device-pixel-ratio:0) {
-		/* CSS Statements that only apply on webkit-based browsers (Chrome, Safari, etc.) */
-		
-		input[type=number]:hover,
-		input[type=number]:focus {
-			padding-right: 1px;  /* Keeps some numbers from shifting during mouse hover and click. */
-		}
-		
-		input:read-only::-webkit-outer-spin-button,
-		input:read-only::-webkit-inner-spin-button {
-			-webkit-appearance: none;
-			margin: 0;
-		}
-	}
-	
-	@-moz-document url-prefix() {
-		/* CSS Statements that only apply on Firefox */
-	
-		input[type=number]:hover,
-		input[type=number]:focus {
-			-moz-appearance: number-input;
-			padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. */
-		}
-		
-		input[type=number]:read-only {
-		  	-moz-appearance: textfield;
-		} 
-		
-	}
-	
-	/* ----------------------------------------------------	*/
-	/* General Styling 										*/
-	/* ----------------------------------------------------	*/
-	
-	/* Okabe and Ito colorblind-safe palette:				*/
-	/* Green: 			#009E73								*/
-	/* Blue: 			#0072B2 							*/
-	/* Light blue: 		#56B4E9 							*/
-	/* Yellow: 			#F0E442								*/
-	/* Orange: 			#E69F00								*/
-	/* Orange-red: 		#D55E00								*/
-	/* Violet: 			#CC79A7								*/
-	/* 														*/
-	/* Plus:												*/
-	/* A mid-tone gray:	#8A8A8A								*/
-	
-	textarea {
-		font-size: 14px;
-		resize: none;
-	}
-	
-	input {
-		font-size: 13px;
-		border: hidden;
-		border-radius: 3px;
-		padding: 0px;
-		text-align: center;
-	}
-	
+	input[type=number]:hover,
 	input[type=number]:focus {
-		outline: none;
+		padding-right: 1px;  /* Keeps some numbers from shifting during mouse hover and click. */
 	}
 	
-	input[type=text]:focus,
-		textarea:focus,
-		button:focus {
-	}
-	
-	input.customCheckbox {
-		width: 20px;
-		height: 20px;
-		vertical-align: middle;
-	}
-	
-	
-	/* --------------------------------------------------------------- */
-	/* Custom select used due to differences between Firefox,          */
-	/* Chrome, and Safari. From:                                       */
-	/* @link https://moderncss.dev/custom-select-styles-with-pure-css/ */
-	/* --------------------------------------------------------------- */
-	
-	
-	select,
-	select::before,
-	select::after {
-  	box-sizing: border-box;
-	}
-		
-	select {
+	input:read-only::-webkit-outer-spin-button,
+	input:read-only::-webkit-inner-spin-button {
 		-webkit-appearance: none;
-		-moz-appearance: none;
-		appearance: none;
-		background-color: transparent;
-		border: none;
-		padding: 0 1em 0 0;
 		margin: 0;
-		width: 100%;
-		font-family: inherit;
-		/* font-size: inherit; */
-		font-size: 12px;
-		cursor: inherit;
-		line-height: inherit;
-		z-index: 1;
-		outline: none;
-		max-height: 22px;
 	}
-	
-	.custom-select,
-	.custom-select-skill,
-	.custom-select-alternate,
-	.custom-select-alternate-skill,
-	.custom-select-option {
-		display: grid;
-		grid-template-areas: "select";
-		align-items: center;
-		position: relative;
-		max-height: 20px;
-		border: 1px solid gray;
-		border-radius: 3px;
-		padding: 0px;
-		padding-bottom: 1px;
-		padding-right: 3px;
-		cursor: pointer;
-		background-color: #fff;
-		background-image: linear-gradient(to top, #f9f9f9, #fff 33%);
-	}
-	
-	.custom-select,
-	.custom-select-skill,
-	.custom-select-alternate,
-	.custom-select-alternate-skill {
-		min-width: 34px;
-		padding-left: 0px;
-	}
-	
-	.custom-select-option {
-		width: 58px;
-		background-color: red;
-		padding-left: 4px;
-		margin-right: 6px;
-	}
-	
-	.custom-select-skill,
-	.custom-select-alternate-skill {
-		margin-top: 2px;
-		margin-bottom: 1px;
-		max-height: 20px;
-	}
-	
-	.custom-select select,
-	.custom-select-skill select,
-	.custom-select-alternate select,
-	.custom-select-alternate-skill select,
-	.custom-select-option select,
-	.custom-select::after,
-	.custom-select-skill::after,
-	.custom-select-alternate::after,
-	.custom-select-alternate-skill::after,
-	.custom-select-option::after {
-		grid-area: select;
-	}
-	
-	.custom-select::after,
-	.custom-select-skill::after,
-	.custom-select-alternate::after,
-	.custom-select-alternate-skill::after,
-	.custom-select-option::after {
-		content: "";
-		justify-self: end;
-		width: 12px;
-		height: 8px;
-		-webkit-clip-path: polygon(100% 0%, 0 0%, 50% 100%);
-		clip-path: polygon(100% 0%, 0 0%, 50% 100%);
-	}
-	
-	.custom-select::after,
-	.custom-select-skill::after {
-		background-color: olive;
-	}
-	
-	.custom-select-alternate::after,
-	.custom-select-alternate-skill::after {
-		background-color: salmon;
-	}
-	
-	.custom-select-option::after  {
-		background-color: dodgerblue;
-	}
-	
-	select:focus + .focus {
-		position: absolute;
-		top: -1px;
-		left: -1px;
-		right: -1px;
-		bottom: -1px;
-		border: 2px solid goldenrod;
-		border-radius: inherit;
-	}
-	
-	.custom-select--disabled,
-	.custom-select-skill--disabled,
-	.custom-select-alternate--disabled,
-	.custom-select-alternate-skill--disabled,
-	.custom-select-alternate-option--disabled {
-		cursor: not-allowed;
-		background-color: #eee;
-		background-image: linear-gradient(to top, #ddd, #eee 33%);
-	}
-	
-	.custom-select-skill,
-	.custom-select-alternate-skill {
-		width: 64px;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Tab Styling                                         */
-	/* --------------------------------------------------- */
-	.tab {
-		display: flex;
-		justify-content: space-between;
-		height:36px;
-		padding: 0px;
-		widows: 100%;
-		margin-bottom: 0px;
-		margin-left: 0px;
-		margin-right: 0px;
-		width: 680px;
-		background: dodgerblue;
-		border: 8px;
-		border-bottom: 0px;
-		border-radius: 4px;
-		border-bottom-left-radius: 0px;
-		border-bottom-right-radius: 0px;
-		border-color: dodgerblue;
-		border-style: solid;
-	}
-	
-	/* Style the buttons inside the tab */
-	.tab button {
-		background-color: #CCCCFF;
-		float: left;
-		outline: none;
-		cursor: pointer;
-		padding: 10px 10px;
-		margin-right: 0px;
-		transition: 0.3s;
-		font-size: 18px;
-		border: 0px;
-	}
-	
-	/* Change background color of buttons on hover */
-	.tab button:hover {
-		background-color: yellow;
-	}
-	
-	/* Create an active/current tab class */
-	.tab button.active {
-		background-color: yellow;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Configure sheet and tab buttons                     */
-	/* --------------------------------------------------- */
-	.sheet-characteristics,
-	.sheet-skills,
-	.sheet-powers,
-	.sheet-complications,
-	.sheet-gear,
-	.sheet-options {
-		display: none;
-		width: 680px;
-		background: dodgerblue;
-		border: 8px;
-		border-color: dodgerblue;
-		border-style: solid;
-	}
-	
-	/* show the selected tab */
-	.sheet-tabstoggle[value="characteristics"] ~ div.sheet-characteristics,
-	.sheet-tabstoggle[value="skills"] ~ div.sheet-skills,
-	.sheet-tabstoggle[value="powers"] ~ div.sheet-powers,
-	.sheet-tabstoggle[value="complications"] ~ div.sheet-complications,
-	.sheet-tabstoggle[value="gear"] ~ div.sheet-gear,
-	.sheet-tabstoggle[value="options"] ~ div.sheet-options {
-		display: block;
-	}
-	
-	/* Styling for characteristics tab labels */
-	.sheet-characteristics label {
-		display:inline-block;
-		font-size: 13px;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Tally Bar styling                                   */
-	/* --------------------------------------------------- */
-	
-	.sheet-tallybar {
-		width: 680px;
-		background: dodgerblue;
-		border: 8px;
-		border-top: 0px;
-		border-radius: 4px;
-		border-top-left-radius: 0px;
-		border-top-right-radius: 0px;
-		border-color: dodgerblue;
-		border-style: solid;
-	}
-	
-	.sheet-flex-tallybar {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
-		align-items: center;
-		justify-content: space-evenly;
-		width: 668px;
-		height: 36px;
-		border: 3px solid #fff990;
-		border-radius: 5px;
-		background: royalblue;
-		margin: 0px;
-		padding-left: 3px;
-		padding-right: 3px;
-	}
-	
-	.sheet-flex-tallybar span {
-		color: white;
-	}
-	
-	.sheet-flex-tallybar span:nth-child(1) {
-		color: white;
-	
-	}
-	
-	.sheet-flex-tallybar input[type=number] {
-		min-width: 52px;
-		text-align: right;
-		padding-right: 0px;
-	}
-	
-	.sheet-flex-tallybar input[type=number]:hover,
-	.sheet-flex-tallybar input[type=number]:focus {
-		padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. Both webkit and moz. For some reason. */
-	}
-	
-	.sheet-flex-tallybar input[readonly] {
-		background: #fff990;
-		padding-right: 0px;
-		min-width: 36px;
-		max-width: 40px;
-		text-align: center;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Characteristics Tab styling                         */
-	/* --------------------------------------------------- */
-	
-	.grid-container-tab-characteristics {
-		display: grid;
-		grid-template-areas: "leftGrid rightGrid";
-		grid-template-columns: 335px 335px;
-		max-width: 674px;
-		height: 801px;
-		font-size: 16px;
-		grid-gap: 5px;
-		background-color: royalblue;
-		border: 3px solid #fff990;
-		border-radius: 5px;
-		margin-bottom: 0px;
-	}
-	
-	.grid-container-tab-characteristics input[readonly]{
-		background: #fff990;
-	}
-	
-	/* characteristics tab left side */
-	
-	.grid-container-characteristics-leftGrid {
-		grid-area: leftGrid;
-		display: grid;
-		grid-template-areas:
-		"logo"
-		"bio"
-		"earnings"
-		"primaryAbilities"
-		"combatAbilities"
-		"movementAbilities";
-		grid-template-columns: 329px;
-		grid-gap: 0px;
-		background: royalblue;
-		margin-bottom: 5px;
-	}
-	
-	.grid-container-characteristics-leftGrid  h1 {
-		padding-left: 0px;
-		padding-top: 5px;
-		padding-bottom: 0px;
-		margin: 0px;
-		font-size: 13px;
-		font-style: normal;
-		line-height: 1.40;
-		min-width: 54px;
-	}
-	
-	.grid-container-characteristics-leftGrid  h2 {
-		height: 20px;
-		line-height: 1.6;
-		margin-left: 5px;
-		margin-bottom: 0px;
-		margin-top: 2px;
-		font-size: 13px;
-		font-style: normal;
-	}
-	
-	/* Item: logo graphic bio0 */
-	
-	.item-characteristics-logo {
-		grid-area: logo;
-		padding: 2px;
-		background-color: royalblue;
-		margin-bottom: 4px;
-	}
-	
-	/* Item: character bio bio1*/
-	
-	.item-characteristics-bio {	
-		max-width: 330px;
-		grid-area: bio;
-		display: grid;
-		grid-template-areas:
-		"nameLabel nameText nameText nameText"
-		"titleLabel titleText titleText titleText"
-		"backgroundLabel backgroundText backgroundText backgroundText";
-		grid-template-columns: 85px 105px 57px 73px;
-		grid-template-rows: 30px 30px 48px;
-		margin-left: 6px;
-		margin-bottom: 0px;
-		padding: 5px;
-		padding-bottom: 0px;
-		background-color: gold;
-		border-top: solid 1px goldenrod;
-		border-right: solid 1px goldenrod;
-		border-left: solid 1px goldenrod;
-		border-top-left-radius: 3px;
-		border-top-right-radius: 3px;
-		vertical-align: top;
-	}
-	
-	.item-characteristics-bio input[type=text] {
-		text-align:left;
-		width: 222px;
-		padding: 2px;
-		padding-left: 4px;
-		margin-left: 5px;
-		border: solid 1px goldenrod;
-		font-size: 13;
-		font-weight: bold;
-	}
-	
-	.item-characteristics-bio textarea {
-		width: 214px;
-		max-height: 36px;
-		padding: 2px;
-		padding-left: 4px;
-		margin-left: 5px;
-		border: solid 1px black;
-		text-align: left;
-		border: solid 1px goldenrod;
-	}
-	
-	/* Subitem: Character Name Label */
-	.item-characteristics-bio-nameLabel {
-		grid-area: nameLabel;
-		background: gold;
-	}
-	
-	/* Subitem: Character Name Text */
-	.item-characteristics-bio-name {
-		grid-area: nameText;
-	}
-	
-	/* Subitem: Character Title Label */
-	.item-characteristics-bio-titleLabel {
-		grid-area: titleLabel;
-		background: gold;
-	}
-	
-	/* Subitem: Character Title Text */
-	.item-characteristics-bio-titleText {
-		grid-area: titleText;
-	}
-	
-	/* Subitem: Character background label */
-	.item-characteristics-bio-backgroundLabel {
-		grid-area: backgroundLabel;
-		background: gold;
-	}
-	
-	/* Subitem: Character background text */
-	.item-characteristics-bio-backgroundText {
-		grid-area: backgroundText;
-	}
-	
-	/* Item: character bio experience and money*/
-	
-	.item-characteristics-earnings {	
-		max-width: 330px;
-		grid-area: earnings;
-		display: grid;
-		grid-template-areas:
-		"experienceLabel experience moneyLabel money";
-		grid-template-columns: 90px 57px 95px 83px;
-		grid-template-rows: 23px;
-		margin-left: 6px;
-		margin-bottom: 6px;
-		padding-top: 0px;
-		padding-bottom: 0px;
-		padding: 5px;
-		padding-bottom: 0px;
-		background-color: #fff990;
-		border-left: solid 1px goldenrod;
-		border-right: solid 1px goldenrod;
-		border-bottom: solid 1px goldenrod;
-		border-bottom-left-radius: 3px;
-		border-bottom-right-radius: 3px;
-		vertical-align: top;
-	}
-	
-	.item-characteristics-earnings h1 {
-		margin-bottom: 10px;
-		padding-left: 3px;
-		padding-top: 4px;
-		line-height: 1.3;
-	}
-	
-	.item-characteristics-earnings-experience input {
-		min-width: 54px;
-		padding-right: 0px;
-		padding-top: 0px;
-	}
-	
-	.item-characteristics-earnings input[type=number] {
-		text-align: right;
-		padding-right: 0px;
-		border: solid 1px palegoldenrod;
-		padding-top: 0px;
-		margin-bottom: 5px;
-	}
-	
-	.item-characteristics-earnings input[type=text] {
-		font-size: 13px;
-		max-width: 90px;
-		text-align: right;
-		background-color: #fff990;
-		font-weight: bold;
-		margin-top: 0px;
-		margin-bottom: 1px;
-		color: black;
-	}
-	
-	/* Subitem: Character Experience */
-	.item-characteristics-earnings-experienceLabel {
-		grid-area: experienceLabel;
-	}
-	
-	/* Subitem: Character Experience */
-	.item-characteristics-earnings-experience {
-		grid-area: experience;
-	}
-	
-	/* Subitem: Character Money */
-	.item-characteristics-earnings-moneyLabel {
-		grid-area: moneyLabel;
-	}
-	
-	/* Subitem: Character Money */
-	.item-characteristics-earnings-money {
-		grid-area: money;
-	}
-	
-	.item-characteristics-earnings-money input[type=number] {
-		min-width: 70px;
-		margin-bottom: 5px;
-	}
-	
-	/* Item: core abilities */
-	.item-characteristics-primary-attributes {
-		grid-area: primaryAbilities;
-		display: grid;
-		grid-template-areas:
-		"primaryAbilityNames primaryAbilityValues primaryAbilityChances primaryAbilityButtons primaryAbilityCosts";
-		grid-template-columns: 126px 49px 50px 45px 45px;
-		min-width: 300px;
-		vertical-align: middle;
-		margin-left: 6px;
-		background-color: #fff990; 
-		border-top: solid 1px goldenrod;
-		border-left: solid 1px goldenrod;
-		border-right: solid 1px goldenrod;
-		border-bottom: 0px;
-		border-top-left-radius: 3px;
-		border-top-right-radius: 3px;
-		padding-bottom: 2px;
-	}
-	
-	.item-characteristics-primary-attributes h1 {
-		background: gold;
-		padding-left: 5px;
-		padding-right: 6px;
-		padding-top: 2px;
-		padding-bottom: 2px;
-		margin: 0px;
-		margin-top: 0px;
-		font-size: 13px;
-		font-style: normal;
-		line-height: 1.35;
-	}
-	
-	.item-characteristics-primary-attributes h2 {
-		margin-left: 8px;
-	}
-	
-	.item-characteristics-primary-attributes input[type=number] {
-		text-align: right;
-		padding-right: 0px;
-		border: solid 1px palegoldenrod;	
-	}
-	
-	.item-characteristics-primary-attributes input[readonly] {
-		text-align: center;
-		border: none;	
-		max-width: 45px;
-	}
-	
-	/* Sub-Item: core abilities characteristics */
-	.item-characteristics-primary-attributes-names {
-		grid-area: primaryAbilityNames;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		text-align: left;
-		min-height: 130px;
-		max-height: 160px;
-	}
-	
-	/* Sub-Item: core abilities values */
-	.item-characteristics-primary-attributes-values {
-		grid-area: primaryAbilityValues;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		text-align: left;
-		min-height: 130px;
-		max-height: 160px;
-		max-width: 55px;
-	}
-	
-	/* Sub-Item: core abilities values */
-	.item-characteristics-primary-attributes-rollChances {
-		grid-area: primaryAbilityChances;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		text-align: left;
-		min-height: 130px;
-		max-height: 160px;
-	}
-	
-	.item-characteristics-primary-attributes-rollChances h1 {
-		margin-left: 6px;
-	}
-	
-	/* Sub-Item: core abilities values */
-	.item-characteristics-primary-attributes-rollButtons {
-		grid-area: primaryAbilityButtons;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		min-height: 130px;
-		max-height: 160px;
-	}
-	
-	/* Sub-Item: core abilities values */
-	.item-characteristics-primary-attributes-costs {
-		grid-area: primaryAbilityCosts;
-		text-align: center;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		min-height: 130px;
-		max-height: 160px;
-	}
-	
-	.item-characteristics-primary-attributes-costs h1 {
-		margin-left: 8px;
-		text-align: left;
-		min-width: 32px;
-	}
-	
-	/* Item: combat abilities */
-	.item-characteristics-combat-attributes {
-		grid-area: combatAbilities;
-		display: grid;
-		grid-template-areas:
-		"combatAbilityNames combatAbilityValues . . combatAbilityCosts";
-		grid-template-columns: 126px 49px 50px 45px 45px;
-		min-width: 300px;
-		vertical-align: middle;
-		margin-left: 6px;
-		background-color: #fff990; 
-		border: solid 1px goldenrod;
-		border-right: solid 1px goldenrod;
-		border-left: solid 1px goldenrod;
-		border-bottom: none;
-		border-top: none;
-		padding-bottom: 2px;
-	}
-	
-	.item-characteristics-combat-attributes input[type=number] {
-		text-align: right;
-		padding-right: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.item-characteristics-combat-attributes input[readonly] {
-		text-align: center;
-		padding-right: 2px;
-		border: none;
-		max-width: 45px;
-	}
-	
-	.item-characteristics-combat-attributes h1 {
-		background: gold;
-		padding-left: 5px;
-		padding-right: 6px;
-		padding-top: 2px;
-		padding-bottom: 2px;
-		margin: 0px;
-		margin-top: 0px;
-		font-size: 13px;
-		font-style: normal;
-		line-height: 1.35;
-	}
-	
-	.item-characteristics-combat-attributes h2 {
-		margin-left: 8px;
-	}
-	
-	/* Sub-Item: combat abilities characteristics */
-	.item-characteristics-combat-attributes-names {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		text-align: left;
-		grid-area: combatAbilityNames;
-		min-width: 120px;
-	}
-	
-	/* Sub-Item: core abilities values */
-	.item-characteristics-combat-attributes-values {
-		text-align: center;
-		grid-area: combatAbilityValues;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		min-width: 152px;
-		text-align: left;
-	}
-	
-	/* Sub-Item: core abilities values */
-	.item-characteristics-combat-attributes-costs {
-		grid-area: combatAbilityCosts;
-		text-align: right;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-	}
-	
-	.item-characteristics-combat-attributes-costs h1 {
-		margin-left: 8px;
-		text-align: left;
-		min-width: 32px;
-	}
-	
-	/* Item: combat abilities */
-	.item-characteristics-movement-abilities {
-		grid-area: movementAbilities;
-		display: grid;
-		grid-template-areas:
-		"movementNames movementValues . . movementCosts";
-		grid-template-columns: 126px 49px 50px 45px 45px;
-		background: purple;
-		min-width: 300px;
-		margin-left: 6px;
-		padding-bottom: 2px;
-		background-color: #fff990; 
-		border-right: solid 1px goldenrod;
-		border-left: solid 1px goldenrod;
-		border-bottom: solid 1px goldenrod;
-		border-top: none;
-		border-bottom-left-radius: 3px;
-		border-bottom-right-radius: 3px;
-	}
-	
-	.item-characteristics-movement-abilities input[type=number] {
-		text-align: right;
-		padding-right: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.item-characteristics-movement-abilities input[readonly] {
-		text-align: center;
-		padding-right: 0px;
-		border: none; 
-		max-width: 45px;
-	}
-	
-	.item-characteristics-movement-abilities h1 {
-		background: gold;
-		padding-left: 5px;
-		padding-right: 6px;
-		padding-top: 2px;
-		padding-bottom: 2px;
-		margin: 0px;
-		margin-top: 0px;
-		font-size: 13px;
-		font-style: normal;
-		line-height: 1.35;
-	}
-	
-	.item-characteristics-movement-abilities h2 {
-		margin-left: 8px;
-	}
-	
-	/* Sub-Item: combat abilities characteristics */
-	.item-characteristics-movement-abilities-names {
-		grid-area: movementNames;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-	}
-	
-	/* Sub-Item: core abilities values */
-	.item-characteristics-movement-abilities-values {
-		grid-area: movementValues;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-	}
-	
-	.item-characteristics-movement-abilities-values h1 {
-		min-width: 141px;
-	}
-	
-	/* Sub-Item: core abilities costs */
-	.item-characteristics-movement-abilities-costs {
-		grid-area: movementCosts;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-	}
-	
-	.item-characteristics-movement-abilities-costs h1 {
-		margin-left: 8px;
-		text-align: left;
-		min-width: 32px;
-	}
-	
-	/* characteristics tab right side */
-	
-	.grid-container-characteristics-rightGrid {
-		grid-area: rightGrid;
-		display: grid;
-		grid-template-areas:
-		"portrait health"
-		"turnSegmentIndicators turnTracker"
-		"perception perception"
-		"history history";
-		grid-template-columns: 264px 68px;
-		grid-template-rows: 260px 22px 100px 419px;
-		background: royalblue;
-		max-height: 800px;
-		max-width: 300px;
-	}
-	
-	
-	/* Item: character portrait graphic */
-	.item-characteristics-portrait {
-		grid-area: portrait;
-		position: relative;
-		width: 100%;
-		max-width: 250px;
-		padding: 0px;
-		height: 250px;
-		margin: 3px;
-		margin-left: 0px;
-		margin-top: 4px;
-		background-color: royalblue;
-	}
-	
-	.item-characteristics-portrait textarea {
-		width: 242px;
-		margin-left: 5px;
-		margin-right: 5px;
-		margin-bottom: 4px;
-		background-color: lavender;
-		height: 242px;
-		font-size: 14px;
-	}
-	
-	.item-characteristics-portrait img {
-		width: 100%;
-		height: auto;
-		margin-left: 7px;
-		border-right: solid gray 1px;
-		border-bottom: solid gray 1px;
-		border-left: solid darkgray 1px;
-		border-top: solid darkgray 1px;
-	}
-	
-	.item-characteristics-portrait .button-left-arrow,
-	.item-characteristics-portrait .button-right-arrow {
-		position: absolute;
-		transform: translate(-50%, -50%);
-		color: transparent;
-		background-color: transparent;
-		font-size: 16px;
-		padding: 12px 12px;
-		border: none;
-		cursor: pointer;
-		border-radius: 5px;
-		text-align: center;
-	}
-	
-	.item-characteristics-portrait .button-left-arrow {
-		top: 50%;
-		left: 11%;
-	}
-	
-	.item-characteristics-portrait .button-right-arrow {
-		top: 50%;
-		left: 95%;
-	}
-	
-	.item-characteristics-portrait .button-right-arrow:hover,
-	.item-characteristics-portrait .button-left-arrow:hover {
-		background-color: gold;	
-	}
-	
-	
-	/* By deafult, hides all portrait images. Add more numbered entries to add more images, notes, or cards. */
-	.item-portrait-00, 
-	.item-portrait-01,
-	.item-portrait-02 {
-		display: none;
-	}
-	
-	/* show the selected portrait frame. Add more numbered entries to add more images, notes, or cards. */
-	.item-portrait-slideshow[value="0"] ~ div.item-portrait-00,
-	.item-portrait-slideshow[value="1"] ~ div.item-portrait-01,
-	.item-portrait-slideshow[value="2"] ~ div.item-portrait-02 {
-		display: block;
-		position: relative;
-	}
-	
-	/* Alternate styling for rule cards instead of portraits */
-	.item-portrait-00 {
-		background-color: white;
-		border: solid 2px gray;
-		height: 250px;
-		width: 250px;
-		margin-left: 5px;
-	}
-	
-	.item-portrait-00 h1 {
-		font-size: 16px;
-		color: white;
-		text-align: center;
-		padding-left: 0px;
-		background-color: crimson;
-	}
-	
-	.item-portrait-flex-container {
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-start;
-		max-height: 240px;
-		padding: 0px;
-	}
-	
-	.item-portrait-rule-description {
-		max-width: 250px;
-		margin: 0px;
-		padding: 0px;
-		line-height: 1.0;
-	}
-	
-	.item-portrait-rule-description h1 {
-		font-size: 16px;
-		color: firebrick;
-		text-align: center;
-		padding-left: 4px;
-		background-color: inherit;
-		line-height: 1.4;
-		padding-bottom: 0px;
-	}
-	
-	.item-portrait-rule-description p {
-		font-size: 13px;
-		padding: 4px;
-		margin: 0px;
-		text-align: left;
-		line-height: 1.2;
-	}
-	
-	/* Item: health status                                     */
-	/* Item: gear tab health status                            */
-	/* Sheet worker used to synchronizes the contents of each  */
-	
-	.item-characteristics-health,
-	.item-gear-health {
-		padding: 0px;
-		width: 68px;
-		background: royalblue;
-		border: white;
-		margin-top: 4px;
-		margin-right: 2px;
-		height: 250px;
-		align-items: center;
-		display: flex;
-		justify-content: space-between;
-		flex-direction: column;
-	}
-	
-	.item-powers-health {
-		padding: 6px;
-		width: 318px;
-		height: 56px;
-		margin: 0px;
-		align-items: center;
-		display: flex;
-		justify-content: space-between;
-		flex-direction: row;
-		background-color: royalblue;
-		border: 3px solid #fff990;
-		border-radius: 5px;
-	}
-	
-	.item-characteristics-health  {
-		grid-area: health;
-	}
-	
-	.item-gear-health {
-		grid-area: gearHealth;
-	}
-	
-	.item-powers-health {
-		grid-area: powerHealth;
-	}
-	
-	.item-gear-health h2,
-	.item-characteristics-health h2,
-	.item-powers-health h2 {
-		color: white;
-		background-color: inherit;
-		text-align: center;
-		font-size: 17px;
-		line-height: 1.0em;
-		margin-top: 0px;
-		margin-bottom: 0px;
-		padding: 0px;
-	}
-	
-	.item-health-stat {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		width: 63px;
-		height: 30px;
-		background-color: gold;
-		border-radius: 3px;
-		align-items: center;
-		padding: 0px;
-		margin-right: 1px;
-		margin-bottom: 2px;
-		border: solid 1px darkgoldenrod;
-	}
-	
-	.item-health-stat-enclosure {
-		padding: none;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		height: 57px;
-	}
-	
-	.item-health-stat-plus-minus-enclosure {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		max-height: 20px;
-		width: 20px;
-		align-items: center;
-		padding: 1px;
-	}
-	
-	.item-health-stat input[type=text] {
-		max-width: 45px;
-		height: 30px;
-		font-size: 20px;
-		background-color: gold;
-	}
-	
-	.item-health-stat input[type=text]:focus{
-		outline: transparent;
-	}
-	
-	.item-health-stat button.buttonPlus,
-	.item-health-stat button.buttonMinus {
-		background-color: LemonChiffon;
-		border: solid 1px slategray;
-		color: slategray;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-		display: inline-block;
-		font-size: 16px;
-		margin: 0px 0px;
-		line-height: 1.4ch;
-		border-radius: 0px;
-	}
-	
-	.item-health-stat button.buttonPlus span,
-	.item-health-stat button.buttonMinus span {
-		display: inline-block;
-		transform: rotate(-90deg);
-		text-align: center;
-	}
-	
-	.item-health-stat button.buttonPlus:hover,
-	.item-health-stat button.buttonMinus:hover {
-		background-color: gray;
-		color: white;
-		transition: 0.05s;
-	}
-	
-	/* Item: Turn Tracker Button Space */
-	
-	.item-characteristics-turn-tracker {
-		grid-area: turnTracker;
-		width: 68px;
-		height: 22px;
-		padding: 0px;
-		line-height: 20px;
-	}
-	
-	/* Item: character history */
-	.item-characteristics-history {
-		grid-area: history;
-		text-align: left;
-		padding: 2px;
-		max-width: 343px;
-		background-color: inherit;
-		margin-bottom: 1px;
-		margin-right: 6px;
-		max-height: 402px;
-		margin-bottom: 6px;
-	}
-	
-	.item-characteristics-history textarea {
-		width: 316px;
-		height: 100%;
-	}
-	
-	/* Item: Speed Phase Indicator Buttons */
-	.item-characteristics-speedIndicatorButtons {
-		grid-area: speedIndicatorButtons;
-		padding-left: 2px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-		background-color: royalblue;
-		width: 264px;
-		margin: 0px;
-	}
-	
-	/* Item: Perception */
-	.item-characteristics-perception {
-		grid-area: perception;
-		max-width: 323px;
-		background-color: inherit;
-		max-height: 95px;
-		margin-left: 3px;
-		border: transparent;
-		margin-top: 0px;
-	}
-	
-	.item-characteristics-perception h1 {
-		font-size: 13px;
-		line-height: 1.6;
-		text-align: left;
-		background-color: royalblue;
-		color: white;
-	}
-	
-	.item-characteristics-perception input[type=number] {
-		text-align: right;
-		padding-right: 0px;
-		border: solid 1px palegoldenrod;
-		margin: 0px;
-		margin-bottom: 3px;
-		background-color: white;
-		max-width: 40px;
-	}
-	
-	.subitem-characteristics-perception-stat-container {
-		display: flex;
-		justify-content: space-between;
-		flex-direction: column;
-		background-color: inherit;
-		padding-left: 0px;
-		align-items: center;
-	}
-	
-	.subitem-characteristics-perception-stat-container input[type=text] {
-		font-size: 13px;
-		max-width: 65px;
-		text-align: center;
-		background-color: royalblue;
-		color: white;
-		font-weight: bold;
-		margin-top: 2px;
-	}
-	
-	.subitem-characteristics-perception-column-container {
-		display: flex;
-		justify-content: space-between;
-		flex-direction: column;
-		background-color: lightblue;
-		padding: 2px;
-		align-items: center;
-		border-radius: 5px;
-		border: solid lightcyan 2px;
-	}
-	
-	.subitem-characteristics-perception-column-container input[type=text] {
-		font-size: 13px;
-		max-width: 32px;
-		line-height: 1.3;
-		text-align: center;
-		background-color: lightcyan;
-		padding: 0px;
-		color: black;
-		font-weight: normal;
-	}
-	
-	.subitem-characteristics-perception-row-container {
-		display: flex;
-		justify-content: space-between;
-		flex-direction: row;
-		margin-top: 2px;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Options Tab                                         */
-	/* --------------------------------------------------- */
-	
-	.grid-container-tab-options {
-		display: grid;
-		grid-template-areas: ". . ." 
-			". options ."
-			". . .";
-		grid-template-columns: 110px 500px 100px;
-		grid-template-rows: 100px 185px 100px;
-		font-size: 16px;
-		background-color: royalblue;
-		border: 3px solid #fff990;
-		border-radius: 5px;
-		margin-bottom: 1px;
-		min-height: 800px;
-		min-width: 674px;
-	}
-	
-	.grid-container-tab-options h1 {
-		font-size: 14px;
-		margin-left: 0px;
-		color: black;
-		padding-bottom: 5px;
-		font-weight: 500;
-	}
-	
-	.grid-container-tab-options label {
-		max-width: 13px;
-		padding: 8px;
-	}
-	
-	/* Sub-Item: options */
-	.item-options {
-		grid-area: options;
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-start;
-		padding-left: 2px;
-		padding-top: 2px;
-		padding-bottom: 2px;
-		background-color: #fff990;
-		margin: 5px;
-		width: 450px;
-		height: 282px;
-		margin: 0px;
-		border: solid 2px goldenrod;
-		border-radius: 3px;
-	}
-	
-	.item-options-row,
-	.item-version-row {
-		align-items: baseline;
-		min-width: 400px;
-		max-height: 28px;
-		margin-left: 10px;
-	}
-	
-	.item-options-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: flex-start;
-	}
+}
 
-	/* --------------------------------------------------- */
-	/* Version Info                                        */
-	/* --------------------------------------------------- */
-	
-	.item-version-row {
-		display: grid;
-		grid-template-areas: "versionLabel versionInfo";
-		justify-content: flex-end;
-	}
+@-moz-document url-prefix() {
+	/* CSS Statements that only apply on Firefox */
 
-	.item-version-label h2 {
-		font-size: 13px;
-		max-height: 28px;
-		color: black;
+	input[type=number]:hover,
+	input[type=number]:focus {
+		-moz-appearance: number-input;
+		padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. */
 	}
 	
-	.item-version-information input[readonly] {
-		background-color: #fff990;
-		color: black;
-		max-width: 35px;
-		padding-bottom: 1px;
-	}
-
-	/* --------------------------------------------------- */
-	/* Custom buttons                                      */
-	/* --------------------------------------------------- */
-	
-	.button {
-		border: none;
-		color: white;
-		text-decoration: none;
-		display: inline-block;
-		cursor: pointer;
-		transition-duration: 0.2s;
-		text-align: center;
-	}
-		
-	.buttonRecover {
-		background-color: darkseagreen;
-		padding-top: 4px;
-		padding-bottom: 4px;
-		margin-left: 2px;
-		margin-right: 2px;
-		margin-top: 0px;
-		margin-bottom: 0px;
-		padding-left: 4px;
-		padding-right: 3.5px;
-		vertical-align: middle;
-		text-align: right;
-		font-size: 13px;
-		font-weight: bold;
-		border-radius: 3px;
-	}
-	
-	.buttonReset {
-		background-color: orange;
-		padding-top: 4px;
-		padding-bottom: 4px;
-		margin-left: 2px;
-		margin-right: 2px;
-		margin-top: 0px;
-		margin-bottom: 0px;
-		padding-left: 12px;
-		padding-right: 12px;
-		vertical-align: middle;
-		text-align: center;
-		font-size: 13px;
-		font-weight: bold;
-		border-radius: 3px;
-	}
-	
-	.buttonTracker {
-		background-color: dodgerblue;
-		padding-left: 3px;
-		padding-right: 3px;
-		padding-top: 2px;
-		padding-bottom: 2px;
-		font-weight: bold;
-	}
-	
-	.button-Power-END-right,
-	.button-Power-END-left {
-		padding-top: 2px;
-		padding-bottom: 2px;
-		padding-right: 2px;
-		padding-left: 2px;
-		min-height: 16px;
-		max-height: 16px;
-		text-align: middle;
-		font-weight: bold;
-		border-radius: 2.5px;
-	}
-	
-	.button-Power-END-left {
-		background-color: olive;
-		margin-right: 0px;
-		min-width: 34px;
-		max-width: 35px;
-	}
-	
-	.button-Power-END-right {
-		background-color: salmon;
-		margin-right: 0px;
-		min-width: 34px;
-		max-width: 35px;
-	}
-	
-	.buttonRoll,
-	.buttonRollAttack,
-	.buttonRollActivate,
-	.buttonRollNormalAttack,
-	.buttonRollShieldAttack,
-	.buttonRollShow,
-	.buttonRollPower {
-		padding-left: 3px;
-		padding-right: 3px;
-		text-align: center;
-		line-height: 13px;
-		padding-top: 2px;
-		padding-bottom: 2px;
-		font-weight: bold;
-		max-height: 16px;
-		min-height: 15px;
-	}
-
-	.buttonRoll,
-	.buttonRollAttack,
-	.buttonRollActivate,
-	.buttonRollShieldAttack {
-		min-width: 25px;
-		max-width: 26px;
-	}
-	
-	
-	.buttonRollPower {
-		min-width: 32px;
-		max-width: 34px;
-	}
-	
-	.button:hover,
-	.buttonRecover:hover,
-	.buttonReset:hover,
-	.buttonRoll:hover,
-	.buttonRollAttack:hover,
-	.buttonRollActivate:hover,
-	.buttonRollNormalAttack:hover,
-	.buttonRollShieldAttack:hover,
-	.buttonRollShow:hover,
-	.buttonRollPower:hover {
-		color: black;
-		background-color: lightgray;
-		text-align: center;
-	}
-	
-	.button-Power-END-left:hover,
-	.button-Power-END-right:hover {
-		background-color: #ff9900;
-		color: black;
-	}
-	
-	.buttonRoll {
-		margin-right: 3px;
-		margin-left: 3px;
-		background-color: #E69F00;
-		border-radius: 3px;
-	}
-	
-	.buttonRollAttack {
-		background-color: #D55E00;
-		border-radius: 2.5px;
-	}
-	
-	.item-flex-maneuver .buttonRollAttack {
-		margin-right: 3px;
-		margin-left: 61px;
-		border-radius: 3px;
-		min-width: 36px;
-		max-width: 38px;
-	}
-
-	.weapon-normal-damage01[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon01"]:not(:hover),
-	.weapon-normal-damage02[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon02"]:not(:hover),
-	.weapon-normal-damage03[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon03"]:not(:hover),
-	.weapon-normal-damage04[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon04"]:not(:hover),
-	.weapon-normal-damage05[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon05"]:not(:hover)
-	{
-		background-color: #009E73;
-	}
-	
-	.maneuver-normal-damage01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
-	.maneuver-normal-damage02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
-	.maneuver-normal-damage03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
-	.maneuver-normal-damage04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
-	.maneuver-normal-damage05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
-	.maneuver-normal-damage06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
-	.maneuver-normal-damage07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
-	.maneuver-normal-damage08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
-	.maneuver-normal-damage09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
-	{
-		background-color: #009E73;
-	}
-
-	.buttonRollActivate {
-		margin-right: 3px;
-		margin-left: 3px;
-		background-color: #0072B2;
-		border-radius: 3px;
-	}
-	
-	.buttonRollNormalAttack {
-		margin-right: 3px;
-		margin-left: 61px;
-		border-radius: 3px;
-		background-color: #D55E00;
-		min-width: 36px;
-		max-width: 38px;
-	}
-	
-	.buttonRollShieldAttack  {
-		background-color: #D55E00;
-		border-radius: 2.5px;
-	}
-	
-	.buttonRollShow {
-		margin-right: 3px;
-		margin-left: 3px;
-		border-radius: 3px;
-		background-color: #8A8A8A;
-		min-width: 36px;
-		max-width: 38px;
-	}
-	
-	.buttonRollPower {
-		background-color: #9184E2; /* lighter than mediumslateblue */
-		border-radius: 2.5px;
-	}
-	
-	/* The d6 of dicefontd6 doesn't look good. Let's hold off for a better idea or stick with the label 'Roll' on the buttons.
-	
-	.buttonRollNormalAttack::before {
-		font-family: 'dicefontd6';
-		font-size: 16px;
-		content: 'F';
-	} */
-	
-	.portrait-display-button-left,
-	.portrait-display-button-right {
-		background-color: orange;
-		padding-top: 4px;
-		padding-bottom: 4px;
-		margin: 4px 2px;
-		padding-left: 14px;
-		padding-right: 14px;
-		vertical-align: middle;
-		text-align: center;
-	}
-	
-	.portrait-display-button-left:hover,
-	.portrait-display-button-right:hover {
-		color: black;
-		background-color: limegreen;
-		text-align: center;
-	}
-	
-	
-	/* --------------------------------------------------- */
-	/* Custom Checkbox used for options                    */
-	/* From w3 schools                                     */
-	/* --------------------------------------------------- */
-	
-	/* Customize the label (the container) */
-	.container-checkbox {
-		display: inline-block;
-		position: relative;
-		padding-left: 25px;
-		padding-top: 2px;
-		/* margin-bottom: 10px; */
-		cursor: pointer;
-		max-width: 400px;
-		font-size: 12px;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		user-select: none;
-		border: transparent;
-	}
-	
-	/* Hide the browser's default checkbox */
-	.container-checkbox input,
-	.container-checkbox-small input,
-	.container-checkbox-small-gray input {
-		position: absolute;
-		opacity: 0;
-		cursor: pointer;
-		height: 0;
-		width: 0;
-	}
-	
-	/* Create a custom checkbox */
-	.checkmark {
-		position: absolute;
-		top: 0;
-		left: 0;
-		height: 20px;
-		width: 20px;
-		background-color: gold;
-	}
-	
-	/* On mouse-over, add a grey background color */
-	.container-checkbox:hover input ~ .checkmark,
-	.container-checkbox-small:hover input ~ .checkmark-small {
-		background-color: goldenrod;
-		border: solid 1px darkgoldenrod;
-	}
-	
-	.container-checkbox-small-gray:hover input ~ .checkmark-small-gray {
-		background-color: lightsteelblue;
-		border: solid 1px darkgray;
-	}
-	
-	/* When the checkbox is checked, add a gold background */
-	.container-checkbox input:checked ~ .checkmark,
-	.container-checkbox-small input:checked ~ .checkmark-small {
-		background-color: gold;
-	}
-	
-	.container-checkbox-small-gray input:checked ~ .checkmark-small-gray {
-		background-color: lightgray;
-	}
-	
-	/* Create the checkmark/indicator (hidden when not checked) */
-	.checkmark:after,
-	.checkmark-small:after {
-		content: "";
-		position: absolute;
-		display: none;
-		border: solid 1px darkgoldenrod;
-	}
-	
-	.checkmark-small-gray:after {
-		content: "";
-		position: absolute;
-		display: none;
-		border: solid 1px gray;
-	}
-	
-	/* Show the checkmark when checked */
-	.container-checkbox input:checked ~ .checkmark:after,
-	.container-checkbox-small input:checked ~ .checkmark-small:after,
-	.container-checkbox-small-gray input:checked ~ .checkmark-small-gray:after {
-		display: block;
-	}
-	
-	/* Style the checkmark/indicator */
-	.container-checkbox .checkmark:after {
-		left: 7px;
-		top: 2px;
-		width: 5px;
-		height: 10px;
-		border: solid black;
-		border-width: 0 3px 3px 0;
-		-webkit-transform: rotate(45deg);
-		-ms-transform: rotate(45deg);
-		transform: rotate(45deg);
-	}
-	
-	/* --------------------------------------------------- */
-	/* Custom Checkbox (small) used for skill enhancers    */
-	/* From w3 schools                                     */
-	/* --------------------------------------------------- */
-	
-	/* Customize the label (the container) */
-	.container-checkbox-small,
-	.container-checkbox-small-gray {
-		display: block;
-		position: relative;
-		padding-left: 20px;
-		padding-top: 0px;
-		cursor: pointer;
-		font-size: 12px;
-		max-width: 20px;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		user-select: none;
-	}
-	
-	/* Create a custom checkbox */
-	.checkmark-small {
-		position: absolute;
-		top: 0;
-		left: 0;
-		height: 15px;
-		width: 15px;
-		background-color: gold;
-	}
-	
-	.checkmark-small-gray {
-		position: absolute;
-		top: 0;
-		left: 0;
-		height: 15px;
-		width: 15px;
-		background-color: lightgray;
-	}
-	
-	/* Style the checkmark/indicator */
-	.container-checkbox-small .checkmark-small:after,
-	.container-checkbox-small-gray .checkmark-small-gray:after {
-		left: 4px;
-		top: 2px;
-		width: 4px;
-		height: 7px;
-		border: solid black;
-		border-width: 0 3px 3px 0;
-		-webkit-transform: rotate(45deg);
-		-ms-transform: rotate(45deg);
-		transform: rotate(45deg);
-	}
-	
-	
-	.subitem-flex-container-martial-cv-damage-row .container-checkbox-small-gray {
-		margin-bottom: 14px;
-		padding: 0px;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Custom Checkboxes used for turn segment indicators  */
-	/* Modification of custom checkbox above               */
-	/* --------------------------------------------------- */
-	
-	.grid-container-container-turn-segments {
-		grid-area: turnSegmentIndicators;
-		display: inline-flex; /* or inline-flex */
-		flex-direction: row;
-		flex-wrap: nowrap;
-		align-items: top;
-		justify-content: space-evenly;
-		width: 264px;
-		height: 24px;
-		background: royalblue;
-		margin-top: 2px;
-		margin-left: 1px;
-		padding: 0px;
-	}
-	
-	.grid-container-container-turn-segments label {
-		display: inline;
-		pointer-events: none;
-		font-style: normal;
-	}
-	
-	/* Custom checkbox indicator */
-	
-	.container-speed-indicator {
-		display: inline-block;
-		position: relative;
-		padding-left: 5px;
-		margin-bottom: 0px;
-		cursor: pointer;
-		font-size: 20px;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		user-select: none;
-	}
-		
-	/* Hide the browser's default checkbox */
-	.container-speed-indicator input {
-		position: absolute;
-		opacity: 0;
-		cursor: pointer;
-		height: 0;
-		width: 0;
-	}
-	
-	/* Custom checkbox */
-	
-	.checkmark01,
-	.checkmark02,
-	.checkmark03,
-	.checkmark04,
-	.checkmark05,
-	.checkmark06,
-	.checkmark07,
-	.checkmark08,
-	.checkmark09,
-	.checkmark10,
-	.checkmark11,
-	.checkmark12 {
-		position: absolute;
-		top: 0;
-		left: 0;
-		height: 20px;
-		width: 20px;
-		background-color: dodgerblue;
-		border: none;
-		border-radius: 5px;
-		pointer-events: none;
-	}
-	
-	/* Custom segment indicator checkbox: Status */
-	.container-speed-indicator input:checked ~ .checkmark01,
-	.container-speed-indicator input:checked ~ .checkmark02,
-	.container-speed-indicator input:checked ~ .checkmark03,
-	.container-speed-indicator input:checked ~ .checkmark04,
-	.container-speed-indicator input:checked ~ .checkmark05,
-	.container-speed-indicator input:checked ~ .checkmark06,
-	.container-speed-indicator input:checked ~ .checkmark07,
-	.container-speed-indicator input:checked ~ .checkmark08,
-	.container-speed-indicator input:checked ~ .checkmark09,
-	.container-speed-indicator input:checked ~ .checkmark10,
-	.container-speed-indicator input:checked ~ .checkmark11,
-	.container-speed-indicator input:checked ~ .checkmark12 {
-		background-color: hotpink;
-		border: none;
-		border-radius: 5px;
-	}
-	
-	/* Custom segment indicator checkbox 01. Active/checked. */
-	.checkmark01:after {
-		content: "1";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 01. Inactive/not checked. */
-	.checkmark01:before {
-		content: "1";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 02. Active/checked. */
-	.checkmark02:after {
-		content: "2";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 02. Inactive/not checked. */
-	.checkmark02:before {
-		content: "2";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 03. Active/checked. */
-	.checkmark03:after {
-		content: "3";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 03. Inactive/not checked. */
-	.checkmark03:before {
-		content: "3";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 04. Active/checked. */
-	.checkmark04:after {
-		content: "4";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 04. Inactive/not checked. */
-	.checkmark04:before {
-		content: "4";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 05. Active/checked. */
-	.checkmark05:after {
-		content: "5";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 05. Inactive/not checked. */
-	.checkmark05:before {
-		content: "5";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 06. Active/checked. */
-	.checkmark06:after {
-		content: "6";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 06. Inactive/not checked. */
-	.checkmark06:before {
-		content: "6";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 07. Active/checked. */
-	.checkmark07:after {
-		content: "7";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 07. Inactive/not checked. */
-	.checkmark07:before {
-		content: "7";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 08. Active/checked. */
-	.checkmark08:after {
-		content: "8";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 08. Inactive/not checked. */
-	.checkmark08:before {
-		content: "8";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 09. Active/checked. */
-	.checkmark09:after {
-		content: "9";
-		color: white;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 09. Inactive/not checked. */
-	.checkmark09:before {
-		content: "9";
-		color: black;
-		position: absolute;
-		padding-left: 6px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 10. Active/checked. */
-	.checkmark10:after {
-		content: "10";
-		color: white;
-		position: absolute;
-		padding-left: 2px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 10. Inactive/not checked. */
-	.checkmark10:before {
-		content: "10";
-		color: black;
-		position: absolute;
-		padding-left: 2px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 11. Active/checked. */
-	.checkmark11:after {
-		content: "11";
-		color: white;
-		position: absolute;
-		padding-left: 3px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 11. Inactive/not checked. */
-	.checkmark11:before {
-		content: "11";
-		color: black;
-		position: absolute;
-		padding-left: 3px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 12. Active/checked. */
-	.checkmark12:after {
-		content: "12";
-		color: white;
-		position: absolute;
-		padding-left: 2px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Custom segment indicator checkbox 12. Inactive/not checked. */
-	.checkmark12:before {
-		content: "12";
-		color: black;
-		position: absolute;
-		padding-left: 2px;
-		padding-top: 1px;
-		display: none;
-	}
-	
-	/* Show the checkmark when checked */
-	.container-speed-indicator input:checked ~ .checkmark01:after,
-	.container-speed-indicator input:checked ~ .checkmark02:after,
-	.container-speed-indicator input:checked ~ .checkmark03:after,
-	.container-speed-indicator input:checked ~ .checkmark04:after,
-	.container-speed-indicator input:checked ~ .checkmark05:after,
-	.container-speed-indicator input:checked ~ .checkmark06:after,
-	.container-speed-indicator input:checked ~ .checkmark07:after,
-	.container-speed-indicator input:checked ~ .checkmark08:after,
-	.container-speed-indicator input:checked ~ .checkmark09:after,
-	.container-speed-indicator input:checked ~ .checkmark10:after,
-	.container-speed-indicator input:checked ~ .checkmark11:after,
-	.container-speed-indicator input:checked ~ .checkmark12:after {
-		display: block;
-	}
-	
-	/* Show the checkmark when checked */
-	.container-speed-indicator input:not(:checked) ~ .checkmark01:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark02:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark03:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark04:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark05:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark06:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark07:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark08:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark09:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark10:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark11:before,
-	.container-speed-indicator input:not(:checked) ~ .checkmark12:before {
-		display: block;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Talents, Perks, and Complications                   */
-	/* --------------------------------------------------- */
-	.grid-container-complications-talents {
-		display: grid;
-		grid-gap: 4px;
-		grid-template-areas: 
-		"theTalentsAndPerks theComplications"
-		"theNotes theNotes";
-		grid-template-columns: 338px 338px;
-		grid-template-rows: 642px 160px;
-		max-width: 685px;
-		padding: 0px;
-		font-size: 16px;
-		background-color: dodgerblue;
-		justify-content: middle;
-		padding-bottom: 0px;
-		margin-bottom: 1px;
-	}
-	
-	.grid-container-complications-talents h2 {
-		font-size: 18px;
-		line-height: 1.3;
-		text-align: center;
-		font-weight: normal;
-	}
-	
-	/* Complications and Talents Tab: Talents and Perks */
-	.flex-container-complications-talents-left {
-		grid-area: theTalentsAndPerks;
-		display: flex;
-		justify-content: space-between;
-		flex-direction: column;
-		border: 3px solid #fff990;
-		border-radius: 5px;
-		max-width: 333px;
-		background: gold;
-		height: 630px;
-		padding: 5px;
-		padding-bottom: 0px;
-		margin-bottom: 0px;
-	}
-	
-	.item-talent-heading {
-		display: flex;
-		flex-wrap: nowrap;
-		justify-content: space-between;
-		align-items: center;
-		flex-direction: row;
-		margin-bottom: 0px;
-		padding: 0px;
-		max-width: 333px;
-	}
-	
-	.item-talent-heading input[type=text] {
-		max-width: 200px;
-		padding: 1px;
-		padding-left: 3px;
-		margin: 0px;
-		margin-right: 0px;
-		margin-left: 2px;
-		text-align: left;
-		font-size: 13px;
-		font-weight: bold;
-		border: solid 1px darkgray;
-	}
-	
-	.item-talent-heading input[type=number] {
-		max-width: 45px;
-		padding: 2px;
-		margin: 0px;
-		padding-right: 0px;
-		text-align: right;
-		border: solid 1px darkgray;
-	}
-	
-	.item-talent-heading h1 {
-		font-size: 12px;
-		line-height: 1.1;
-		padding-right: 2px;
-		padding-left: 6px;
-	}
-	
-	.item-talent-textbox textarea {
-		max-width: 314px;
-		max-height: 36px;
-		padding: 3px;
-		border: solid 1px darkgray;
-		margin-bottom: 6px;
-	}
-	
-	
-	/* Complications and Talents Tab: Complications */
-	.flex-container-complications-talents-right {
-		grid-area: theComplications;
-		display: flex;
-		justify-content: space-between;
-		flex-direction: column;
-		border: 3px solid lightcyan;
-		border-radius: 5px;
-		max-width: 333px;
-		background: lightblue;
-		height: 630px;
-		padding: 5px;
-		padding-bottom: 0px;
-		margin-bottom: 0px;
-	}
-	
-	.item-complication-heading {
-		display: flex;
-		flex-wrap: nowrap;
-		justify-content: space-between;
-		align-items: center;
-		flex-direction: row;
-		margin-bottom: 0px;
-		padding: 0px;
-		max-width: 333px;
-	}
-	
-	.item-complication-heading input[type=text] {
-		max-width: 210px;
-		padding: 1px;
-		padding-left: 3px;
-		margin: 0px;
-		margin-right: 0px;
-		margin-left: 2px;
-		text-align: left;
-		font-size: 13px;
-		font-weight: bold;
-		border: solid 1px darkgray;
-	}
-	
-	.item-complication-heading input[type=number] {
-		max-width: 45px;
-		padding: 2px;
-		margin: 0px;
-		padding-right: 0px;
-		text-align: right;
-		border: solid 1px darkgray;
-	}
-	
-	.item-complication-heading h1 {
-		font-size: 12px;
-		line-height: 1.1;
-		padding-right: 2px;
-		padding-left: 6px;
-	}
-	
-	.item-complication-textbox textarea {
-		max-width: 314px;
-		max-height: 54px;
-		padding: 3px;
-		border: solid 1px darkgray;
-		margin-bottom: 6px;
-	}
-	
-	/* Complications Tab: Notes Text Panel */
-	
-	.flex-container-complications-bottom {
-		grid-area: theNotes;
-		display: flex;
-		flex-direction: row;
-		flex-wrap: nowrap;
-		justify-content: space-between;
-		border: 3px solid lightgray;
-		border-radius: 5px;
-		max-width: 674px;
-		padding: 5px;
-		margin: 0px;
-		height: 145px;
-		background: white;
-	}
-	
-	.flex-container-complications-bottom textarea {
-		width: 322px;
-		max-height: 143px;
-		padding: 0px;
-		margin: 0px;
-		border: transparent;
-	}
-	
-	/* ----------------------------------------------------- */
-	/* Powers                                                */
-	/* Organized in two columns with different color styles. */
-	/* ----------------------------------------------------- */
-	.grid-container-powers {
-		display: grid;
-		grid-gap: 5px 5px;
-		grid-template-areas: 
-		"leftPowers powerHealth"
-		"leftPowers rightPowers";
-		grid-template-columns: 338px 336px;
-		grid-template-rows: 74px 727px;
-		max-width: 686px;
-		min-width: 676px;
-		padding: 0px;
-		font-size: 16px;
-		background-color: dodgerblue;
-		justify-content: middle;
-		padding-bottom: 0px;
-		margin-bottom: 1px;
-	}
-	
-	.grid-container-powers h1 {
-		display:inline-block;
-		margin-left: 0px;
-		padding-left: 2px;
-		padding-right: 0px;
-		padding-top: 0px;
-		padding-bottom: 0px;
-		margin: 0px;
-		margin-top: 1px;
-		font-size: 13px;
-		font-style: normal;
-		line-height: 1.35;
-	}
-	
-	.grid-container-powers input[type=number] {
-		padding-right: 0px;
-		padding-top: 2px;
-		width: 30px;
-		margin: 0px;
-		text-align: right;
-		height: 21px;
-		padding: 1px;
-	}
-	
-	.flex-container-powers-right,
-	.flex-container-powers-left {
-		display: flex;
-		justify-content: space-between;
-		flex-direction: column;
-		border-radius: 5px;
-		max-width: 333px;
-		padding-left: 4px;
-		padding-right: 4px;
-		margin: 0px;
-	}
-	
-	.flex-container-powers-left,
-	.flex-container-powers-right {
-		padding-top: 3px;
-		padding-bottom: 3px;
-	}
-	
-	.flex-container-powers-left {
-		height: 795px;
-	}
-	
-	.flex-container-powers-right {
-		height: 716px;
-	}
-	
-	.flex-container-powers-left textarea,
-	.flex-container-powers-right textarea {
-		color: gray; 
-		height: 54px;
-		padding: 3px;
-		margin: 0px;
-		margin-top: 1px;
-		font-size: 8;
-	}
-	
-	.flex-container-powers-left textarea {
-		max-width: 316px;
-	}
-	
-	.flex-container-powers-right textarea {
-		border: solid 1px goldenrod;
-		max-width: 315px;
-	}
-	
-	/* Power subitems. */
-	
-	.item-flex-power {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-top: 2px;
-		padding-bottom: 3px;
-	}
-	
-	.subitem-flex-power-heading-left,
-	.subitem-flex-power-heading-right,
-	.subitem-flex-power-effect-left,
-	.subitem-flex-power-effect-right {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		margin-top: 1px;
-		margin-bottom: 0px;
-		align-items: center;
-		max-height: 23px;
-	}
-	
-	.subitem-flex-power-heading-left input[type=text],
-	.subitem-flex-power-heading-right input[type=text],
-	.subitem-flex-power-effect-left input[type=text],
-	.subitem-flex-power-effect-right input[type=text] {
-		min-height: 22px;
-		text-align: left;
-		padding-left: 2px;
-		margin-right: 0px;
-	}
-	
-	.subitem-flex-power-heading-left input[type=text]:nth-child(2),
-	.subitem-flex-power-heading-right input[type=text]:nth-child(2) {
-		font-weight: bold;
-		max-width: 130px;
-		margin-left: 1px;
-	}
-	
-	.subitem-flex-power-heading-left input[type=text]:nth-child(4),
-	.subitem-flex-power-heading-right input[type=text]:nth-child(4) {
-		font-weight: bold;
-		text-align: center;
-	}
-	
-	.subitem-flex-power-heading-left select,
-	.subitem-flex-power-heading-right select {
-		font-size: 13px;
-		height: 19px;
-		width: 98px;
-		margin: 0px;
-		padding-left: 3px;
-	}
-	
-	/* Effect */
-	.subitem-flex-power-effect-left input[type=text]:nth-child(2),
-	.subitem-flex-power-effect-right input[type=text]:nth-child(2){
-		max-width: 130px;
-		max-height: 23px;
-	}
-	
-	/* Dice */
-	.subitem-flex-power-effect-left input[type=text]:nth-child(3),
-	.subitem-flex-power-effect-right input[type=text]:nth-child(3) {
-		max-width: 58px;
-		text-align: center;
-		margin-left: 2px;
-		margin-right: 0px;
-		padding-left: 0px;
-		padding-right: 0px;
-	}
-	
-	/* Roll chance */
-	.subitem-flex-power-effect-left input[type=number]:nth-child(5), 
-	.subitem-flex-power-effect-right input[type=number]:nth-child(5) {
-		max-width: 41px;
-		min-width: 41px;
-		text-align: right;
-		margin-left: 1px;
-		margin-right: 2px;
-	}
-	
-	.subitem-flex-power-activeCost input[type=number]:nth-child(2), /* Advantages */
-	.subitem-flex-power-activeCost input[type=number]:nth-child(4) /* Limitations */ {
-		border: solid 1px gray;
-		min-width: 55px;
-	}
-	
-	/* Powers Tab: Left Powers and general to right. */
-	.flex-container-powers-left {
-		grid-area: leftPowers;
-		border: 3px solid lightcyan;
-		background: lightblue;
-	}
-	
-	.flex-container-powers-left textarea {
-		border: solid 1px black;
-	}
-	
-	.flex-container-powers-left input[readonly]{
-		background: lightcyan;
-		border: solid 1px #89abb9;
-		line-height: 1.0;
-	}
-	
-	.flex-container-powers-left textarea{
-		border: 1px solid #89ABB9;
-	}
-	
-	.subitem-flex-power-heading-left input[type=text]{
-		border: solid 1px #89ABB9;
-		max-width: 28px;
-	}
-	
-	.subitem-flex-power-effect-left input[type=text],
-	.subitem-flex-power-effect-left input[type=number]{
-		border: solid 1px #89ABB9;
-	}
-	
-	.subitem-flex-power-points-block-left,
-	.subitem-flex-power-points-block-right {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: center;
-		max-height: 23px;
-		margin-bottom: 2px;
-	}
-	
-	.subitem-flex-power-points-block-left input[type=number] {
-		/* Active, Real Cost */
-		border: solid 1px #89ABB9;
-	}
-	
-	.subitem-flex-power-points-block-left input[readonly] {
-		/* Active, Real Cost */
-		max-width: 38px;
-		text-align: center;
-		padding: 0px;
-	}
-	
-	.subitem-flex-power-limitations-left,
-	.subitem-flex-power-limitations-right {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-width: 333px;
-		margin-bottom: 2px;
-		max-height: 23px;
-	}
-	
-	.subitem-flex-power-limitations-left input[type=number]{
-		/* Advantages, limitations */
-		border: solid 1px #89ABB9;
-		min-width: 50px;
-	}
-	
-	.subitem-flex-power-limitations-left select,
-	.subitem-flex-power-limitations-right select {
-		font-size: 13px;
-		height: 19px;
-		max-width: 115px;
-		margin: 0px;
-		align-items: center;
-		padding-left: 3px;
-	}
-
-	
-	/* Powers Tab: Right Powers */
-	.flex-container-powers-right {
-		grid-area: rightPowers;
-		border: 3px solid #fff990;
-		background: gold;
-	}
-	
-	.flex-container-powers-right textarea {
-		border: solid 1px black;
-	}
-	
-	.flex-container-powers-right input[readonly]{
-		background: #fff990;
-		border: solid 1px goldenrod;
-		line-height: 1.0;
-	}
-	
-	.flex-container-powers-right textarea{
-		border: 1px solid goldenrod;
-	}
-	
-	.subitem-flex-power-heading-right input[type=text] {
-		max-width: 28px;
-		border: solid 1px goldenrod;
-	}
-	
-	.subitem-flex-power-effect-right input[type=text],
-	.subitem-flex-power-effect-right input[type=number]{
-		border: solid 1px goldenrod;
-	}
-	
-	.subitem-flex-power-points-block-right input[type=number] {
-		/* Active, Real Cost */
-		border: solid 1px goldenrod;
-	}
-	
-	.subitem-flex-power-points-block-right input[readonly] {
-		/* Active, Real Cost */
-		max-width: 38px;
-		text-align: center;
-	}
-	
-	.subitem-flex-power-limitations-right input[type=number]{
-		/* Advantages, limitations */
-		border: solid 1px goldenrod;
-		min-width: 50px;
-	}
-	
-	
-	/* Buttons for power, talent, and complication movers. */
-	.power-mover-plus-minus-enclosure,
-	.talent-mover-plus-minus-enclosure,
-	.complication-mover-plus-minus-enclosure {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-	}
-	
-	.power-mover-plus-minus-button,
-	.talent-mover-plus-minus-button,
-	.complication-mover-plus-minus-button {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		height: 24px;
-		width: 10px;
-		align-items: center;
-		padding: 0px;
-		margin-right: 2px;
-		margin-left:3px;
-	}
-	
-	.power-mover-plus-minus-button button.buttonPlus,
-	.power-mover-plus-minus-button button.buttonMinus,
-	.talent-mover-plus-minus-button button.buttonPlus,
-	.talent-mover-plus-minus-button button.buttonMinus,
-	.complication-mover-plus-minus-button button.buttonPlus,
-	.complication-mover-plus-minus-button button.buttonMinus {
-		background-color: LemonChiffon;
-		border: solid 1px silver;
-		color: slategray;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-		display: inline-block;
-		font-size: 10px;
-		margin: 0px 0px;
-		line-height: 1.25ch;
-		border-radius: 0px;
-		max-width: 10px;
-	}
-	
-	.power-mover-plus-minus-button button.buttonPlus span,
-	.power-mover-plus-minus-button button.buttonMinus span,
-	.talent-mover-plus-minus-button button.buttonPlus span,
-	.talent-mover-plus-minus-button button.buttonMinus span,
-	.complication-mover-plus-minus-button button.buttonPlus span,
-	.complication-mover-plus-minus-button button.buttonMinus span {
-		display: inline-block;
-		transform: rotate(-90deg);
-		text-align: center;
-	}
-	
-	.power-mover-plus-minus-button button.buttonPlus:hover,
-	.power-mover-plus-minus-button button.buttonMinus:hover,
-	.talent-mover-plus-minus-button button.buttonPlus:hover,
-	.talent-mover-plus-minus-button button.buttonMinus:hover,
-	.complication-mover-plus-minus-button button.buttonPlus:hover,
-	.complication-mover-plus-minus-button button.buttonMinus:hover {
-		background-color: gray;
-		color: white;
-		transition: 0.05s;
+	input[type=number]:read-only {
+		  -moz-appearance: textfield;
 	} 
 	
-	
-	/* ----------------------------------------------------- */
-	/* Skills                                                */
-	/* Organized into a 2x3 grid of containers               */
-	/* ----------------------------------------------------- */
-	.grid-container-skills-tab {
-		display: grid;
-		grid-template-areas:
-		"theSkills1 theCombatSkills"
-		"theSkills2 theLanguageSkills"
-		"theSkills3 theEnhancers";
-		grid-gap: 6px;
-		grid-template-columns: 358px 322px;
-		grid-template-rows: 273px 251px 259px;
-		max-width: 692px;
-		padding: 0px;
-		padding-left: 0px;
-		padding-top: 6px;
-		margin-bottom: 0px;
-		font-size: 16px;
-		background-color: gold;
-		border: 3px solid #fff990;
-		border-radius: 5px;
-		justify-content: middle;
-		min-height: 795px;
-	}
-	
-	.grid-container-skills-tab h1 {
-		display:inline-block;
-		margin-left: 0px;
-		padding-left: 2px;
-		padding-right: 0px;
-		padding-top: 0px;
-		padding-bottom: 0px;
-		margin: 0px;
-		margin-top: 1px;
-		font-size: 13px;
-		font-style: normal;
-		line-height: 1.10;
-		text-align: center;
-	}
-	
-	.grid-container-skills-tab input[type=text] {
-		height: 22px;
-	}
-	
-	.grid-container-skills-tab .custom-select,
-	.grid-container-skills-tab .custom-select-skill,
-	.grid-container-skills-tab .custom-select-alternate,
-	.grid-container-skills-tab .custom-select-alternate-skill {
-		font-size: 13px;
-		max-width: 110px;
-		margin-left: 3px;
-		padding-left: 3px;
-	}
-	
-	/* Item: Skill Containers for Skill Groups 01, 02, and 03 */
-	.item-skillsTab-flex-container-skills-group01,
-	.item-skillsTab-flex-container-skills-group02,
-	.item-skillsTab-flex-container-skills-group03 {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-evenly;
-		max-width: 358px;
-		margin-left: 5px;
-		background-color: #fff990; 
-		border: solid 2px goldenrod;
-		border-radius: 3px;
-		line-height: 1.10;
-		padding-left: 1px;
-		padding-right: 4px;
-	}
-	
-	.item-skillsTab-flex-container-skills-group01 {
-		grid-area: theSkills1;
-		padding-bottom: 2px;
-	}
-	
-	.item-skillsTab-flex-container-skills-group02 {
-		grid-area: theSkills2;
-		padding-top: 3px;
-		padding-bottom: 2px;
-	}
-	
-	.item-skillsTab-flex-container-skills-group03 {
-		grid-area: theSkills3;
-		padding-top: 3px;
-		padding-bottom: 2px;
-		margin-bottom: 4px;
-	}
-	
-	.item-skillsTab-flex-container-skills-group01 input[type=number],
-	.item-skillsTab-flex-container-skills-group02 input[type=number],
-	.item-skillsTab-flex-container-skills-group03 input[type=number] {
-		text-align: right;
-		padding-right: 0px;
-		margin-top: 0px;
-		margin-bottom: 0px;
-		border: solid 1px palegoldenrod;
-		max-height: 22px;
-	}
-	
-	.item-skillsTab-flex-container-skills-group01 input[readonly],
-	.item-skillsTab-flex-container-skills-group02 input[readonly],
-	.item-skillsTab-flex-container-skills-group03 input[readonly] {
-		text-align: center;
-		background-color: #fff990; 
-		border: transparent;
-		max-width: 24px;
-	}
-	
-	.item-skillsTab-flex-container-skills-group01 input[type=text]:nth-child(1),
-	.item-skillsTab-flex-container-skills-group02 input[type=text]:nth-child(1),
-	.item-skillsTab-flex-container-skills-group03 input[type=text]:nth-child(1) {
-		max-width: 140px;
-		margin-top: 1px;
-		margin-bottom: 1px;
-		font-size: 13px;
-		text-align: left;
-		margin-left: 4px;
-		margin-right: 1px;
-		padding-left: 1px;
-		padding-right: 1px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	/* Sub-Item: Flex containers for rows */
-	.subitem-skillsTab-grid-container-skills-heading-left {
-		grid-template-areas: "skillName skillType rollChance . skillCost";
-		grid-template-columns: 164px 70px 26px 38px 46px;
-		display: grid;
-	}
-	
-	.subitem-skillsTab-grid-container-skills-heading-left-name {
-		grid-area: skillName;
-		padding-left: 5px;
-	}
-	
-	.subitem-skillsTab-grid-container-skills-heading-left-name h2 {
-		text-align: left;
-	}
-	
-	.subitem-skillsTab-grid-container-skills-heading-left-type {
-		grid-area: skillType;
-		text-align: center;
-	}
-	
-	.subitem-skillsTab-grid-container-skills-heading-left-roll {
-		grid-area: rollChance;
-		text-align: center;
-	}
-	
-	.subitem-skillsTab-grid-container-skills-heading-left-cost {
-		grid-area: skillCost;
-		text-align: center;
-	}
-	
-	.subitem-skillsTab-flex-container-skill {
-		text-align: left;
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-height: 24px;
-	}
-	
-	.subitem-skillsTab-flex-container {
-		text-align: right;
-	}
-	
-	/* Buttons for skill movers. */
-	.skill-mover-plus-minus-enclosure {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-	}
-	
-	.skill-mover-plus-minus-button {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		height: 24px;
-		width: 10px;
-		align-items: center;
-		padding: 0px;
-		margin-right: 2px;
-		margin-left: 2px;
-	}
-	
-	.skill-mover-plus-minus-button button.buttonPlus,
-	.skill-mover-plus-minus-button button.buttonMinus {
-		background-color: lemonchiffon;
-		border: solid 1px silver;
-		color: slategray;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-		display: inline-block;
-		font-size: 10px;
-		margin: 0px 0px;
-		line-height: 1.25ch;
-		border-radius: 0px;
-		max-width: 10px;
-	}
-	
-	.skill-mover-plus-minus-button button.buttonPlus span,
-	.skill-mover-plus-minus-button button.buttonMinus span {
-		display: inline-block;
-		transform: rotate(-90deg);
-		text-align: center;
-	}
-	
-	.skill-mover-plus-minus-button button.buttonPlus:hover,
-	.skill-mover-plus-minus-button button.buttonMinus:hover {
-		background-color: gray;
-		color: white;
-		transition: 0.05s;
-	} 
-	
-	/* Item: Skill Container for combat skill flex "columns" */
-	.item-skillsTab-grid-container-combat-skills {
-		grid-area: theCombatSkills;
-		display: grid;
-		grid-template-areas: 
-		"skillNames skillLevels skillTypes skillCosts"
-		"skillLevelNames skillLevels . skillCosts";
-		grid-template-columns: 150px 50px 61px 38px;
-		grid-template-rows: 199px 76px;
-		max-width: 292px;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-bottom: 3px;
-		padding-top: 0px;
-		background-color: #fff990; 
-		border: solid 2px goldenrod;
-		border-radius: 3px;
-		line-height: 1.10;
-	}
-	
-	/* Subitem: flex container for combat skill name "column" */
-	.subitem-skillsTab-flex-container-combat-skills-names {
-		grid-area: skillNames;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-bottom: 3px;
-		padding-top: 0px;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-names input[type=text] {
-		max-width: 140px;
-		margin-top: 0px;
-		margin-bottom: 3px;
-		font-size: 13px;
-		text-align: left;
-		margin-left: 4px;
-		padding-left: 1px;
-		padding-right: 1px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-names h1 {
-		text-align: left;
-		padding-top: 3px;
-		padding-bottom: 3px;
-		max-height: 18px;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-level-names {
-		grid-area: skillLevelNames;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-bottom: 8px;
-		padding-top: 0px;
-	} 
-	
-	.subitem-skillsTab-flex-container-combat-skills-level-names h1 {
-		text-align: left;
-		padding-top: 3px;
-		padding-bottom: 3px;
-		max-height: 18px;
-		font-weight: bold;
-	}
-	
-	/* Subitem: flex container for combat skill levels "column" */
-	.subitem-skillsTab-flex-container-combat-skills-levels {
-		grid-area: skillLevels;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-top: 7px;
-		margin-bottom: 6px;
-		max-height: 264px;
-		margin-top: 3px;
-		padding-bottom: 2px;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-levels input[type=number] {
-		text-align: center;
-		padding-left: 3px;
-		padding-right: 1px; /* Fix for shifting spinners on focus */
-		max-width: 45px;
-		margin-right: 5px;
-		padding-bottom: 1px;
-		max-height: 22px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-levels h1 {
-		text-align: left;
-		padding-top: 0px;
-		padding-bottom: 0px;
-		max-height: 18px;
-		margin-left: 0px;
-	}
-	
-	/* Subitem: flex container for combat skill type "column" */
-	.subitem-skillsTab-flex-container-combat-skills-types {
-		grid-area: skillTypes;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-top: 3px;
-		margin-bottom: 5px;
-		margin-left: 0px;
-		height: 189px;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-types h1 {
-		text-align: center;
-		padding-top: 0px;
-		padding-bottom: 0px;
-		max-height: 18px;
-		margin-left: 0px;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-types .custom-select {
-		max-width: 55px;
-		text-align: center;
-		height: 19px;
-		padding-left: 3px;
-	}
-	
-	/* Subitem: flex container for combat skill costs "column" */
-	.subitem-skillsTab-flex-container-combat-skills-costs {
-		grid-area: skillCosts;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-bottom: 7px;
-		margin-top: 3px;
-		padding-bottom: 2px;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-costs h1 {
-		text-align: center;
-		padding-top: 0px;
-		padding-bottom: 0px;
-		padding-right: 0px;
-		max-height: 18px;
-		max-width: 40px;
-	}
-	
-	.subitem-skillsTab-flex-container-combat-skills-costs input[readonly] {
-		text-align: center;
-		background-color: #fff990;
-		max-width: 30px;
-		margin-left: 5px;
-	}
-	
-	/* Item: Skill Container for Language Skill "rows" */
-	.item-skillsTab-flex-container-languages {
-		grid-area: theLanguageSkills;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		max-width: 292px;
-		background-color: #fff990; 
-		border: solid 2px goldenrod;
-		border-radius: 3px;
-		line-height: 1.10;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-bottom: 3px;
-	}
-	
-	/* Sub-Item: Flex containers for columns */
-	.subitem-skillsTab-flex-container-languages-heading {
-		grid-template-areas: "skillName skillFluency literacy skillCost";
-		grid-template-columns: 148px 83px 31px 36px;
-		display: grid;
-		margin-left: 0px;
-	}
-	
-	.subitem-skillsTab-flex-container-languages-heading-name {
-		grid-area: skillName;
-		text-align: left;
-	}
-	
-	.subitem-skillsTab-flex-container-languages-heading-fluency {
-		grid-area: skillFluency;
-		text-align: center;
-	}
-	
-	.subitem-skillsTab-flex-container-languages-heading-literacy {
-		grid-area: literacy;
-		text-align: center;
-	}
-	
-	.subitem-skillsTab-flex-container-languages-heading-cost {
-		grid-area: skillCost;
-		text-align: center;
-	}
-	
-	.subitem-skillsTab-flex-container-language {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-width: 285px;
-		margin-left: 0px;
-		padding: 0px;
-		margin-left: 4px;
-	}
-	
-	.subitem-skillsTab-flex-container-language input[type=text]:nth-child(1) {
-		text-align: left;
-		padding-left: 2px;
-		min-width: 140px;
-		margin-right: 0px;
-		border: solid 1px palegoldenrod;	
-	}
-	
-	.subitem-skillsTab-flex-container-language input[readonly] {
-		text-align: center;
-		background-color: #fff990;
-		max-width: 22px;
-		margin-right: 0px;
-		margin-left: 3px;
-		border: transparent;
-	}
-	
-	.subitem-skillsTab-flex-container-language .container-checkbox-small {
-		margin-top: 3px;
-		margin-left: 10px;
-	}
-	
-	.subitem-skillsTab-flex-container-language .custom-select {
-		min-width: 70px;
-		margin-left: 8px;
-		max-height: 19px;
-		padding-left: 3px;
-	}
-	
-	
-	/* Item: Skill Container for Skill Enhancers */
-	.item-skillsTab-grid-container-skill-enhancers {
-		grid-area: theEnhancers;
-		display: grid;
-		grid-template-areas: 
-		". skillEnhancersHeading skillEnhancersHeading skillEnhancersHeading"
-		"checkboxes skillNames . skillCosts"
-		". skillNames skillLevels skillCosts";
-		grid-template-columns: 25px 175px 65px 38px;
-		grid-template-rows: 20px 112px 112px;
-		max-width: 295px;
-		padding-left: 5px;
-		grid-gap:0px;
-		background-color: #fff990; 
-		border: solid 2px goldenrod;
-		border-radius: 3px;
-		max-height: 251px;
-	}
-	
-	.item-skillsTab-grid-container-skill-enhancers input[readonly]{
-		background-color: #fff990;
-		text-align: center;
-		height: 18px;
-		max-width: 30px;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-checkboxes {
-		grid-area: checkboxes;
-		text-align: center;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		line-height: 1.2;
-		padding-bottom: 5px;
-		padding-top: 5px;
-		height: 113px;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-heading {
-		grid-area: skillEnhancersHeading;
-		text-align: left;
-		display: flex;
-		flex-direction: row;
-		padding-top: 4px;
-		justify-content: space-between;
-		line-height: 1.15;
-		width: 264px;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-heading h1:nth-child(2) {
-		padding-right: 0px;
-		line-height: 1.15;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-names {
-		grid-area: skillNames;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-evenly;
-		height: 229px;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-names h1 {
-		text-align: left;
-		line-height: 1.15;
-		font-weight: bold;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-levels {
-		grid-area: skillLevels;
-		text-align: left;
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-end;
-		line-height: 1.15;
-		margin-top: 11px;
-		height: 107px;
-		margin-bottom: 4px;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-levels input[type=number]{
-		border: solid 1px palegoldenrod;
-		height: 19px;
-		margin-bottom: 2px;
-	}
-	
-	.subitem-skillsTab-flex-container-skill-enhancers-costs {
-		grid-area: skillCosts;
-		text-align: center;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-evenly;
-		line-height: 1.15;
-		height: 229px;
-	}
-	
-	/* ----------------------------------------------------- */
-	/* Gear: armor, weapons, and equipment                   */
-	/* Organized into a 3x4 grid of containers               */
-	/* ----------------------------------------------------- */
-	
-	.grid-container-tab-gear {
-		display: grid;
-		grid-template-areas:
-		"theEncumbrance theEncumbrance gearHealth"
-		"theArmor theArmor gearHealth"
-		"theWeapons theWeapons theWeapons"
-		"theEquipment theSlides theSlides";
-		grid-gap: 8px;
-		grid-template-columns: 250px 336px 84px;
-		grid-template-rows: 63px 174px 155px 322px;
-		max-width: 692px;
-		padding: 0px;
-		padding-left: 2px;
-		font-size: 16px;
-		background-color: royalblue;
-		border: 3px solid #fff990;
-		border-radius: 5px;
-		justify-content: middle;
-		min-height: 801px;
-	}
-	
-	.grid-container-tab-gear h1 {
-		display:inline-block;
-		margin-left: 0px;
-		padding-left: 2px;
-		padding-right: 0px;
-		padding-top: 0px;
-		padding-bottom: 0px;
-		margin: 0px;
-		margin-top: 1px;
-		font-size: 13px;
-		font-style: normal;
-		line-height: 1.10;
-		text-align: center;
-	}
-	
-	.grid-container-tab-gear .custom-select {
-		font-size: 13px;
-		max-width: 110px;
-		max-height: 19px;
-	}
-	
-	/* Health status styling grouped with item-health-characteristics */
-	
-	/* Encumbrance */
-	.item-tab-gear-flex-container-encumbrance {
-		grid-area: theEncumbrance;
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		margin-left: 4px;
-		margin-top: 6px;
-		padding: 0px;
-		max-width: 594px;
-		max-height: 56px;
-		padding-left: 20px;
-		padding-right: 20px;
-		text-align: left;
-		vertical-align: middle;
-		background-color: royalblue;
-		border: none;
-	}
-	
-	.item-tab-gear-flex-container-encumbrance h1 {
-		text-align: center;
-		color: white;
-		font-size: 13px;
-	}
-	
-	.item-tab-gear-flex-container-encumbrance input[type=number]{
-		background-color: #fff990;
-		text-align: center;
-		max-width: 70px;
-		background-color: gold;
-		border: solid 1px goldenrod;
-		font-size: 16px;
-		margin-left: 0px;
-		padding-right: 0px;
-		min-height: 22px;
-	}
-	
-	.subitem-tab-gear-flex-container-encumbrance,
-	.subitem-tab-gear-flex-container-encumbrance-bonus {
-		display:flex;
-		flex-direction: column;
-		justify-content: space-between;
-		max-width: 80px;
-		align-items: center;
-	}
-	
-	.subitem-tab-gear-flex-container-encumbrance-bonus {
-		margin-left: 0px;
-	}
-	
-	.subitem-tab-gear-plus-minus-enclosure {
-		display: flex;
-		flex-direction: row;
-		background-color: gold;
-		justify-content: space-between;
-		width: 50px;
-		max-height: 20px;
-		border: solid 1px goldenrod;
-		border-radius: 3px;
-	}
-	
-	.subitem-tab-gear-plus-minus-enclosure input[type=text] {
-		max-width: 40px;
-		height: 20px;
-		font-size: 16px;
-		background-color: transparent;
-		text-align: center;
-		vertical-align: center;
-	}
-	
-	.subitem-tab-gear-plus-minus-enclosure input[type=text]:focus{
-		outline: transparent;
-	}
-	
-	.subitem-tab-gear-flex-container-stat {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		height: 20px;
-		width: 10px;
-		align-items: center;
-		padding: 0px;
-	}
-	
-	.subitem-tab-gear-flex-container-stat button.buttonPlus,
-	.subitem-tab-gear-flex-container-stat button.buttonMinus {
-		background-color: LemonChiffon;
-		border: solid 1px slategray;
-		color: slategray;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-		display: inline-block;
-		font-size: 10px;
-		margin: 0px 0px;
-		line-height: 1.4ch;
-		border-radius: 0px;
-		max-width: 10px;
-	}
-	
-	.subitem-tab-gear-flex-container-stat button.buttonPlus span,
-	.subitem-tab-gear-flex-container-stat button.buttonMinus span {
-		display: inline-block;
-		transform: rotate(-90deg);
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-stat button.buttonPlus:hover,
-	.subitem-tab-gear-flex-container-stat button.buttonMinus:hover {
-		background-color: gray;
-		color: white;
-		transition: 0.05s;
-	} 
-	
-	/* ------------- */
-	/* Item: Armor   */
-	/* ------------- */
-	.item-tab-gear-grid-container-armor {
-		grid-area: theArmor;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-around;
-		max-width: 594px;
-		padding-left: 5px;
-		margin-left: 4px;
-		padding-top: 0px;
-		grid-gap: 3px;
-		background-color: #fff990; 
-		border: solid 2px goldenrod;
-		border-radius: 3px;
-		min-height: 179px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: center;
-		max-width: 575px;
-		margin-bottom: 1px;
-		height: 24px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(1) {
-		min-width: 118px;
-		text-align: left;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(2),
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(3),
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(4),
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(5) {
-		min-width: 34px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(6),
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(7) {
-		min-width: 44px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(8) {
-		min-width: 36px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(9) {
-		min-width: 98px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row h1:nth-child(10) {
-		min-width: 46px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row input {
-		max-height: 22px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row input[type=number] {
-		text-align: right;
-		padding-left: 2px;
-		max-width: 36px;
-		min-width: 34px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1),
-	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
-		padding-left: 1px;
-		padding-right: 1px;
-		margin-right: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1) {
-		text-align: left;
-		max-width: 120px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
-		text-align: center;
-		max-width: 100px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row input[type=number]:nth-child(10) {
-		text-align: right;
-		min-width: 48px;
-	}
-	
-	.subitem-tab-gear-flex-container-armor-row select {
-		text-align-last: center; /* For Chrome */
-		text-align: center; /* Firefox */
-	}
-	
-	/* Shield */
-	
-	.subitem-tab-gear-flex-container-shield {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-right: 5px;
-		margin-top: 5px;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1 {
-		margin-bottom: 3px;
-		padding: 0px;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row input {
-		max-height: 21px;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row label {
-		max-width: 5px;
-		margin-left: 2px;
-		margin-top: 3px;
-		padding-right: 0px;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row .container-checkbox-small {
-		padding-left: 10px;
-		margin-right: 3px;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(1) {
-		min-width: 120px;
-		text-align: left;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(3) {
-		min-width: 67px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(4) {
-		min-width: 24px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(6) {
-		min-width: 38px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(7) {
-		min-width: 48px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(5),
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(8),
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(9) {
-		min-width: 32px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(2),
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(10),
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(11) {
-		min-width: 40px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row h1:nth-child(12) {
-		min-width: 42px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1),
-	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
-		padding-left: 1px;
-		padding-right: 1px;
-		margin-right: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1) {
-		max-width: 120px;
-		text-align: left;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
-		max-width: 65px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row  input[readonly]:nth-child(9){
-		background-color: inherit;
-		text-align: center;
-		padding-left: 0px;
-		max-width: 24px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 0px;
-		margin-top: 3px;
-		margin-bottom: 2px;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row input[type=number] {
-		text-align: right;
-		padding-left: 3px;
-		max-width: 38px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row input[type=number]:nth-child(12) {
-		text-align: right;
-		padding-left: 3px;
-		min-width: 42px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-shield-row{
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-width: 576px;
-	}
-	
-	/* ------------- */
-	/* Item: Weapons */
-	/* ------------- */
-	.item-tab-gear-flex-container-weapons {
-		grid-area: theWeapons;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-around;
-		margin-left: 4px;
-		padding: 0px;
-		padding-left: 5px;
-		margin-top: 8px;
-		max-height: 145px;
-		max-width: 655px;
-		background-color: #fff990;
-		border: solid 2px goldenrod;
-		border-radius: 3px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-width: 650px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row input {
-		max-height: 21px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1 {
-		min-width: 39px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row label {
-		max-width: 5px;
-		margin-left: 2px;
-		margin-top: 3px;
-		padding-right: 0px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(1) {
-		min-width: 120px;
-		text-align: left;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(2) {
-		min-width: 65px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(3) {
-		min-width: 26px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(4) {
-		min-width: 32px;
-		text-align: left;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(5) {
-		min-width: 36px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(6) {
-		min-width: 40x;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(7) {
-		min-width: 44px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(8) {
-		min-width: 42px;
-		text-align: center;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(9) {
-		min-width: 32px;
-		text-align: right;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(10) {
-		min-width: 34px;
-		text-align: right;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(11) {
-		min-width: 45px;
-		text-align: center;
-		padding-left: 0px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(12) {
-		min-width: 32px;
-		text-align: center;
-		padding: 0px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(13) {
-		min-width: 32px;
-		text-align: right;
-		margin-right: 6px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(1) {
-		text-align: left;
-		padding-left: 1px;
-		padding-right: 1px;
-		max-width: 120px;
-		margin-right: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(2) {
-		text-align: center;
-		padding-left: 1px;
-		padding-right: 1px;
-		max-width: 68px;
-		margin-right: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row .container-checkbox-small {
-		padding-left: 10px;
-		margin-right: 3px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row button:nth-child(4) {
-		margin-left: 0px;
-		margin-right: 0px;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(5),
-	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(6),
-	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(7),
-	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(9) {
-		text-align: right;
-		padding-left: 3px;
-		max-width: 38px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(8),
-	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(11),
-	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(13) {
-		text-align: right;
-		padding-left: 3px;
-		max-width: 46px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 0px;
-		border: solid 1px palegoldenrod;
-	}
-	
-	.subitem-tab-gear-flex-container-weapon-row input[readonly]:nth-child(10){
-		background-color: inherit;
-		text-align: center;
-		padding-left: 0px;
-		max-width: 24px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 0px;
-		margin-top: 3px;
-		margin-bottom: 2px;
-	}
-	
-	/* --------------- */
-	/* Item: Equipment */
-	/* --------------- */
-	.item-tab-gear-flex-container-equipment {
-		grid-area: theEquipment;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		max-width: 248px;
-		padding-left: 5px;
-		margin-left: 4px;
-		padding: 4px;
-		background-color: lightcyan;
-		border: solid 2px lightgray;
-		border-radius: 3px;
-		height: 367px;
-	}
-	
-	.subitem-tab-gear-flex-container-equipment {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-	}
-	
-	.subitem-tab-gear-flex-container-equipment h1 {
-		margin-right: 8px;
-	}
-	
-	.subitem-tab-gear-flex-container-equipment input[type=text] {
-		text-align: left;
-		padding-left: 1px;
-		padding-right: 1px;
-		max-width: 162px;
-		max-height: 21px;
-		margin-right: 0px;
-		border: solid 1px #eaeaea;
-	}
-	
-	.subitem-tab-gear-flex-container-equipment input[type=number] {
-		text-align: right;
-		padding-left: 3px;
-		max-width: 120px;
-		min-width: 50px;
-		max-height: 21px;
-		padding-right: 0px;
-		margin-right: 0px;
-		margin-left: 2px;
-		border: solid 1px #eaeaea;
-	}
-	
-	/* Buttons for equipment movers. */
-	
-	.gear-mover-plus-minus-enclosure {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		
-	}
-	
-	.gear-mover-plus-minus-button {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		height: 22px;
-		width: 10px;
-		align-items: center;
-		padding: 0px;
-		margin-right: 2px;
-	}
-	
-	.gear-mover-plus-minus-button button.buttonPlus,
-	.gear-mover-plus-minus-button button.buttonMinus {
-		background-color: white;
-		border: solid 1px lightgray;
-		color: lightskyblue;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-		display: inline-block;
-		font-size: 8px;
-		margin: 0px 0px;
-		line-height: 1.25ch;
-		border-radius: 0px;
-		max-width: 10px;
-	}
-	
-	.gear-mover-plus-minus-button button.buttonPlus span,
-	.gear-mover-plus-minus-button button.buttonMinus span {
-		display: inline-block;
-		transform: rotate(-90deg);
-		text-align: center;
-	}
-	
-	.gear-mover-plus-minus-button button.buttonPlus:hover,
-	.gear-mover-plus-minus-button button.buttonMinus:hover {
-		background-color: silver;
-		transition: 0.05s;
-		color: white;
-	} 
-	
-	/* ----------------------------------------------------------- */
-	/* Item: Attacks and Maneuvers or treasures text box slideshow */
-	/* ----------------------------------------------------------- */
-	
-	.item-tab-gear-slide-container {
-		grid-area: theSlides;
-		position: relative;
-	}
-	
-	.item-tab-gear-slide-container h1 {
-		text-align: left;
-		line-height: 1.2;
-		font-size: 12px;
-		margin: 0px;
-	}
-	
-	.item-tab-gear-slide-container h2 {
-		font-size: 12px;
-		text-align: center;
-		font-weight: 400;
-		line-height: 1.2;
-	}
-	
-	.item-tab-gear-slide-container .button-left-arrow {
-		position: absolute;
-		top: 4.5%;
-		left: 88%;
-		transform: translate(-50%, -50%);
-		color: gray;
-		background-color: lightgray;
-		font-size: 12px;
-		padding: 1px 5px;
-		border: none;
-		cursor: pointer;
-		border-radius: 3px;
-		text-align: center;
-	}
-	
-	.item-tab-gear-slide-container .button-right-arrow {
-		position: absolute;
-		top: 4.5%;
-		left: 92.5%;
-		transform: translate(-50%, -50%);
-		color: gray;
-		background-color: lightgray;
-		font-size: 12px;
-		padding: 1px 5px;
-		border: none;
-		cursor: pointer;
-		border-radius: 3px;
-		text-align: center;
-	}
-	
-	.item-tab-gear-slide-container .button-right-arrow:hover,
-	.item-tab-gear-slide-container .button-left-arrow:hover {
-		background-color: gold;
-		color: black;
-	}
-	
-	.item-tab-gear-slide-flex-container-maneuvers,
-	.item-tab-gear-slide-flex-container-martial-maneuvers {
-		width: 406px;
-		height: 375px;
-		padding: 0px;
-		margin-left: 0px;
-		margin-bottom: 0px;
-		background-color: lightcyan;
-		border: solid 2px lightgray;
-		border-radius: 3px;
-	}
-	
-	.item-tab-gear-slide-flex-container-martial-maneuvers-block {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		margin-top: 6px;
-		max-height: 310px;
-		min-height: 270px;
-	}
-	
-	.item-tab-gear-slide-flex-container-martial-maneuvers input[type=text] {
-		border: 1px solid lightgray;
-		height: 22px;
-		width: 30px;
-	}
-	
-	.subitem-flex-container-martial-row input {
-		text-align: center;
-		height: 22px;
-		border: solid 1px lightgray;
-		margin: 0px;
-		padding: 0px;
-	}
+}
 
-	.subitem-flex-container-martial-row input[type=number] {
-		text-align: right;
-		height: 22px;
-		border: solid 1px lightgray;
-		max-width: 38px;
-	}
+/* ----------------------------------------------------	*/
+/* General Styling 										*/
+/* ----------------------------------------------------	*/
 
-	.subitem-flex-container-martial-row input[type=text]:nth-child(2) {
-		width: 220px;
-		margin: 0px;
-		height: 22px;
-		text-align: left;
-		padding-left: 1px;	
-	}
+/* Okabe and Ito colorblind-safe palette:				*/
+/* Green: 			#009E73								*/
+/* Blue: 			#0072B2 							*/
+/* Light blue: 		#56B4E9 							*/
+/* Yellow: 			#F0E442								*/
+/* Orange: 			#E69F00								*/
+/* Orange-red: 		#D55E00								*/
+/* Violet: 			#CC79A7								*/
+/* 														*/
+/* Plus:												*/
+/* A mid-tone gray:	#8A8A8A								*/
 
-	.subitem-flex-container-martial-cv-row input[type=text] {
-		width: 30px;
-		border: 1px solid lightgray;
-		text-align: center;
-		padding-left: 2px;
-		height: 18px;
-		margin-left: 3px;
-	}
-	
-	.item-tab-gear-slide-flex-container-martial-maneuvers textarea {
-		width: 244px;
-		border: 1px solid lightgray;
-		max-height: 37px;
-		padding: 0px 3px; 
-		font-size: 12px;
-		margin: 0px;
-	}
-	
-	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(1),
-	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(1) {
-		width: 108px;
-	}
-	
-	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(2),
-	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(2),
-	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(3),
-	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(3),
-	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(4),
-	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(4) {
-		width: 40px;
-		padding: 0px;
-		margin: 0px;
-		text-align: center;
-	}
-	
-	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(5),
-	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(5) {
-		text-align: left;
-		padding-left: 0px;
-		margin-left: 0px;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(1) {
-		padding-left: 2px;
-		width: 260px;
-	}
+textarea {
+	font-size: 14px;
+	resize: none;
+}
 
-	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(2),
-	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(3) {
-		text-align: center;
-		width: 40px;
-	}
+input {
+	font-size: 13px;
+	border: hidden;
+	border-radius: 3px;
+	padding: 0px;
+	text-align: center;
+}
 
-	.subitem-tab-gear-slide-flex-container-maneuvers-heading,
-	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading {
-		flex-direction: row;
-		display: flex;
-		justify-content: flex-start;
-		width: 402px;
-		height: 19px;
-		padding: 0px;
-		margin-left: 0px;
-		padding-top: 5px;
-		padding-left: 4px;
-		margin-bottom: 0px;
-		background-color: lightcyan;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-maneuvers-light-row,
-	.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
-		flex-direction: row;
-		display: flex;
-		justify-content: flex-start;
-		width: 402px;
-		height: 19px;
-		padding: 0px;
-		margin-left: 0px;
-		padding-top: 4px;
-		padding-left: 4px;
-		margin-top: 0px;
-		margin-bottom: 0px;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-maneuvers-light-row {
-		background-color: white;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
-		background-color: lightcyan;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-martial-maneuvers-row {
-		flex-direction: row;
-		display: flex;
-		justify-content: space-between;
-		width: 397px;
-		height: 40px;
-		padding: 0px;
-		margin-left: 0px;
-		padding-top: 0px;
-		padding-left: 4px;
-		margin-top: 0px;
-		margin-bottom: 0px;
-	}
+input[type=number]:focus {
+	outline: none;
+}
 
-	/* Buttons for maneuver movers. */
-	.maneuver-mover-plus-minus-enclosure {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-	}
-	
-	.maneuver-mover-plus-minus-button {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		height: 24px;
-		width: 10px;
-		align-items: center;
-		padding: 0px;
-		margin-right: 2px;
-		margin-left: 2px;
-	}
-	
-	.maneuver-mover-plus-minus-button button.buttonPlus,
-	.maneuver-mover-plus-minus-button button.buttonMinus {
-		background-color: LemonChiffon;
-		border: solid 1px silver;
-		color: slategray;
-		padding-left: 4px;
-		padding-right: 4px;
-		padding-top: 1px;
-		padding-bottom: 1px;
-		display: inline-block;
-		font-size: 10px;
-		margin: 0px 0px;
-		line-height: 1.25ch;
-		border-radius: 0px;
-		max-width: 10px;
-	}
-	
-	.maneuver-mover-plus-minus-button button.buttonPlus span,
-	.maneuver-mover-plus-minus-button button.buttonMinus span {
-		display: inline-block;
-		transform: rotate(-90deg);
-		text-align: center;
-	}
-	
-	.maneuver-mover-plus-minus-button button.buttonPlus:hover,
-	.maneuver-mover-plus-minus-button button.buttonMinus:hover {
-		background-color: gray;
-		color: white;
-		transition: 0.05s;
-	} 
+input[type=text]:focus,
+	textarea:focus,
+	button:focus {
+}
 
-	.item-flex-maneuver {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		width: 399px;
-		padding-left: 4px;
-		margin-top: 2px;
-		padding-bottom: 2px;
-	}
+input.customCheckbox {
+	width: 20px;
+	height: 20px;
+	vertical-align: middle;
+}
 
-	.subitem-flex-container-martial-row {
-		text-align: left;
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-height: 24px;
-	}
-	
-	/* Update when custom maneuver attack roll made */
-	.subitem-flex-container-martial-row .buttonRollAttack {
-		margin-top: 1px;
-		margin-left: 3px;
-	}
 
-	.subitem-flex-container-martial-ocv-dcv {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		max-height: 40px;
-		max-width: 134px;
-		padding: 0px 0px;
-	}
-	
-	/* Martial Maneuver Details */
-	
-	.subitem-flex-container-martial-details-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: top;
-		max-width: 397px;
-		height: 48px;
-		padding-left: 23px;
-		padding-top: 0px;
-		padding-bottom: 0px;
-	}
-	
-	.subitem-flex-container-martial-details-row .buttonRollShow {
-		margin-top: 3px;
-	}
-	
-	.subitem-flex-container-martial-details-column {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		height: 49px;
-	}
-	
-	.subitem-flex-container-martial-cv-damage-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-height: 21px;
-		align-items: center;
-		padding-right: 1px;
-	}
-	
-	.subitem-flex-container-martial-cv-damage-row h1 {
-		padding-right: 1px;
-	}
-	
-	.subitem-flex-container-martial-cv-damage-row h1:not(:first-child) {
-		padding-left: 7px;
-	}
-	
-	.subitem-flex-container-martial-cv-damage-row input[type=number] {
-		height: 21px;
-		max-width: 38px;
-		border: solid 1px lightgray;
-	}
-	
-	.subitem-flex-container-martial-cv-damage-row input[type=text] {
-		text-align: center;
-		height: 21px;
-		width: 68px;
-		padding-left: 2px;
-		padding-right: 4px;
-	}
-	
-	.subitem-martial-description-row {
-		max-height: 22px;
-		max-width: 374px;
-	}
-	
-	.subitem-martial-description-row input[type=text] {
-		width: 321px;
-		height: 22px;
-		text-align: left;
-		padding-left: 2px;
-	}
-	
-	/* Basic Attack */
-	.subitem-tab-gear-slide-flex-container-standard-attack {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		margin-left: 23px;
-		margin-bottom: 1px;
-		padding-right: 0px;
-		min-width: 376px;
-		align-items: center;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-standard-attack h1 {
-		text-align: left;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-standard-attack input[type=text] {
-		text-align: left;
-		margin-left: 96px;
-		margin-right: 41px;
-		text-align: center;
-	}
-	
-	/* Range Modifier Table */
-	.subitem-tab-gear-slide-flex-container-range-modifiers {
-		flex-direction: row;
-		display: flex;
-		justify-content: space-between;
-		width: 397px;
-		height: 30px;
-		padding: 0px;
-		padding-left: 5px;
-		margin-left: 0px;
-		margin-top: 11px;
-		margin-bottom: 2px;
-	}
-	
-	.subitem-tab-gear-slide-range-modifier-container-first,
-	.subitem-tab-gear-slide-range-modifier-container {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		height: 30px;
-	}
-	
-	.subitem-tab-gear-slide-range-modifier-container-first {
-		min-width: 83px;
-		align-items: flex-start;
-	}
-	
-	.subitem-tab-gear-slide-range-modifier-container {
-		min-width: 50px;
-		align-items: center;
-	}
-	
-	.subitem-tab-gear-slide-range-modifier-container h2:nth-child(1) {
-		font-weight: bold;
-	}
-	
-	.subitem-tab-gear-slide-range-modifier-container-first h2 {
-		font-weight: bold;
-	}
-	
-	/* Item: Hit Locations */
-	.item-tab-gear-slide-flex-container-hit-locations {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		width: 403px;
-		height: 375px;
-		padding: 0px;
-		padding-left: 3px;
-		background-color: lightcyan;
-		margin-left: 0px;
-		margin-bottom: 0px;
-		border: solid 2px lightgray;
-		border-radius: 3px;
-	}
-	
-	.item-gear-slide-container-hit-locations-flex-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		border-radius: 3px;
-		width: 400px;
-	}
-	
-	/* Special Hit Locations */
-	.item-gear-slide-flex-container-hit-locations-special {
-		width: 260px;
-		height: 145px;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-	}
-	
-	.item-gear-slide-flex-container-hit-locations-special label {
-		display: inline-block;
-		margin-left: 14px;
-		margin-right: 4px;
-		margin-top: 2px; /* A fix to get a uniform look with the hit location table */
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-heading {
-		background-color: lightcyan;
-		height: 20px;
-		margin-bottom: 3px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(1){
-		width: 42px;
-		text-align: left;
-		margin-left: 2px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(2){
-		width: 40px;
-		text-align: center;
-		margin-left: 3px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(3){
-		width: 52px;
-		text-align: center;
-		margin-left: 30px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(4){
-		width: 44px;
-		text-align: right;
-		margin-left: 15px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-top-row,
-	.subitem-gear-slide-flex-container-hit-locations-special-middle-row,
-	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		background-color: white;
-		border-left: solid 1px lightgray;
-		border-right: solid 1px lightgray;
-		width: 260px;
-		height: 20px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-top-row {
-		border-top: solid 1px lightgray;
-		border-top-left-radius: 3px;
-		border-top-right-radius: 3px;
-		padding-top: 5px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
-		border-bottom: solid 1px lightgray;
-		border-bottom-left-radius: 3px;
-		border-bottom-right-radius: 3px;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-top-row h1,
-	.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1,
-	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1 {
-		width: 65px;
-		text-align: center;
-	}
-	
-	.subitem-gear-slide-flex-container-hit-locations-special-top-row h1:nth-child(4),
-	.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1:nth-child(4),
-	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1:nth-child(4) {
-		width: 35px;
-		text-align: right;
-		padding-right: 19px;
-	}
-	
-	/* Targeting Options */
-	.item-gear-slide-container-hit-locations-options {
-		width: 130px;
-		height: 100px;
-		margin-top: 50px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-options-top,
-	.subitem-gear-slide-container-hit-locations-options-bottom {
-		display: flex;
-		flex-direction: row;
-		justify-content: flex-start;
-		width: 115px;
-		margin: 3px;
-		margin-bottom: 15px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-options-top {
-		margin-left: 10px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-options-top h1,
-	.subitem-gear-slide-container-hit-locations-options-bottom h1 {
-		padding-top: 4px;
-		margin: 0px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-options-top label {
-		max-width: 0px;
-		margin-left: 2px;
-		margin-right: 0px;
-		margin-top: 3px;
-		padding-right: 0px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-options-bottom input {
-		margin-left: 5px;
-		border: solid 1px lightgray;
-	}
-	
-	/* Hit Location Table */
-	.item-gear-slide-container-hit-locations-table {
-		width: 399px;
-		height: 215px;
-	}
-	
-	.item-gear-slide-container-hit-locations-table h1 {
-		width: 51px;
-		text-align: center;
-	}
-	
-	.item-gear-slide-container-hit-locations-table label {
-		display: inline-block;
-		margin-left: 14px;
-		margin-right: 3px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-heading {
-		background-color: lightcyan;
-		height: 20px;
-		margin-bottom: 3px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-heading h1 {
-		text-align: center;
-		margin-left: 2px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(1){
-		width: 42px;
-		text-align: left;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(2){
-		width: 34px;
-		text-align: center;
-		margin-right: 9px;
-		margin-left: 3px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-top-row,
-	.subitem-gear-slide-container-hit-locations-table-middle-row,
-	.subitem-gear-slide-container-hit-locations-table-bottom-row {
-		height: 19px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
-	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
-	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
-		width: 40x;
-		text-align: center;
-		margin-right: 11px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
-	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
-	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
-		width: 34px;
-		text-align: center;
-		margin-left: 21px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(6),
-	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(6),
-	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(6){
-		width: 45px;
-		text-align: center;
-		margin-left: 6px;
-		margin-right: 0px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(7),
-	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(7),
-	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(7){
-		width: 34px;
-		text-align: right;
-		margin-left: 4px;
-		margin-right: 17px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-top-row {
-		background-color: white;
-		border-top: solid 1px lightgray;
-		border-left: solid 1px lightgray;
-		border-right: solid 1px lightgray;
-		border-top-left-radius: 3px;
-		border-top-right-radius: 3px;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-middle-row {
-		background-color: white;
-		border-left: solid 1px lightgray;
-		border-right: solid 1px lightgray;
-	}
-	
-	.subitem-gear-slide-container-hit-locations-table-bottom-row {
-		background-color: white;
-		border-left: solid 1px lightgray;
-		border-right: solid 1px lightgray;
-		border-bottom: solid 1px lightgray;
-		border-bottom-left-radius: 3px;
-		border-bottom-right-radius: 3px;
-		padding-bottom: 5px;
-	}
-	
-	/* Item: Slide of treasure and notes box  */
-	.item-tab-gear-slide-treasure-text {
-		width: 402px;
-		height: 367px;
-		padding: 0px;
-		margin-left: 0px;
-		margin-bottom: 0px;
-	}
-	
-	.item-tab-gear-slide-treasure-text textarea {
-		width: 398px;
-		height: 367px;
-		margin: 0px;
-		border: solid 2px lightgray;
-		border-radius: 3px;
-	}
-	
-	/* hide all gear tab slides by default */
-	
-	.item-tab-gear-slide-flex-container-maneuvers,
-	.item-tab-gear-slide-flex-container-martial-maneuvers,
-	.item-tab-gear-slide-flex-container-hit-locations,
-	.item-tab-gear-slide-treasure-text {
-		display: none;
-	}
-	
-	/* show the selected gear slide */
-	.item-gear-slideshow[value="1"] ~ div.item-tab-gear-slide-flex-container-maneuvers,
-	.item-gear-slideshow[value="2"] ~ div.item-tab-gear-slide-flex-container-martial-maneuvers,
-	.item-gear-slideshow[value="3"] ~ div.item-tab-gear-slide-flex-container-hit-locations,
-	.item-gear-slideshow[value="4"] ~ div.item-tab-gear-slide-treasure-text {
-		display: block;
-		position: relative;
-	}
-	
-	/* ---------------------------------------------------------------- */
-	/* Custom radio button from w3 schools.                             */
-	/* https://www.w3schools.com/howto/howto_css_custom_checkbox.asp    */
-	/* ---------------------------------------------------------------- */
-	
-	/* Customize the label (the container) */
-	.custom-radio-button-container {
-		display: block;
-		position: relative;
-		padding: 0px;
-		margin: 0px;
-		cursor: pointer;
-		font-size: 12px;
-		max-width: 0px;
-		max-height: 0px;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		user-select: none;
-		background-color: orange;
-		/* background-color: orange; */
-	}
-	
-	/* Hide the browser's default radio button */
-	.custom-radio-button-container input {
-		position: absolute;
-		opacity: 0;
-		cursor: pointer;
-		height: 0;
-		width: 0;
-	}
-	
-	/* Create a custom radio button */
-	.custom-radio-button {
-		position: absolute;
-		top: -2px; /* A fix to get a uniform look with the hit location table */
-		left: 0px;
-		height: 11px;
-		width: 11px;
-		background-color: white;
-		border: solid 2px lightsteelblue;
-		border-radius: 50%;
-		margin-bottom: 0px;
-		padding: 0px;
-	}
-	
-	/* On mouse-over, add a grey background color */
-	.custom-radio-button-container:hover input ~ .custom-radio-button {
-		background-color: lightsteelblue;
-	}
-	
-	/* When the radio button is checked, add a blue background */
-	.custom-radio-button-container input:checked ~ .custom-radio-button {
-		background-color: indianred;
-		border: solid 2px indianred;
-	}
-	
-	/* Create the indicator (the dot/circle - hidden when not checked) */
-	.custom-radio-button:after {
-		content: "";
-		position: absolute;
-		display: none;
-	}
-	
-	/* Show the indicator (dot/circle) when checked */
-	.custom-radio-button-container input:checked ~ .custom-radio-button:after {
-		display: block;
-	}
-	
-	/* Style the indicator (dot/circle) */
-	.custom-radio-button-container .custom-radio-button:after {
-		top: 0px;
-		left: 0px;
-		width: 7px;
-		height: 7px;
-		border-radius: 50%;
-		border: solid 2px white;
-		background: indianred;
-		margin: 0px;
-		padding: 0px;
-	}
-	
-	/* ---------------------------------------------------------------- */
-	/* Jackob's Roll Template                                           */
-	/* https://wiki.roll20.net/Building_Character_Sheets/Roll_Templates */
-	/* ---------------------------------------------------------------- */
-	
-	/* Three different Templates for attacks, armor activation, and skills ability checks. */
-	.sheet-rolltemplate-custom,
-	.sheet-rolltemplate-custom-success-roll,
-	.sheet-rolltemplate-custom-defense,
-	.sheet-rolltemplate-custom-attack,
-	.sheet-rolltemplate-custom-normal-attack,
-	.sheet-rolltemplate-custom-maneuver,
-	.sheet-rolltemplate-custom-normal-maneuver,
-	.sheet-rolltemplate-custom-power-attack,
-	.sheet-rolltemplate-custom-activate,
-	.sheet-rolltemplate-custom-show {
-		margin-left: -37px;
-		color: #181818;
-	}
-	
-	.withoutavatars .sheet-rolltemplate-custom,
-	.withoutavatars .sheet-rolltemplate-custom-success-roll,
-	.withoutavatars .sheet-rolltemplate-custom-defense,
-	.withoutavatars .sheet-rolltemplate-custom-attack,
-	.withoutavatars .sheet-rolltemplate-custom-normal-attack,
-	.withoutavatars .sheet-rolltemplate-custom-maneuver,
-	.withoutavatars .sheet-rolltemplate-custom-normal-maneuver,
-	.withoutavatars .sheet-rolltemplate-custom-power-attack,
-	.withoutavatars .sheet-rolltemplate-custom-activate,
-	.withoutavatars .sheet-rolltemplate-custom-show {
-		margin-left: -7px;
-		color: #181818;
-	}
-	
-	.sheet-rolltemplate-custom .sheet-container,
-	.sheet-rolltemplate-custom-success-roll .sheet-container,
-	.sheet-rolltemplate-custom-defense .sheet-container,
-	.sheet-rolltemplate-custom-attack .sheet-container,
-	.sheet-rolltemplate-custom-normal-attack .sheet-container,
-	.sheet-rolltemplate-custom-maneuver .sheet-container,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
-	.sheet-rolltemplate-custom-power-attack .sheet-container,
-	.sheet-rolltemplate-custom-activate .sheet-container,
-	.sheet-rolltemplate-custom-show .sheet-container {
-		border: 1px solid;
-		/* by default, the border is the same color as the header. You can change this here, e.g. to black */
-		border-color: var(--header-bg-color);
-	}
-	
-	/* Header formatting - title and subtitle */
-	.sheet-rolltemplate-custom .sheet-header,
-	.sheet-rolltemplate-custom-success-roll .sheet-header {
-		background-color: #E69F00;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-defense .sheet-header {
-		background-color: #56B4E9;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-attack .sheet-header {
-		background-color: #D55E00;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-normal-attack .sheet-header {
-		background-color: #009E73;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-maneuver .sheet-header {
-		background-color: #D55E00
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-header {
-		background-color: #009E73;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-power-attack .sheet-header {
-		background-color: #CC79A7;
-		/* background-color: #56B4E9; */
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-activate .sheet-header {
-		background-color: #0072B2;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom-show .sheet-header {
-		background-color: #8A8A8A;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-	
-	.sheet-rolltemplate-custom .sheet-title,
-	.sheet-rolltemplate-custom-success-roll .sheet-title,
-	.sheet-rolltemplate-custom-defense .sheet-title,
-	.sheet-rolltemplate-custom-attack .sheet-title,
-	.sheet-rolltemplate-custom-normal-attack .sheet-title,
-	.sheet-rolltemplate-custom-maneuver .sheet-title,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-title,
-	.sheet-rolltemplate-custom-power-attack .sheet-title,
-	.sheet-rolltemplate-custom-activate .sheet-title,
-	.sheet-rolltemplate-custom-show .sheet-title {
-		font-size:1.2em;
-	}
-	
-	.sheet-rolltemplate-custom .sheet-subtitle,
-	.sheet-rolltemplate-custom-success-roll .sheet-subtitle,
-	.sheet-rolltemplate-custom-defense .sheet-subtitle,
-	.sheet-rolltemplate-custom-attack .sheet-subtitle,
-	.sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
-	.sheet-rolltemplate-custom-maneuver .sheet-subtitle,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-subtitle,
-	.sheet-rolltemplate-custom-power-attack .sheet-subtitle,
-	.sheet-rolltemplate-custom-activate .sheet-subtitle,
-	.sheet-rolltemplate-custom-show .sheet-subtitle {
-		font-size:1.0em;
-		padding-top: 0.1em;
-	}
-	
-	/* example colors */
-	.sheet-rolltemplate-custom .sheet-container,
-	.sheet-rolltemplate-custom-success-roll .sheet-container,
-	.sheet-rolltemplate-custom-defense .sheet-container,
-	.sheet-rolltemplate-custom-attack .sheet-container,
-	.sheet-rolltemplate-custom-normal-attack .sheet-container,
-	.sheet-rolltemplate-custom-maneuver .sheet-container,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
-	.sheet-rolltemplate-custom-power-attack .sheet-container,
-	.sheet-rolltemplate-custom-activate .sheet-container,
-	.sheet-rolltemplate-custom-show .sheet-container  {
-		/* this is the default color */
-		--header-bg-color: black;
-		--header-text-color: #FFF;
-	}
-	
-	/* Allprops part */
-	.sheet-rolltemplate-custom .sheet-content,
-	.sheet-rolltemplate-custom-success-roll .sheet-content,
-	.sheet-rolltemplate-custom-defense .sheet-content,
-	.sheet-rolltemplate-custom-attack .sheet-content,
-	.sheet-rolltemplate-custom-normal-attack .sheet-content,
-	.sheet-rolltemplate-custom-maneuver .sheet-content,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-content,
-	.sheet-rolltemplate-custom-power-attack .sheet-content,
-	.sheet-rolltemplate-custom-activate .sheet-content,
-	.sheet-rolltemplate-custom-show .sheet-content {
-		display: grid;
-		background: #FFF;
-		/* Header formatting - modify the column layout below */
-		grid-template-columns: auto auto;
-		/* Line height to match default roll template */
-		line-height:1.4em;
-	}
-	
-	.sheet-rolltemplate-custom .sheet-content > div,
-	.sheet-rolltemplate-custom-success-roll .sheet-content > div,
-	.sheet-rolltemplate-custom-defense .sheet-content > div,
-	.sheet-rolltemplate-custom-attack .sheet-content > div,
-	.sheet-rolltemplate-custom-normal-attack .sheet-content > div,
-	.sheet-rolltemplate-custom-maneuver .sheet-content > div,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-content > div,
-	.sheet-rolltemplate-custom-power-attack .sheet-content > div,
-	.sheet-rolltemplate-custom-activate .sheet-content > div,
-	.sheet-rolltemplate-custom-show .sheet-content > div {
-		padding: 5px;
-	}
-	
-	/* Left column */
-	.sheet-rolltemplate-custom .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-success-roll .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-defense .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-attack .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-maneuver .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-activate .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-show .sheet-content .sheet-key {
-		font-weight: bold;
-		padding-right: 10px;
-		text-align: right;
-		color: #222222; /* To fix dark mode in Chrome. */
-	}
-	
-	/* Right column. Color to fix dark mode in Chrome. */
-	.sheet-rolltemplate-custom .sheet-value,
-	.sheet-rolltemplate-custom-success-roll .sheet-value,
-	.sheet-rolltemplate-custom-defense .sheet-value,
-	.sheet-rolltemplate-custom-attack .sheet-value,
-	.sheet-rolltemplate-custom-normal-attack .sheet-value,
-	.sheet-rolltemplate-custom-maneuver .sheet-value,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-value,
-	.sheet-rolltemplate-custom-power-attack .sheet-value,
-	.sheet-rolltemplate-custom-activate .sheet-value,
-	.sheet-rolltemplate-custom-show .sheet-value {
-		color: #222222;
-	}
-	
-	/* Make even-numbered rows grey */
-	.sheet-rolltemplate-custom .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n) {
-		background:#EEE;
-	}
-	
-	/* Description field */
-	.sheet-rolltemplate-custom .sheet-desc,
-	.sheet-rolltemplate-custom-success-roll .sheet-desc,
-	.sheet-rolltemplate-custom-defense .sheet-desc,
-	.sheet-rolltemplate-custom-attack .sheet-desc,
-	.sheet-rolltemplate-custom-normal-attack .sheet-desc,
-	.sheet-rolltemplate-custom-maneuver .sheet-desc,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-desc,
-	.sheet-rolltemplate-custom-power-attack .sheet-desc,
-	.sheet-rolltemplate-custom-activate .sheet-desc,
-	.sheet-rolltemplate-custom-show .sheet-desc {
-		grid-column: span 2;
-		padding-right: 10px;
-		text-align: left;
-		color: #222222; /* To fix dark mode in Chrome. */
-	}
-	
-	/* Dice roll face colors. Needed to prevent problems with dark mode. */
-	.sheet-rolltemplate-custom .inlinerollresult,
-	.sheet-rolltemplate-custom-success-roll .inlinerollresult,
-	.sheet-rolltemplate-custom-defense .inlinerollresult,
-	.sheet-rolltemplate-custom-attack .inlinerollresult,
-	.sheet-rolltemplate-custom-normal-attack .inlinerollresult,
-	.sheet-rolltemplate-custom-maneuver .inlinerollresult,
-	.sheet-rolltemplate-custom-normal-maneuver .inlinerollresult,
-	.sheet-rolltemplate-custom-power-attack .inlinerollresult,
-	.sheet-rolltemplate-custom-activate .inlinerollresult,
-	.sheet-rolltemplate-custom-show .inlinerollresult {
-		display: inline-block;
-		min-width: 1.5em;
-		text-align: center;
-		border: 2px solid palegoldenrod;
-		background: #fff990;
-	}
-	
-	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult {
-		background-color: #fff990;
-		border: 2px solid palegoldenrod;
-	}
-	
-	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullcrit {
-		border: 2px solid #228833;
-	}
-	
-	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullfail {
-		border: 2px solid #AA3377;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Power block expanding/collapse functionality        */
-	/* --------------------------------------------------- */
-	
-	/* Nominal state for expanded areas */
-	.sheet-power-expand-01,
-	.sheet-power-expand-02,
-	.sheet-power-expand-03,
-	.sheet-power-expand-04,
-	.sheet-power-expand-05,
-	.sheet-power-expand-06,
-	.sheet-power-expand-07,
-	.sheet-power-expand-08,
-	.sheet-power-expand-09,
-	.sheet-power-expand-10,
-	.sheet-power-expand-11,
-	.sheet-power-expand-12,
-	.sheet-power-expand-13,
-	.sheet-power-expand-14,
-	.sheet-power-expand-15,
-	.sheet-power-expand-16,
-	.sheet-power-expand-17 {
-		display: none;
-	}
-	
-	/* Expand the selected left power block. */
-	.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .sheet-power-expand-01,
-	.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .sheet-power-expand-02,
-	.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .sheet-power-expand-03,
-	.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .sheet-power-expand-04,
-	.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .sheet-power-expand-05,
-	.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .sheet-power-expand-06,
-	.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .sheet-power-expand-07,
-	.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .sheet-power-expand-08,
-	.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .sheet-power-expand-09 {
-		display: block;
-	}
+/* --------------------------------------------------------------- */
+/* Custom select used due to differences between Firefox,          */
+/* Chrome, and Safari. From:                                       */
+/* @link https://moderncss.dev/custom-select-styles-with-pure-css/ */
+/* --------------------------------------------------------------- */
 
-	/* Expand the selected right power block. */
-	.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .sheet-power-expand-10,
-	.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .sheet-power-expand-11,
-	.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .sheet-power-expand-12,
-	.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .sheet-power-expand-13,
-	.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .sheet-power-expand-14,
-	.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .sheet-power-expand-15,
-	.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .sheet-power-expand-16,
-	.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .sheet-power-expand-17 {
-		display: block;
-	}
-	
-	/* Turn down the opacity on the left point values to help visibility overall. */
-	.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-opacity-power01,
-	.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-opacity-power02,
-	.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-opacity-power03,
-	.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-opacity-power04,
-	.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-opacity-power05,
-	.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-opacity-power06,
-	.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-opacity-power07,
-	.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-opacity-power08,
-	.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-opacity-power09 {
-		opacity: 0.4;
-	}
-	
-	/* Turn down the opacity on the right point values to help visibility overall. */
-	.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-opacity-power10,
-	.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-opacity-power11,
-	.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-opacity-power12,
-	.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-opacity-power13,
-	.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-opacity-power14,
-	.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-opacity-power15,
-	.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-opacity-power16,
-	.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-opacity-power17 {
-		opacity: 0.4;
-	}
-	
-	/* Hide the base and active costs for a tidier look. */
-	.subitem-visibility-power01,
-	.subitem-visibility-power02,
-	.subitem-visibility-power03,
-	.subitem-visibility-power04,
-	.subitem-visibility-power05,
-	.subitem-visibility-power06,
-	.subitem-visibility-power07,
-	.subitem-visibility-power08,
-	.subitem-visibility-power09,
-	.subitem-visibility-power10,
-	.subitem-visibility-power11,
-	.subitem-visibility-power12,
-	.subitem-visibility-power13,
-	.subitem-visibility-power14,
-	.subitem-visibility-power15,
-	.subitem-visibility-power16,
-	.subitem-visibility-power17 {
-		visibility: hidden;
-	}
-	
-	.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power01,
-	.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power02,
-	.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power03,
-	.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power04,
-	.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power05,
-	.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power06,
-	.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power07,
-	.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power08,
-	.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power09 {
-		visibility: visible;
-	}
-	
-	.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power10,
-	.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power11,
-	.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power12,
-	.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power13,
-	.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power14,
-	.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power15,
-	.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power16,
-	.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power17 {
-		visibility: visible;
-	}
-	
-	/* --------------------------------------------------- */
-	/* Maneuver block expanding/collapse functionality     */
-	/* --------------------------------------------------- */
-	
-	/* Nominal state for expanded areas */
-	.sheet-maneuver-expand-01,
-	.sheet-maneuver-expand-02,
-	.sheet-maneuver-expand-03,
-	.sheet-maneuver-expand-04,
-	.sheet-maneuver-expand-05,
-	.sheet-maneuver-expand-06,
-	.sheet-maneuver-expand-07,
-	.sheet-maneuver-expand-08,
-	.sheet-maneuver-expand-09  {
-		display: none;
-	}
-	
-	/* Expand the selected maneuver block. */
-	.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .sheet-maneuver-expand-01,
-	.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .sheet-maneuver-expand-02,
-	.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .sheet-maneuver-expand-03,
-	.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .sheet-maneuver-expand-04,
-	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .sheet-maneuver-expand-05,
-	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .sheet-maneuver-expand-06,
-	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .sheet-maneuver-expand-07,
-	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08,
-	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .sheet-maneuver-expand-09 {
-		display: block;
-	}
 
-	/* ---------------------------------------------------------------- */
-	/* Custom button for power expand                                   */
-	/* ---------------------------------------------------------------- */
+select,
+select::before,
+select::after {
+  box-sizing: border-box;
+}
 	
-	.custom-expand-button-container {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		margin-right: 1px;
-	}
-	
-	.custom-expand-button-container button.buttonExpand {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		height: 24px;
-		width: 10px;
-		align-items: center;
-		padding: 0px;
-		margin-right: 2px;
-		margin-left: 0px;
-		border-color: transparent;
-		background: transparent;
-	}
-	
-	.custom-expand-button-container button.buttonExpand span {
-		display: inline-block;
-		text-align: center;
-	}
-	
-	/* Rotate when expanded */
-	.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01,
-	.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02,
-	.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03,
-	.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04,
-	.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05,
-	.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06,
-	.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07,
-	.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08,
-	.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09,
-	.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10,
-	.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11,
-	.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12,
-	.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13,
-	.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14,
-	.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15,
-	.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16,
-	.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17,
-	.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01,
-	.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02,
-	.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03,
-	.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04,
-	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05,
-	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06,
-	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07,
-	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08,
-	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09
- 	{
-		transform: rotate(90deg);
-	}
-	
-	/* Rotate when not expanded, but hover */
-	.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01:hover,
-	.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02:hover,
-	.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03:hover,
-	.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04:hover,
-	.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05:hover,
-	.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06:hover,
-	.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07:hover,
-	.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08:hover,
-	.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09:hover,
-	.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10:hover,
-	.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11:hover,
-	.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12:hover,
-	.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13:hover,
-	.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14:hover,
-	.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15:hover,
-	.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16:hover,
-	.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand01"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand02"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand03"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand04"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand05"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand06"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand07"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand09"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09:hover
-	{
-		transition: 0.25s;
-		transform: rotate(90deg);
-	}
-	
-	.custom-button-triangle {
-		position: relative; 
-		border-top: 8px solid transparent;
-		border-bottom: 8px solid transparent;
-		border-left: 12px solid silver;
-		border-right: 8px solid transparent;
-		top: 0px;
-		left: 5px;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-standard-attack .custom-button-triangle {
-		left: 3px
-	}
+select {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	background-color: transparent;
+	border: none;
+	padding: 0 1em 0 0;
+	margin: 0;
+	width: 100%;
+	font-family: inherit;
+	/* font-size: inherit; */
+	font-size: 12px;
+	cursor: inherit;
+	line-height: inherit;
+	z-index: 1;
+	outline: none;
+	max-height: 22px;
+}
 
-	.custom-button-triangle:before {
-		content: "";
-		width: 0;
-		height: 0;
-		position: absolute;
-		border-top: 6px solid transparent;
-		border-bottom: 6px solid transparent;
-		border-left: 10px solid #FFF9CF;
-		top: -6px;
-		left: -11px; 
-	}
+.custom-select,
+.custom-select-skill,
+.custom-select-alternate,
+.custom-select-alternate-skill,
+.custom-select-option {
+	display: grid;
+	grid-template-areas: "select";
+	align-items: center;
+	position: relative;
+	max-height: 20px;
+	border: 1px solid gray;
+	border-radius: 3px;
+	padding: 0px;
+	padding-bottom: 1px;
+	padding-right: 3px;
+	cursor: pointer;
+	background-color: #fff;
+	background-image: linear-gradient(to top, #f9f9f9, #fff 33%);
+}
+
+.custom-select,
+.custom-select-skill,
+.custom-select-alternate,
+.custom-select-alternate-skill {
+	min-width: 34px;
+	padding-left: 0px;
+}
+
+.custom-select-option {
+	width: 58px;
+	background-color: red;
+	padding-left: 4px;
+	margin-right: 6px;
+}
+
+.custom-select-skill,
+.custom-select-alternate-skill {
+	margin-top: 2px;
+	margin-bottom: 1px;
+	max-height: 20px;
+}
+
+.custom-select select,
+.custom-select-skill select,
+.custom-select-alternate select,
+.custom-select-alternate-skill select,
+.custom-select-option select,
+.custom-select::after,
+.custom-select-skill::after,
+.custom-select-alternate::after,
+.custom-select-alternate-skill::after,
+.custom-select-option::after {
+	grid-area: select;
+}
+
+.custom-select::after,
+.custom-select-skill::after,
+.custom-select-alternate::after,
+.custom-select-alternate-skill::after,
+.custom-select-option::after {
+	content: "";
+	justify-self: end;
+	width: 12px;
+	height: 8px;
+	-webkit-clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+	clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+}
+
+.custom-select::after,
+.custom-select-skill::after {
+	background-color: olive;
+}
+
+.custom-select-alternate::after,
+.custom-select-alternate-skill::after {
+	background-color: salmon;
+}
+
+.custom-select-option::after  {
+	background-color: dodgerblue;
+}
+
+select:focus + .focus {
+	position: absolute;
+	top: -1px;
+	left: -1px;
+	right: -1px;
+	bottom: -1px;
+	border: 2px solid goldenrod;
+	border-radius: inherit;
+}
+
+.custom-select--disabled,
+.custom-select-skill--disabled,
+.custom-select-alternate--disabled,
+.custom-select-alternate-skill--disabled,
+.custom-select-alternate-option--disabled {
+	cursor: not-allowed;
+	background-color: #eee;
+	background-image: linear-gradient(to top, #ddd, #eee 33%);
+}
+
+.custom-select-skill,
+.custom-select-alternate-skill {
+	width: 64px;
+}
+
+/* --------------------------------------------------- */
+/* Tab Styling                                         */
+/* --------------------------------------------------- */
+.tab {
+	display: flex;
+	justify-content: space-between;
+	height:36px;
+	padding: 0px;
+	widows: 100%;
+	margin-bottom: 0px;
+	margin-left: 0px;
+	margin-right: 0px;
+	width: 680px;
+	background: dodgerblue;
+	border: 8px;
+	border-bottom: 0px;
+	border-radius: 4px;
+	border-bottom-left-radius: 0px;
+	border-bottom-right-radius: 0px;
+	border-color: dodgerblue;
+	border-style: solid;
+}
+
+/* Style the buttons inside the tab */
+.tab button {
+	background-color: #CCCCFF;
+	float: left;
+	outline: none;
+	cursor: pointer;
+	padding: 10px 10px;
+	margin-right: 0px;
+	transition: 0.3s;
+	font-size: 18px;
+	border: 0px;
+}
+
+/* Change background color of buttons on hover */
+.tab button:hover {
+	background-color: yellow;
+}
+
+/* Create an active/current tab class */
+.tab button.active {
+	background-color: yellow;
+}
+
+/* --------------------------------------------------- */
+/* Configure sheet and tab buttons                     */
+/* --------------------------------------------------- */
+.sheet-characteristics,
+.sheet-skills,
+.sheet-powers,
+.sheet-complications,
+.sheet-gear,
+.sheet-options {
+	display: none;
+	width: 680px;
+	background: dodgerblue;
+	border: 8px;
+	border-color: dodgerblue;
+	border-style: solid;
+}
+
+/* show the selected tab */
+.sheet-tabstoggle[value="characteristics"] ~ div.sheet-characteristics,
+.sheet-tabstoggle[value="skills"] ~ div.sheet-skills,
+.sheet-tabstoggle[value="powers"] ~ div.sheet-powers,
+.sheet-tabstoggle[value="complications"] ~ div.sheet-complications,
+.sheet-tabstoggle[value="gear"] ~ div.sheet-gear,
+.sheet-tabstoggle[value="options"] ~ div.sheet-options {
+	display: block;
+}
+
+/* Styling for characteristics tab labels */
+.sheet-characteristics label {
+	display:inline-block;
+	font-size: 13px;
+}
+
+/* --------------------------------------------------- */
+/* Tally Bar styling                                   */
+/* --------------------------------------------------- */
+
+.sheet-tallybar {
+	width: 680px;
+	background: dodgerblue;
+	border: 8px;
+	border-top: 0px;
+	border-radius: 4px;
+	border-top-left-radius: 0px;
+	border-top-right-radius: 0px;
+	border-color: dodgerblue;
+	border-style: solid;
+}
+
+.sheet-flex-tallybar {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-evenly;
+	width: 668px;
+	height: 36px;
+	border: 3px solid #fff990;
+	border-radius: 5px;
+	background: royalblue;
+	margin: 0px;
+	padding-left: 3px;
+	padding-right: 3px;
+}
+
+.sheet-flex-tallybar span {
+	color: white;
+}
+
+.sheet-flex-tallybar span:nth-child(1) {
+	color: white;
+
+}
+
+.sheet-flex-tallybar input[type=number] {
+	min-width: 52px;
+	text-align: right;
+	padding-right: 0px;
+}
+
+.sheet-flex-tallybar input[type=number]:hover,
+.sheet-flex-tallybar input[type=number]:focus {
+	padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. Both webkit and moz. For some reason. */
+}
+
+.sheet-flex-tallybar input[readonly] {
+	background: #fff990;
+	padding-right: 0px;
+	min-width: 36px;
+	max-width: 40px;
+	text-align: center;
+}
+
+/* --------------------------------------------------- */
+/* Characteristics Tab styling                         */
+/* --------------------------------------------------- */
+
+.grid-container-tab-characteristics {
+	display: grid;
+	grid-template-areas: "leftGrid rightGrid";
+	grid-template-columns: 335px 335px;
+	max-width: 674px;
+	height: 801px;
+	font-size: 16px;
+	grid-gap: 5px;
+	background-color: royalblue;
+	border: 3px solid #fff990;
+	border-radius: 5px;
+	margin-bottom: 0px;
+}
+
+.grid-container-tab-characteristics input[readonly]{
+	background: #fff990;
+}
+
+/* characteristics tab left side */
+
+.grid-container-characteristics-leftGrid {
+	grid-area: leftGrid;
+	display: grid;
+	grid-template-areas:
+	"logo"
+	"bio"
+	"earnings"
+	"primaryAbilities"
+	"combatAbilities"
+	"movementAbilities";
+	grid-template-columns: 329px;
+	grid-gap: 0px;
+	background: royalblue;
+	margin-bottom: 5px;
+}
+
+.grid-container-characteristics-leftGrid  h1 {
+	padding-left: 0px;
+	padding-top: 5px;
+	padding-bottom: 0px;
+	margin: 0px;
+	font-size: 13px;
+	font-style: normal;
+	line-height: 1.40;
+	min-width: 54px;
+}
+
+.grid-container-characteristics-leftGrid  h2 {
+	height: 20px;
+	line-height: 1.6;
+	margin-left: 5px;
+	margin-bottom: 0px;
+	margin-top: 2px;
+	font-size: 13px;
+	font-style: normal;
+}
+
+/* Item: logo graphic bio0 */
+
+.item-characteristics-logo {
+	grid-area: logo;
+	padding: 2px;
+	background-color: royalblue;
+	margin-bottom: 4px;
+}
+
+/* Item: character bio bio1*/
+
+.item-characteristics-bio {	
+	max-width: 330px;
+	grid-area: bio;
+	display: grid;
+	grid-template-areas:
+	"nameLabel nameText nameText nameText"
+	"titleLabel titleText titleText titleText"
+	"backgroundLabel backgroundText backgroundText backgroundText";
+	grid-template-columns: 85px 105px 57px 73px;
+	grid-template-rows: 30px 30px 48px;
+	margin-left: 6px;
+	margin-bottom: 0px;
+	padding: 5px;
+	padding-bottom: 0px;
+	background-color: gold;
+	border-top: solid 1px goldenrod;
+	border-right: solid 1px goldenrod;
+	border-left: solid 1px goldenrod;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	vertical-align: top;
+}
+
+.item-characteristics-bio input[type=text] {
+	text-align:left;
+	width: 222px;
+	padding: 2px;
+	padding-left: 4px;
+	margin-left: 5px;
+	border: solid 1px goldenrod;
+	font-size: 13;
+	font-weight: bold;
+}
+
+.item-characteristics-bio textarea {
+	width: 214px;
+	max-height: 36px;
+	padding: 2px;
+	padding-left: 4px;
+	margin-left: 5px;
+	border: solid 1px black;
+	text-align: left;
+	border: solid 1px goldenrod;
+}
+
+/* Subitem: Character Name Label */
+.item-characteristics-bio-nameLabel {
+	grid-area: nameLabel;
+	background: gold;
+}
+
+/* Subitem: Character Name Text */
+.item-characteristics-bio-name {
+	grid-area: nameText;
+}
+
+/* Subitem: Character Title Label */
+.item-characteristics-bio-titleLabel {
+	grid-area: titleLabel;
+	background: gold;
+}
+
+/* Subitem: Character Title Text */
+.item-characteristics-bio-titleText {
+	grid-area: titleText;
+}
+
+/* Subitem: Character background label */
+.item-characteristics-bio-backgroundLabel {
+	grid-area: backgroundLabel;
+	background: gold;
+}
+
+/* Subitem: Character background text */
+.item-characteristics-bio-backgroundText {
+	grid-area: backgroundText;
+}
+
+/* Item: character bio experience and money*/
+
+.item-characteristics-earnings {	
+	max-width: 330px;
+	grid-area: earnings;
+	display: grid;
+	grid-template-areas:
+	"experienceLabel experience moneyLabel money";
+	grid-template-columns: 90px 57px 95px 83px;
+	grid-template-rows: 23px;
+	margin-left: 6px;
+	margin-bottom: 6px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	padding: 5px;
+	padding-bottom: 0px;
+	background-color: #fff990;
+	border-left: solid 1px goldenrod;
+	border-right: solid 1px goldenrod;
+	border-bottom: solid 1px goldenrod;
+	border-bottom-left-radius: 3px;
+	border-bottom-right-radius: 3px;
+	vertical-align: top;
+}
+
+.item-characteristics-earnings h1 {
+	margin-bottom: 10px;
+	padding-left: 3px;
+	padding-top: 4px;
+	line-height: 1.3;
+}
+
+.item-characteristics-earnings-experience input {
+	min-width: 54px;
+	padding-right: 0px;
+	padding-top: 0px;
+}
+
+.item-characteristics-earnings input[type=number] {
+	text-align: right;
+	padding-right: 0px;
+	border: solid 1px palegoldenrod;
+	padding-top: 0px;
+	margin-bottom: 5px;
+}
+
+.item-characteristics-earnings input[type=text] {
+	font-size: 13px;
+	max-width: 90px;
+	text-align: right;
+	background-color: #fff990;
+	font-weight: bold;
+	margin-top: 0px;
+	margin-bottom: 1px;
+	color: black;
+}
+
+/* Subitem: Character Experience */
+.item-characteristics-earnings-experienceLabel {
+	grid-area: experienceLabel;
+}
+
+/* Subitem: Character Experience */
+.item-characteristics-earnings-experience {
+	grid-area: experience;
+}
+
+/* Subitem: Character Money */
+.item-characteristics-earnings-moneyLabel {
+	grid-area: moneyLabel;
+}
+
+/* Subitem: Character Money */
+.item-characteristics-earnings-money {
+	grid-area: money;
+}
+
+.item-characteristics-earnings-money input[type=number] {
+	min-width: 70px;
+	margin-bottom: 5px;
+}
+
+/* Item: core abilities */
+.item-characteristics-primary-attributes {
+	grid-area: primaryAbilities;
+	display: grid;
+	grid-template-areas:
+	"primaryAbilityNames primaryAbilityValues primaryAbilityChances primaryAbilityButtons primaryAbilityCosts";
+	grid-template-columns: 126px 49px 50px 45px 45px;
+	min-width: 300px;
+	vertical-align: middle;
+	margin-left: 6px;
+	background-color: #fff990; 
+	border-top: solid 1px goldenrod;
+	border-left: solid 1px goldenrod;
+	border-right: solid 1px goldenrod;
+	border-bottom: 0px;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	padding-bottom: 2px;
+}
+
+.item-characteristics-primary-attributes h1 {
+	background: gold;
+	padding-left: 5px;
+	padding-right: 6px;
+	padding-top: 2px;
+	padding-bottom: 2px;
+	margin: 0px;
+	margin-top: 0px;
+	font-size: 13px;
+	font-style: normal;
+	line-height: 1.35;
+}
+
+.item-characteristics-primary-attributes h2 {
+	margin-left: 8px;
+}
+
+.item-characteristics-primary-attributes input[type=number] {
+	text-align: right;
+	padding-right: 0px;
+	border: solid 1px palegoldenrod;	
+}
+
+.item-characteristics-primary-attributes input[readonly] {
+	text-align: center;
+	border: none;	
+	max-width: 45px;
+}
+
+/* Sub-Item: core abilities characteristics */
+.item-characteristics-primary-attributes-names {
+	grid-area: primaryAbilityNames;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	text-align: left;
+	min-height: 130px;
+	max-height: 160px;
+}
+
+/* Sub-Item: core abilities values */
+.item-characteristics-primary-attributes-values {
+	grid-area: primaryAbilityValues;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	text-align: left;
+	min-height: 130px;
+	max-height: 160px;
+	max-width: 55px;
+}
+
+/* Sub-Item: core abilities values */
+.item-characteristics-primary-attributes-rollChances {
+	grid-area: primaryAbilityChances;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	text-align: left;
+	min-height: 130px;
+	max-height: 160px;
+}
+
+.item-characteristics-primary-attributes-rollChances h1 {
+	margin-left: 6px;
+}
+
+/* Sub-Item: core abilities values */
+.item-characteristics-primary-attributes-rollButtons {
+	grid-area: primaryAbilityButtons;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	min-height: 130px;
+	max-height: 160px;
+}
+
+/* Sub-Item: core abilities values */
+.item-characteristics-primary-attributes-costs {
+	grid-area: primaryAbilityCosts;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	min-height: 130px;
+	max-height: 160px;
+}
+
+.item-characteristics-primary-attributes-costs h1 {
+	margin-left: 8px;
+	text-align: left;
+	min-width: 32px;
+}
+
+/* Item: combat abilities */
+.item-characteristics-combat-attributes {
+	grid-area: combatAbilities;
+	display: grid;
+	grid-template-areas:
+	"combatAbilityNames combatAbilityValues . . combatAbilityCosts";
+	grid-template-columns: 126px 49px 50px 45px 45px;
+	min-width: 300px;
+	vertical-align: middle;
+	margin-left: 6px;
+	background-color: #fff990; 
+	border: solid 1px goldenrod;
+	border-right: solid 1px goldenrod;
+	border-left: solid 1px goldenrod;
+	border-bottom: none;
+	border-top: none;
+	padding-bottom: 2px;
+}
+
+.item-characteristics-combat-attributes input[type=number] {
+	text-align: right;
+	padding-right: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.item-characteristics-combat-attributes input[readonly] {
+	text-align: center;
+	padding-right: 2px;
+	border: none;
+	max-width: 45px;
+}
+
+.item-characteristics-combat-attributes h1 {
+	background: gold;
+	padding-left: 5px;
+	padding-right: 6px;
+	padding-top: 2px;
+	padding-bottom: 2px;
+	margin: 0px;
+	margin-top: 0px;
+	font-size: 13px;
+	font-style: normal;
+	line-height: 1.35;
+}
+
+.item-characteristics-combat-attributes h2 {
+	margin-left: 8px;
+}
+
+/* Sub-Item: combat abilities characteristics */
+.item-characteristics-combat-attributes-names {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	text-align: left;
+	grid-area: combatAbilityNames;
+	min-width: 120px;
+}
+
+/* Sub-Item: core abilities values */
+.item-characteristics-combat-attributes-values {
+	text-align: center;
+	grid-area: combatAbilityValues;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	min-width: 152px;
+	text-align: left;
+}
+
+/* Sub-Item: core abilities values */
+.item-characteristics-combat-attributes-costs {
+	grid-area: combatAbilityCosts;
+	text-align: right;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+.item-characteristics-combat-attributes-costs h1 {
+	margin-left: 8px;
+	text-align: left;
+	min-width: 32px;
+}
+
+/* Item: combat abilities */
+.item-characteristics-movement-abilities {
+	grid-area: movementAbilities;
+	display: grid;
+	grid-template-areas:
+	"movementNames movementValues . . movementCosts";
+	grid-template-columns: 126px 49px 50px 45px 45px;
+	background: purple;
+	min-width: 300px;
+	margin-left: 6px;
+	padding-bottom: 2px;
+	background-color: #fff990; 
+	border-right: solid 1px goldenrod;
+	border-left: solid 1px goldenrod;
+	border-bottom: solid 1px goldenrod;
+	border-top: none;
+	border-bottom-left-radius: 3px;
+	border-bottom-right-radius: 3px;
+}
+
+.item-characteristics-movement-abilities input[type=number] {
+	text-align: right;
+	padding-right: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.item-characteristics-movement-abilities input[readonly] {
+	text-align: center;
+	padding-right: 0px;
+	border: none; 
+	max-width: 45px;
+}
+
+.item-characteristics-movement-abilities h1 {
+	background: gold;
+	padding-left: 5px;
+	padding-right: 6px;
+	padding-top: 2px;
+	padding-bottom: 2px;
+	margin: 0px;
+	margin-top: 0px;
+	font-size: 13px;
+	font-style: normal;
+	line-height: 1.35;
+}
+
+.item-characteristics-movement-abilities h2 {
+	margin-left: 8px;
+}
+
+/* Sub-Item: combat abilities characteristics */
+.item-characteristics-movement-abilities-names {
+	grid-area: movementNames;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+/* Sub-Item: core abilities values */
+.item-characteristics-movement-abilities-values {
+	grid-area: movementValues;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+.item-characteristics-movement-abilities-values h1 {
+	min-width: 141px;
+}
+
+/* Sub-Item: core abilities costs */
+.item-characteristics-movement-abilities-costs {
+	grid-area: movementCosts;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+.item-characteristics-movement-abilities-costs h1 {
+	margin-left: 8px;
+	text-align: left;
+	min-width: 32px;
+}
+
+/* characteristics tab right side */
+
+.grid-container-characteristics-rightGrid {
+	grid-area: rightGrid;
+	display: grid;
+	grid-template-areas:
+	"portrait health"
+	"turnSegmentIndicators turnTracker"
+	"perception perception"
+	"history history";
+	grid-template-columns: 264px 68px;
+	grid-template-rows: 260px 22px 100px 419px;
+	background: royalblue;
+	max-height: 800px;
+	max-width: 300px;
+}
+
+
+/* Item: character portrait graphic */
+.item-characteristics-portrait {
+	grid-area: portrait;
+	position: relative;
+	width: 100%;
+	max-width: 250px;
+	padding: 0px;
+	height: 250px;
+	margin: 3px;
+	margin-left: 0px;
+	margin-top: 4px;
+	background-color: royalblue;
+}
+
+.item-characteristics-portrait textarea {
+	width: 242px;
+	margin-left: 5px;
+	margin-right: 5px;
+	margin-bottom: 4px;
+	background-color: lavender;
+	height: 242px;
+	font-size: 14px;
+}
+
+.item-characteristics-portrait img {
+	width: 100%;
+	height: auto;
+	margin-left: 7px;
+	border-right: solid gray 1px;
+	border-bottom: solid gray 1px;
+	border-left: solid darkgray 1px;
+	border-top: solid darkgray 1px;
+}
+
+.item-characteristics-portrait .button-left-arrow,
+.item-characteristics-portrait .button-right-arrow {
+	position: absolute;
+	transform: translate(-50%, -50%);
+	color: transparent;
+	background-color: transparent;
+	font-size: 16px;
+	padding: 12px 12px;
+	border: none;
+	cursor: pointer;
+	border-radius: 5px;
+	text-align: center;
+}
+
+.item-characteristics-portrait .button-left-arrow {
+	top: 50%;
+	left: 11%;
+}
+
+.item-characteristics-portrait .button-right-arrow {
+	top: 50%;
+	left: 95%;
+}
+
+.item-characteristics-portrait .button-right-arrow:hover,
+.item-characteristics-portrait .button-left-arrow:hover {
+	background-color: gold;	
+}
+
+
+/* By deafult, hides all portrait images. Add more numbered entries to add more images, notes, or cards. */
+.item-portrait-00, 
+.item-portrait-01,
+.item-portrait-02 {
+	display: none;
+}
+
+/* show the selected portrait frame. Add more numbered entries to add more images, notes, or cards. */
+.item-portrait-slideshow[value="0"] ~ div.item-portrait-00,
+.item-portrait-slideshow[value="1"] ~ div.item-portrait-01,
+.item-portrait-slideshow[value="2"] ~ div.item-portrait-02 {
+	display: block;
+	position: relative;
+}
+
+/* Alternate styling for rule cards instead of portraits */
+.item-portrait-00 {
+	background-color: white;
+	border: solid 2px gray;
+	height: 250px;
+	width: 250px;
+	margin-left: 5px;
+}
+
+.item-portrait-00 h1 {
+	font-size: 16px;
+	color: white;
+	text-align: center;
+	padding-left: 0px;
+	background-color: crimson;
+}
+
+.item-portrait-flex-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	max-height: 240px;
+	padding: 0px;
+}
+
+.item-portrait-rule-description {
+	max-width: 250px;
+	margin: 0px;
+	padding: 0px;
+	line-height: 1.0;
+}
+
+.item-portrait-rule-description h1 {
+	font-size: 16px;
+	color: firebrick;
+	text-align: center;
+	padding-left: 4px;
+	background-color: inherit;
+	line-height: 1.4;
+	padding-bottom: 0px;
+}
+
+.item-portrait-rule-description p {
+	font-size: 13px;
+	padding: 4px;
+	margin: 0px;
+	text-align: left;
+	line-height: 1.2;
+}
+
+/* Item: health status                                     */
+/* Item: gear tab health status                            */
+/* Sheet worker used to synchronizes the contents of each  */
+
+.item-characteristics-health,
+.item-gear-health {
+	padding: 0px;
+	width: 68px;
+	background: royalblue;
+	border: white;
+	margin-top: 4px;
+	margin-right: 2px;
+	height: 250px;
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+}
+
+.item-powers-health {
+	padding: 6px;
+	width: 318px;
+	height: 56px;
+	margin: 0px;
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	flex-direction: row;
+	background-color: royalblue;
+	border: 3px solid #fff990;
+	border-radius: 5px;
+}
+
+.item-characteristics-health  {
+	grid-area: health;
+}
+
+.item-gear-health {
+	grid-area: gearHealth;
+}
+
+.item-powers-health {
+	grid-area: powerHealth;
+}
+
+.item-gear-health h2,
+.item-characteristics-health h2,
+.item-powers-health h2 {
+	color: white;
+	background-color: inherit;
+	text-align: center;
+	font-size: 17px;
+	line-height: 1.0em;
+	margin-top: 0px;
+	margin-bottom: 0px;
+	padding: 0px;
+}
+
+.item-health-stat {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	width: 63px;
+	height: 30px;
+	background-color: gold;
+	border-radius: 3px;
+	align-items: center;
+	padding: 0px;
+	margin-right: 1px;
+	margin-bottom: 2px;
+	border: solid 1px darkgoldenrod;
+}
+
+.item-health-stat-enclosure {
+	padding: none;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	height: 57px;
+}
+
+.item-health-stat-plus-minus-enclosure {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	max-height: 20px;
+	width: 20px;
+	align-items: center;
+	padding: 1px;
+}
+
+.item-health-stat input[type=text] {
+	max-width: 45px;
+	height: 30px;
+	font-size: 20px;
+	background-color: gold;
+}
+
+.item-health-stat input[type=text]:focus{
+	outline: transparent;
+}
+
+.item-health-stat button.buttonPlus,
+.item-health-stat button.buttonMinus {
+	background-color: LemonChiffon;
+	border: solid 1px slategray;
+	color: slategray;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	display: inline-block;
+	font-size: 16px;
+	margin: 0px 0px;
+	line-height: 1.4ch;
+	border-radius: 0px;
+}
+
+.item-health-stat button.buttonPlus span,
+.item-health-stat button.buttonMinus span {
+	display: inline-block;
+	transform: rotate(-90deg);
+	text-align: center;
+}
+
+.item-health-stat button.buttonPlus:hover,
+.item-health-stat button.buttonMinus:hover {
+	background-color: gray;
+	color: white;
+	transition: 0.05s;
+}
+
+/* Item: Turn Tracker Button Space */
+
+.item-characteristics-turn-tracker {
+	grid-area: turnTracker;
+	width: 68px;
+	height: 22px;
+	padding: 0px;
+	line-height: 20px;
+}
+
+/* Item: character history */
+.item-characteristics-history {
+	grid-area: history;
+	text-align: left;
+	padding: 2px;
+	max-width: 343px;
+	background-color: inherit;
+	margin-bottom: 1px;
+	margin-right: 6px;
+	max-height: 402px;
+	margin-bottom: 6px;
+}
+
+.item-characteristics-history textarea {
+	width: 316px;
+	height: 100%;
+}
+
+/* Item: Speed Phase Indicator Buttons */
+.item-characteristics-speedIndicatorButtons {
+	grid-area: speedIndicatorButtons;
+	padding-left: 2px;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	background-color: royalblue;
+	width: 264px;
+	margin: 0px;
+}
+
+/* Item: Perception */
+.item-characteristics-perception {
+	grid-area: perception;
+	max-width: 323px;
+	background-color: inherit;
+	max-height: 95px;
+	margin-left: 3px;
+	border: transparent;
+	margin-top: 0px;
+}
+
+.item-characteristics-perception h1 {
+	font-size: 13px;
+	line-height: 1.6;
+	text-align: left;
+	background-color: royalblue;
+	color: white;
+}
+
+.item-characteristics-perception input[type=number] {
+	text-align: right;
+	padding-right: 0px;
+	border: solid 1px palegoldenrod;
+	margin: 0px;
+	margin-bottom: 3px;
+	background-color: white;
+	max-width: 40px;
+}
+
+.subitem-characteristics-perception-stat-container {
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	background-color: inherit;
+	padding-left: 0px;
+	align-items: center;
+}
+
+.subitem-characteristics-perception-stat-container input[type=text] {
+	font-size: 13px;
+	max-width: 65px;
+	text-align: center;
+	background-color: royalblue;
+	color: white;
+	font-weight: bold;
+	margin-top: 2px;
+}
+
+.subitem-characteristics-perception-column-container {
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	background-color: lightblue;
+	padding: 2px;
+	align-items: center;
+	border-radius: 5px;
+	border: solid lightcyan 2px;
+}
+
+.subitem-characteristics-perception-column-container input[type=text] {
+	font-size: 13px;
+	max-width: 32px;
+	line-height: 1.3;
+	text-align: center;
+	background-color: lightcyan;
+	padding: 0px;
+	color: black;
+	font-weight: normal;
+}
+
+.subitem-characteristics-perception-row-container {
+	display: flex;
+	justify-content: space-between;
+	flex-direction: row;
+	margin-top: 2px;
+}
+
+/* --------------------------------------------------- */
+/* Options Tab                                         */
+/* --------------------------------------------------- */
+
+.grid-container-tab-options {
+	display: grid;
+	grid-template-areas: ". . ." 
+		". options ."
+		". . .";
+	grid-template-columns: 110px 500px 100px;
+	grid-template-rows: 100px 185px 100px;
+	font-size: 16px;
+	background-color: royalblue;
+	border: 3px solid #fff990;
+	border-radius: 5px;
+	margin-bottom: 1px;
+	min-height: 800px;
+	min-width: 674px;
+}
+
+.grid-container-tab-options h1 {
+	font-size: 14px;
+	margin-left: 0px;
+	color: black;
+	padding-bottom: 5px;
+	font-weight: 500;
+}
+
+.grid-container-tab-options label {
+	max-width: 13px;
+	padding: 8px;
+}
+
+/* Sub-Item: options */
+.item-options {
+	grid-area: options;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	padding-left: 2px;
+	padding-top: 2px;
+	padding-bottom: 2px;
+	background-color: #fff990;
+	margin: 5px;
+	width: 450px;
+	height: 282px;
+	margin: 0px;
+	border: solid 2px goldenrod;
+	border-radius: 3px;
+}
+
+.item-options-row,
+.item-version-row {
+	align-items: baseline;
+	min-width: 400px;
+	max-height: 28px;
+	margin-left: 10px;
+}
+
+.item-options-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-start;
+}
+
+/* --------------------------------------------------- */
+/* Version Info                                        */
+/* --------------------------------------------------- */
+
+.item-version-row {
+	display: grid;
+	grid-template-areas: "versionLabel versionInfo";
+	justify-content: flex-end;
+}
+
+.item-version-label h2 {
+	font-size: 13px;
+	max-height: 28px;
+	color: black;
+}
+
+.item-version-information input[readonly] {
+	background-color: #fff990;
+	color: black;
+	max-width: 35px;
+	padding-bottom: 1px;
+}
+
+/* --------------------------------------------------- */
+/* Custom buttons                                      */
+/* --------------------------------------------------- */
+
+.button {
+	border: none;
+	color: white;
+	text-decoration: none;
+	display: inline-block;
+	cursor: pointer;
+	transition-duration: 0.2s;
+	text-align: center;
+}
 	
-	.subitem-flex-container-martial-row .custom-expand-button-container button.buttonExpand {
-		height: 18px;
-	}
+.buttonRecover {
+	background-color: darkseagreen;
+	padding-top: 4px;
+	padding-bottom: 4px;
+	margin-left: 2px;
+	margin-right: 2px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+	padding-left: 4px;
+	padding-right: 3.5px;
+	vertical-align: middle;
+	text-align: right;
+	font-size: 13px;
+	font-weight: bold;
+	border-radius: 3px;
+}
+
+.buttonReset {
+	background-color: orange;
+	padding-top: 4px;
+	padding-bottom: 4px;
+	margin-left: 2px;
+	margin-right: 2px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+	padding-left: 12px;
+	padding-right: 12px;
+	vertical-align: middle;
+	text-align: center;
+	font-size: 13px;
+	font-weight: bold;
+	border-radius: 3px;
+}
+
+.buttonTracker {
+	background-color: dodgerblue;
+	padding-left: 3px;
+	padding-right: 3px;
+	padding-top: 2px;
+	padding-bottom: 2px;
+	font-weight: bold;
+}
+
+.button-Power-END-right,
+.button-Power-END-left {
+	padding-top: 2px;
+	padding-bottom: 2px;
+	padding-right: 2px;
+	padding-left: 2px;
+	min-height: 16px;
+	max-height: 16px;
+	text-align: middle;
+	font-weight: bold;
+	border-radius: 2.5px;
+}
+
+.button-Power-END-left {
+	background-color: olive;
+	margin-right: 0px;
+	min-width: 34px;
+	max-width: 35px;
+}
+
+.button-Power-END-right {
+	background-color: salmon;
+	margin-right: 0px;
+	min-width: 34px;
+	max-width: 35px;
+}
+
+.buttonRoll,
+.buttonRollAttack,
+.buttonRollActivate,
+.buttonRollNormalAttack,
+.buttonRollShieldAttack,
+.buttonRollShow,
+.buttonRollPower {
+	padding-left: 3px;
+	padding-right: 3px;
+	text-align: center;
+	line-height: 13px;
+	padding-top: 2px;
+	padding-bottom: 2px;
+	font-weight: bold;
+	max-height: 16px;
+	min-height: 15px;
+}
+
+.buttonRoll,
+.buttonRollAttack,
+.buttonRollActivate,
+.buttonRollShieldAttack {
+	min-width: 25px;
+	max-width: 26px;
+}
+
+
+.buttonRollPower {
+	min-width: 32px;
+	max-width: 34px;
+}
+
+.button:hover,
+.buttonRecover:hover,
+.buttonReset:hover,
+.buttonRoll:hover,
+.buttonRollAttack:hover,
+.buttonRollActivate:hover,
+.buttonRollNormalAttack:hover,
+.buttonRollShieldAttack:hover,
+.buttonRollShow:hover,
+.buttonRollPower:hover {
+	color: black;
+	background-color: lightgray;
+	text-align: center;
+}
+
+.button-Power-END-left:hover,
+.button-Power-END-right:hover,
+.buttonManeuverEND:hover {
+	background-color: #ff9900;
+	color: black;
+}
+
+.buttonRoll {
+	margin-right: 3px;
+	margin-left: 3px;
+	background-color: #E69F00;
+	border-radius: 3px;
+}
+
+.buttonRollAttack {
+	background-color: #D55E00;
+	border-radius: 2.5px;
+}
+
+.item-flex-maneuver .buttonRollAttack {
+	margin-right: 3px;
+	margin-left: 61px;
+	border-radius: 3px;
+	min-width: 36px;
+	max-width: 38px;
+}
+
+.weapon-normal-damage01[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon01"]:not(:hover),
+.weapon-normal-damage02[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon02"]:not(:hover),
+.weapon-normal-damage03[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon03"]:not(:hover),
+.weapon-normal-damage04[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon04"]:not(:hover),
+.weapon-normal-damage05[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon05"]:not(:hover)
+{
+	background-color: #009E73;
+}
+
+.maneuver-normal-damage01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
+.maneuver-normal-damage02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
+.maneuver-normal-damage03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
+.maneuver-normal-damage04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
+.maneuver-normal-damage05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
+.maneuver-normal-damage06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
+.maneuver-normal-damage07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
+.maneuver-normal-damage08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
+.maneuver-normal-damage09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
+{
+	background-color: #009E73;
+}
+
+.buttonRollActivate {
+	margin-right: 3px;
+	margin-left: 3px;
+	background-color: #0072B2;
+	border-radius: 3px;
+}
+
+.buttonRollNormalAttack,
+.buttonManeuverEND,
+.buttonRollShow {
+	margin-right: 3px;
+	margin-left: 3px;
+	border-radius: 3px;
+	min-width: 34px;
+	max-width: 36px;
+}
+
+.buttonRollNormalAttack {
+	margin-left: 61px;
+	background-color: #D55E00;
+}
+
+.buttonManeuverEND {
+	background-color: #8A8A8A;
+	font-weight: bold;
+}
+
+.buttonRollShow {
+	background-color: #8A8A8A;
+}
+
+.buttonRollShieldAttack  {
+	background-color: #D55E00;
+	border-radius: 2.5px;
+}
+
+.buttonRollPower {
+	background-color: #9184E2; /* lighter than mediumslateblue */
+	border-radius: 2.5px;
+}
+
+/* The d6 of dicefontd6 doesn't look good. Let's hold off for a better idea or stick with the label 'Roll' on the buttons.
+
+.buttonRollNormalAttack::before {
+	font-family: 'dicefontd6';
+	font-size: 16px;
+	content: 'F';
+} */
+
+.portrait-display-button-left,
+.portrait-display-button-right {
+	background-color: orange;
+	padding-top: 4px;
+	padding-bottom: 4px;
+	margin: 4px 2px;
+	padding-left: 14px;
+	padding-right: 14px;
+	vertical-align: middle;
+	text-align: center;
+}
+
+.portrait-display-button-left:hover,
+.portrait-display-button-right:hover {
+	color: black;
+	background-color: limegreen;
+	text-align: center;
+}
+
+
+/* --------------------------------------------------- */
+/* Custom Checkbox used for options                    */
+/* From w3 schools                                     */
+/* --------------------------------------------------- */
+
+/* Customize the label (the container) */
+.container-checkbox {
+	display: inline-block;
+	position: relative;
+	padding-left: 25px;
+	padding-top: 2px;
+	/* margin-bottom: 10px; */
+	cursor: pointer;
+	max-width: 400px;
+	font-size: 12px;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	border: transparent;
+}
+
+/* Hide the browser's default checkbox */
+.container-checkbox input,
+.container-checkbox-small input,
+.container-checkbox-small-gray input {
+	position: absolute;
+	opacity: 0;
+	cursor: pointer;
+	height: 0;
+	width: 0;
+}
+
+/* Create a custom checkbox */
+.checkmark {
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 20px;
+	width: 20px;
+	background-color: gold;
+}
+
+/* On mouse-over, add a grey background color */
+.container-checkbox:hover input ~ .checkmark,
+.container-checkbox-small:hover input ~ .checkmark-small {
+	background-color: goldenrod;
+	border: solid 1px darkgoldenrod;
+}
+
+.container-checkbox-small-gray:hover input ~ .checkmark-small-gray {
+	background-color: lightsteelblue;
+	border: solid 1px darkgray;
+}
+
+/* When the checkbox is checked, add a gold background */
+.container-checkbox input:checked ~ .checkmark,
+.container-checkbox-small input:checked ~ .checkmark-small {
+	background-color: gold;
+}
+
+.container-checkbox-small-gray input:checked ~ .checkmark-small-gray {
+	background-color: lightgray;
+}
+
+/* Create the checkmark/indicator (hidden when not checked) */
+.checkmark:after,
+.checkmark-small:after {
+	content: "";
+	position: absolute;
+	display: none;
+	border: solid 1px darkgoldenrod;
+}
+
+.checkmark-small-gray:after {
+	content: "";
+	position: absolute;
+	display: none;
+	border: solid 1px gray;
+}
+
+/* Show the checkmark when checked */
+.container-checkbox input:checked ~ .checkmark:after,
+.container-checkbox-small input:checked ~ .checkmark-small:after,
+.container-checkbox-small-gray input:checked ~ .checkmark-small-gray:after {
+	display: block;
+}
+
+/* Style the checkmark/indicator */
+.container-checkbox .checkmark:after {
+	left: 7px;
+	top: 2px;
+	width: 5px;
+	height: 10px;
+	border: solid black;
+	border-width: 0 3px 3px 0;
+	-webkit-transform: rotate(45deg);
+	-ms-transform: rotate(45deg);
+	transform: rotate(45deg);
+}
+
+/* --------------------------------------------------- */
+/* Custom Checkbox (small) used for skill enhancers    */
+/* From w3 schools                                     */
+/* --------------------------------------------------- */
+
+/* Customize the label (the container) */
+.container-checkbox-small,
+.container-checkbox-small-gray {
+	display: block;
+	position: relative;
+	padding-left: 20px;
+	padding-top: 0px;
+	cursor: pointer;
+	font-size: 12px;
+	max-width: 20px;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+/* Create a custom checkbox */
+.checkmark-small {
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 15px;
+	width: 15px;
+	background-color: gold;
+}
+
+.checkmark-small-gray {
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 15px;
+	width: 15px;
+	background-color: lightgray;
+}
+
+/* Style the checkmark/indicator */
+.container-checkbox-small .checkmark-small:after,
+.container-checkbox-small-gray .checkmark-small-gray:after {
+	left: 4px;
+	top: 2px;
+	width: 4px;
+	height: 7px;
+	border: solid black;
+	border-width: 0 3px 3px 0;
+	-webkit-transform: rotate(45deg);
+	-ms-transform: rotate(45deg);
+	transform: rotate(45deg);
+}
+
+
+.subitem-flex-container-martial-cv-damage-row .container-checkbox-small-gray {
+	margin-bottom: 14px;
+	padding: 0px;
+}
+
+/* --------------------------------------------------- */
+/* Custom Checkboxes used for turn segment indicators  */
+/* Modification of custom checkbox above               */
+/* --------------------------------------------------- */
+
+.grid-container-container-turn-segments {
+	grid-area: turnSegmentIndicators;
+	display: inline-flex; /* or inline-flex */
+	flex-direction: row;
+	flex-wrap: nowrap;
+	align-items: top;
+	justify-content: space-evenly;
+	width: 264px;
+	height: 24px;
+	background: royalblue;
+	margin-top: 2px;
+	margin-left: 1px;
+	padding: 0px;
+}
+
+.grid-container-container-turn-segments label {
+	display: inline;
+	pointer-events: none;
+	font-style: normal;
+}
+
+/* Custom checkbox indicator */
+
+.container-speed-indicator {
+	display: inline-block;
+	position: relative;
+	padding-left: 5px;
+	margin-bottom: 0px;
+	cursor: pointer;
+	font-size: 20px;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
 	
-	.custom-button-triangle:hover,
-	.custom-button-triangle:after {
-		position: relative; 
-		border-top: 8px solid transparent;
-		border-bottom: 8px solid transparent;
-		border-left: 12px solid #666666;
-		border-right: 8px solid transparent;
-		top: 0px;
-		left: 5px;
-	}
+/* Hide the browser's default checkbox */
+.container-speed-indicator input {
+	position: absolute;
+	opacity: 0;
+	cursor: pointer;
+	height: 0;
+	width: 0;
+}
+
+/* Custom checkbox */
+
+.checkmark01,
+.checkmark02,
+.checkmark03,
+.checkmark04,
+.checkmark05,
+.checkmark06,
+.checkmark07,
+.checkmark08,
+.checkmark09,
+.checkmark10,
+.checkmark11,
+.checkmark12 {
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 20px;
+	width: 20px;
+	background-color: dodgerblue;
+	border: none;
+	border-radius: 5px;
+	pointer-events: none;
+}
+
+/* Custom segment indicator checkbox: Status */
+.container-speed-indicator input:checked ~ .checkmark01,
+.container-speed-indicator input:checked ~ .checkmark02,
+.container-speed-indicator input:checked ~ .checkmark03,
+.container-speed-indicator input:checked ~ .checkmark04,
+.container-speed-indicator input:checked ~ .checkmark05,
+.container-speed-indicator input:checked ~ .checkmark06,
+.container-speed-indicator input:checked ~ .checkmark07,
+.container-speed-indicator input:checked ~ .checkmark08,
+.container-speed-indicator input:checked ~ .checkmark09,
+.container-speed-indicator input:checked ~ .checkmark10,
+.container-speed-indicator input:checked ~ .checkmark11,
+.container-speed-indicator input:checked ~ .checkmark12 {
+	background-color: hotpink;
+	border: none;
+	border-radius: 5px;
+}
+
+/* Custom segment indicator checkbox 01. Active/checked. */
+.checkmark01:after {
+	content: "1";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 01. Inactive/not checked. */
+.checkmark01:before {
+	content: "1";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 02. Active/checked. */
+.checkmark02:after {
+	content: "2";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 02. Inactive/not checked. */
+.checkmark02:before {
+	content: "2";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 03. Active/checked. */
+.checkmark03:after {
+	content: "3";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 03. Inactive/not checked. */
+.checkmark03:before {
+	content: "3";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 04. Active/checked. */
+.checkmark04:after {
+	content: "4";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 04. Inactive/not checked. */
+.checkmark04:before {
+	content: "4";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 05. Active/checked. */
+.checkmark05:after {
+	content: "5";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 05. Inactive/not checked. */
+.checkmark05:before {
+	content: "5";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 06. Active/checked. */
+.checkmark06:after {
+	content: "6";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 06. Inactive/not checked. */
+.checkmark06:before {
+	content: "6";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 07. Active/checked. */
+.checkmark07:after {
+	content: "7";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 07. Inactive/not checked. */
+.checkmark07:before {
+	content: "7";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 08. Active/checked. */
+.checkmark08:after {
+	content: "8";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 08. Inactive/not checked. */
+.checkmark08:before {
+	content: "8";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 09. Active/checked. */
+.checkmark09:after {
+	content: "9";
+	color: white;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 09. Inactive/not checked. */
+.checkmark09:before {
+	content: "9";
+	color: black;
+	position: absolute;
+	padding-left: 6px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 10. Active/checked. */
+.checkmark10:after {
+	content: "10";
+	color: white;
+	position: absolute;
+	padding-left: 2px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 10. Inactive/not checked. */
+.checkmark10:before {
+	content: "10";
+	color: black;
+	position: absolute;
+	padding-left: 2px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 11. Active/checked. */
+.checkmark11:after {
+	content: "11";
+	color: white;
+	position: absolute;
+	padding-left: 3px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 11. Inactive/not checked. */
+.checkmark11:before {
+	content: "11";
+	color: black;
+	position: absolute;
+	padding-left: 3px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 12. Active/checked. */
+.checkmark12:after {
+	content: "12";
+	color: white;
+	position: absolute;
+	padding-left: 2px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Custom segment indicator checkbox 12. Inactive/not checked. */
+.checkmark12:before {
+	content: "12";
+	color: black;
+	position: absolute;
+	padding-left: 2px;
+	padding-top: 1px;
+	display: none;
+}
+
+/* Show the checkmark when checked */
+.container-speed-indicator input:checked ~ .checkmark01:after,
+.container-speed-indicator input:checked ~ .checkmark02:after,
+.container-speed-indicator input:checked ~ .checkmark03:after,
+.container-speed-indicator input:checked ~ .checkmark04:after,
+.container-speed-indicator input:checked ~ .checkmark05:after,
+.container-speed-indicator input:checked ~ .checkmark06:after,
+.container-speed-indicator input:checked ~ .checkmark07:after,
+.container-speed-indicator input:checked ~ .checkmark08:after,
+.container-speed-indicator input:checked ~ .checkmark09:after,
+.container-speed-indicator input:checked ~ .checkmark10:after,
+.container-speed-indicator input:checked ~ .checkmark11:after,
+.container-speed-indicator input:checked ~ .checkmark12:after {
+	display: block;
+}
+
+/* Show the checkmark when checked */
+.container-speed-indicator input:not(:checked) ~ .checkmark01:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark02:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark03:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark04:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark05:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark06:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark07:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark08:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark09:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark10:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark11:before,
+.container-speed-indicator input:not(:checked) ~ .checkmark12:before {
+	display: block;
+}
+
+/* --------------------------------------------------- */
+/* Talents, Perks, and Complications                   */
+/* --------------------------------------------------- */
+.grid-container-complications-talents {
+	display: grid;
+	grid-gap: 4px;
+	grid-template-areas: 
+	"theTalentsAndPerks theComplications"
+	"theNotes theNotes";
+	grid-template-columns: 338px 338px;
+	grid-template-rows: 642px 160px;
+	max-width: 685px;
+	padding: 0px;
+	font-size: 16px;
+	background-color: dodgerblue;
+	justify-content: middle;
+	padding-bottom: 0px;
+	margin-bottom: 1px;
+}
+
+.grid-container-complications-talents h2 {
+	font-size: 18px;
+	line-height: 1.3;
+	text-align: center;
+	font-weight: normal;
+}
+
+/* Complications and Talents Tab: Talents and Perks */
+.flex-container-complications-talents-left {
+	grid-area: theTalentsAndPerks;
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	border: 3px solid #fff990;
+	border-radius: 5px;
+	max-width: 333px;
+	background: gold;
+	height: 630px;
+	padding: 5px;
+	padding-bottom: 0px;
+	margin-bottom: 0px;
+}
+
+.item-talent-heading {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	align-items: center;
+	flex-direction: row;
+	margin-bottom: 0px;
+	padding: 0px;
+	max-width: 333px;
+}
+
+.item-talent-heading input[type=text] {
+	max-width: 200px;
+	padding: 1px;
+	padding-left: 3px;
+	margin: 0px;
+	margin-right: 0px;
+	margin-left: 2px;
+	text-align: left;
+	font-size: 13px;
+	font-weight: bold;
+	border: solid 1px darkgray;
+}
+
+.item-talent-heading input[type=number] {
+	max-width: 45px;
+	padding: 2px;
+	margin: 0px;
+	padding-right: 0px;
+	text-align: right;
+	border: solid 1px darkgray;
+}
+
+.item-talent-heading h1 {
+	font-size: 12px;
+	line-height: 1.1;
+	padding-right: 2px;
+	padding-left: 6px;
+}
+
+.item-talent-textbox textarea {
+	max-width: 314px;
+	max-height: 36px;
+	padding: 3px;
+	border: solid 1px darkgray;
+	margin-bottom: 6px;
+}
+
+
+/* Complications and Talents Tab: Complications */
+.flex-container-complications-talents-right {
+	grid-area: theComplications;
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	border: 3px solid lightcyan;
+	border-radius: 5px;
+	max-width: 333px;
+	background: lightblue;
+	height: 630px;
+	padding: 5px;
+	padding-bottom: 0px;
+	margin-bottom: 0px;
+}
+
+.item-complication-heading {
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	align-items: center;
+	flex-direction: row;
+	margin-bottom: 0px;
+	padding: 0px;
+	max-width: 333px;
+}
+
+.item-complication-heading input[type=text] {
+	max-width: 210px;
+	padding: 1px;
+	padding-left: 3px;
+	margin: 0px;
+	margin-right: 0px;
+	margin-left: 2px;
+	text-align: left;
+	font-size: 13px;
+	font-weight: bold;
+	border: solid 1px darkgray;
+}
+
+.item-complication-heading input[type=number] {
+	max-width: 45px;
+	padding: 2px;
+	margin: 0px;
+	padding-right: 0px;
+	text-align: right;
+	border: solid 1px darkgray;
+}
+
+.item-complication-heading h1 {
+	font-size: 12px;
+	line-height: 1.1;
+	padding-right: 2px;
+	padding-left: 6px;
+}
+
+.item-complication-textbox textarea {
+	max-width: 314px;
+	max-height: 54px;
+	padding: 3px;
+	border: solid 1px darkgray;
+	margin-bottom: 6px;
+}
+
+/* Complications Tab: Notes Text Panel */
+
+.flex-container-complications-bottom {
+	grid-area: theNotes;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
+	justify-content: space-between;
+	border: 3px solid lightgray;
+	border-radius: 5px;
+	max-width: 674px;
+	padding: 5px;
+	margin: 0px;
+	height: 145px;
+	background: white;
+}
+
+.flex-container-complications-bottom textarea {
+	width: 322px;
+	max-height: 143px;
+	padding: 0px;
+	margin: 0px;
+	border: transparent;
+}
+
+/* ----------------------------------------------------- */
+/* Powers                                                */
+/* Organized in two columns with different color styles. */
+/* ----------------------------------------------------- */
+.grid-container-powers {
+	display: grid;
+	grid-gap: 5px 5px;
+	grid-template-areas: 
+	"leftPowers powerHealth"
+	"leftPowers rightPowers";
+	grid-template-columns: 338px 336px;
+	grid-template-rows: 74px 727px;
+	max-width: 686px;
+	min-width: 676px;
+	padding: 0px;
+	font-size: 16px;
+	background-color: dodgerblue;
+	justify-content: middle;
+	padding-bottom: 0px;
+	margin-bottom: 1px;
+}
+
+.grid-container-powers h1 {
+	display:inline-block;
+	margin-left: 0px;
+	padding-left: 2px;
+	padding-right: 0px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin: 0px;
+	margin-top: 1px;
+	font-size: 13px;
+	font-style: normal;
+	line-height: 1.35;
+}
+
+.grid-container-powers input[type=number] {
+	padding-right: 0px;
+	padding-top: 2px;
+	width: 30px;
+	margin: 0px;
+	text-align: right;
+	height: 21px;
+	padding: 1px;
+}
+
+.flex-container-powers-right,
+.flex-container-powers-left {
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
+	border-radius: 5px;
+	max-width: 333px;
+	padding-left: 4px;
+	padding-right: 4px;
+	margin: 0px;
+}
+
+.flex-container-powers-left,
+.flex-container-powers-right {
+	padding-top: 3px;
+	padding-bottom: 3px;
+}
+
+.flex-container-powers-left {
+	height: 795px;
+}
+
+.flex-container-powers-right {
+	height: 716px;
+}
+
+.flex-container-powers-left textarea,
+.flex-container-powers-right textarea {
+	color: gray; 
+	height: 54px;
+	padding: 3px;
+	margin: 0px;
+	margin-top: 1px;
+	font-size: 8;
+}
+
+.flex-container-powers-left textarea {
+	max-width: 316px;
+}
+
+.flex-container-powers-right textarea {
+	border: solid 1px goldenrod;
+	max-width: 315px;
+}
+
+/* Power subitems. */
+
+.item-flex-power {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-top: 2px;
+	padding-bottom: 3px;
+}
+
+.subitem-flex-power-heading-left,
+.subitem-flex-power-heading-right,
+.subitem-flex-power-effect-left,
+.subitem-flex-power-effect-right {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin-top: 1px;
+	margin-bottom: 0px;
+	align-items: center;
+	max-height: 23px;
+}
+
+.subitem-flex-power-heading-left input[type=text],
+.subitem-flex-power-heading-right input[type=text],
+.subitem-flex-power-effect-left input[type=text],
+.subitem-flex-power-effect-right input[type=text] {
+	min-height: 22px;
+	text-align: left;
+	padding-left: 2px;
+	margin-right: 0px;
+}
+
+.subitem-flex-power-heading-left input[type=text]:nth-child(2),
+.subitem-flex-power-heading-right input[type=text]:nth-child(2) {
+	font-weight: bold;
+	max-width: 130px;
+	margin-left: 1px;
+}
+
+.subitem-flex-power-heading-left input[type=text]:nth-child(4),
+.subitem-flex-power-heading-right input[type=text]:nth-child(4) {
+	font-weight: bold;
+	text-align: center;
+}
+
+.subitem-flex-power-heading-left select,
+.subitem-flex-power-heading-right select {
+	font-size: 13px;
+	height: 19px;
+	width: 98px;
+	margin: 0px;
+	padding-left: 3px;
+}
+
+/* Effect */
+.subitem-flex-power-effect-left input[type=text]:nth-child(2),
+.subitem-flex-power-effect-right input[type=text]:nth-child(2){
+	max-width: 130px;
+	max-height: 23px;
+}
+
+/* Dice */
+.subitem-flex-power-effect-left input[type=text]:nth-child(3),
+.subitem-flex-power-effect-right input[type=text]:nth-child(3) {
+	max-width: 58px;
+	text-align: center;
+	margin-left: 2px;
+	margin-right: 0px;
+	padding-left: 0px;
+	padding-right: 0px;
+}
+
+/* Roll chance */
+.subitem-flex-power-effect-left input[type=number]:nth-child(5), 
+.subitem-flex-power-effect-right input[type=number]:nth-child(5) {
+	max-width: 41px;
+	min-width: 41px;
+	text-align: right;
+	margin-left: 1px;
+	margin-right: 2px;
+}
+
+.subitem-flex-power-activeCost input[type=number]:nth-child(2), /* Advantages */
+.subitem-flex-power-activeCost input[type=number]:nth-child(4) /* Limitations */ {
+	border: solid 1px gray;
+	min-width: 55px;
+}
+
+/* Powers Tab: Left Powers and general to right. */
+.flex-container-powers-left {
+	grid-area: leftPowers;
+	border: 3px solid lightcyan;
+	background: lightblue;
+}
+
+.flex-container-powers-left textarea {
+	border: solid 1px black;
+}
+
+.flex-container-powers-left input[readonly]{
+	background: lightcyan;
+	border: solid 1px #89abb9;
+	line-height: 1.0;
+}
+
+.flex-container-powers-left textarea{
+	border: 1px solid #89ABB9;
+}
+
+.subitem-flex-power-heading-left input[type=text]{
+	border: solid 1px #89ABB9;
+	max-width: 28px;
+}
+
+.subitem-flex-power-effect-left input[type=text],
+.subitem-flex-power-effect-left input[type=number]{
+	border: solid 1px #89ABB9;
+}
+
+.subitem-flex-power-points-block-left,
+.subitem-flex-power-points-block-right {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	max-height: 23px;
+	margin-bottom: 2px;
+}
+
+.subitem-flex-power-points-block-left input[type=number] {
+	/* Active, Real Cost */
+	border: solid 1px #89ABB9;
+}
+
+.subitem-flex-power-points-block-left input[readonly] {
+	/* Active, Real Cost */
+	max-width: 38px;
+	text-align: center;
+	padding: 0px;
+}
+
+.subitem-flex-power-limitations-left,
+.subitem-flex-power-limitations-right {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-width: 333px;
+	margin-bottom: 2px;
+	max-height: 23px;
+}
+
+.subitem-flex-power-limitations-left input[type=number]{
+	/* Advantages, limitations */
+	border: solid 1px #89ABB9;
+	min-width: 50px;
+}
+
+.subitem-flex-power-limitations-left select,
+.subitem-flex-power-limitations-right select {
+	font-size: 13px;
+	height: 19px;
+	max-width: 115px;
+	margin: 0px;
+	align-items: center;
+	padding-left: 3px;
+}
+
+
+/* Powers Tab: Right Powers */
+.flex-container-powers-right {
+	grid-area: rightPowers;
+	border: 3px solid #fff990;
+	background: gold;
+}
+
+.flex-container-powers-right textarea {
+	border: solid 1px black;
+}
+
+.flex-container-powers-right input[readonly]{
+	background: #fff990;
+	border: solid 1px goldenrod;
+	line-height: 1.0;
+}
+
+.flex-container-powers-right textarea{
+	border: 1px solid goldenrod;
+}
+
+.subitem-flex-power-heading-right input[type=text] {
+	max-width: 28px;
+	border: solid 1px goldenrod;
+}
+
+.subitem-flex-power-effect-right input[type=text],
+.subitem-flex-power-effect-right input[type=number]{
+	border: solid 1px goldenrod;
+}
+
+.subitem-flex-power-points-block-right input[type=number] {
+	/* Active, Real Cost */
+	border: solid 1px goldenrod;
+}
+
+.subitem-flex-power-points-block-right input[readonly] {
+	/* Active, Real Cost */
+	max-width: 38px;
+	text-align: center;
+}
+
+.subitem-flex-power-limitations-right input[type=number]{
+	/* Advantages, limitations */
+	border: solid 1px goldenrod;
+	min-width: 50px;
+}
+
+
+/* Buttons for power, talent, and complication movers. */
+.power-mover-plus-minus-enclosure,
+.talent-mover-plus-minus-enclosure,
+.complication-mover-plus-minus-enclosure {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.power-mover-plus-minus-button,
+.talent-mover-plus-minus-button,
+.complication-mover-plus-minus-button {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 24px;
+	width: 10px;
+	align-items: center;
+	padding: 0px;
+	margin-right: 2px;
+	margin-left:3px;
+}
+
+.power-mover-plus-minus-button button.buttonPlus,
+.power-mover-plus-minus-button button.buttonMinus,
+.talent-mover-plus-minus-button button.buttonPlus,
+.talent-mover-plus-minus-button button.buttonMinus,
+.complication-mover-plus-minus-button button.buttonPlus,
+.complication-mover-plus-minus-button button.buttonMinus {
+	background-color: LemonChiffon;
+	border: solid 1px silver;
+	color: slategray;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	display: inline-block;
+	font-size: 10px;
+	margin: 0px 0px;
+	line-height: 1.25ch;
+	border-radius: 0px;
+	max-width: 10px;
+}
+
+.power-mover-plus-minus-button button.buttonPlus span,
+.power-mover-plus-minus-button button.buttonMinus span,
+.talent-mover-plus-minus-button button.buttonPlus span,
+.talent-mover-plus-minus-button button.buttonMinus span,
+.complication-mover-plus-minus-button button.buttonPlus span,
+.complication-mover-plus-minus-button button.buttonMinus span {
+	display: inline-block;
+	transform: rotate(-90deg);
+	text-align: center;
+}
+
+.power-mover-plus-minus-button button.buttonPlus:hover,
+.power-mover-plus-minus-button button.buttonMinus:hover,
+.talent-mover-plus-minus-button button.buttonPlus:hover,
+.talent-mover-plus-minus-button button.buttonMinus:hover,
+.complication-mover-plus-minus-button button.buttonPlus:hover,
+.complication-mover-plus-minus-button button.buttonMinus:hover {
+	background-color: gray;
+	color: white;
+	transition: 0.05s;
+} 
+
+
+/* ----------------------------------------------------- */
+/* Skills                                                */
+/* Organized into a 2x3 grid of containers               */
+/* ----------------------------------------------------- */
+.grid-container-skills-tab {
+	display: grid;
+	grid-template-areas:
+	"theSkills1 theCombatSkills"
+	"theSkills2 theLanguageSkills"
+	"theSkills3 theEnhancers";
+	grid-gap: 6px;
+	grid-template-columns: 358px 322px;
+	grid-template-rows: 273px 251px 259px;
+	max-width: 692px;
+	padding: 0px;
+	padding-left: 0px;
+	padding-top: 6px;
+	margin-bottom: 0px;
+	font-size: 16px;
+	background-color: gold;
+	border: 3px solid #fff990;
+	border-radius: 5px;
+	justify-content: middle;
+	min-height: 795px;
+}
+
+.grid-container-skills-tab h1 {
+	display:inline-block;
+	margin-left: 0px;
+	padding-left: 2px;
+	padding-right: 0px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin: 0px;
+	margin-top: 1px;
+	font-size: 13px;
+	font-style: normal;
+	line-height: 1.10;
+	text-align: center;
+}
+
+.grid-container-skills-tab input[type=text] {
+	height: 22px;
+}
+
+.grid-container-skills-tab .custom-select,
+.grid-container-skills-tab .custom-select-skill,
+.grid-container-skills-tab .custom-select-alternate,
+.grid-container-skills-tab .custom-select-alternate-skill {
+	font-size: 13px;
+	max-width: 110px;
+	margin-left: 3px;
+	padding-left: 3px;
+}
+
+/* Item: Skill Containers for Skill Groups 01, 02, and 03 */
+.item-skillsTab-flex-container-skills-group01,
+.item-skillsTab-flex-container-skills-group02,
+.item-skillsTab-flex-container-skills-group03 {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-evenly;
+	max-width: 358px;
+	margin-left: 5px;
+	background-color: #fff990; 
+	border: solid 2px goldenrod;
+	border-radius: 3px;
+	line-height: 1.10;
+	padding-left: 1px;
+	padding-right: 4px;
+}
+
+.item-skillsTab-flex-container-skills-group01 {
+	grid-area: theSkills1;
+	padding-bottom: 2px;
+}
+
+.item-skillsTab-flex-container-skills-group02 {
+	grid-area: theSkills2;
+	padding-top: 3px;
+	padding-bottom: 2px;
+}
+
+.item-skillsTab-flex-container-skills-group03 {
+	grid-area: theSkills3;
+	padding-top: 3px;
+	padding-bottom: 2px;
+	margin-bottom: 4px;
+}
+
+.item-skillsTab-flex-container-skills-group01 input[type=number],
+.item-skillsTab-flex-container-skills-group02 input[type=number],
+.item-skillsTab-flex-container-skills-group03 input[type=number] {
+	text-align: right;
+	padding-right: 0px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+	border: solid 1px palegoldenrod;
+	max-height: 22px;
+}
+
+.item-skillsTab-flex-container-skills-group01 input[readonly],
+.item-skillsTab-flex-container-skills-group02 input[readonly],
+.item-skillsTab-flex-container-skills-group03 input[readonly] {
+	text-align: center;
+	background-color: #fff990; 
+	border: transparent;
+	max-width: 24px;
+}
+
+.item-skillsTab-flex-container-skills-group01 input[type=text]:nth-child(1),
+.item-skillsTab-flex-container-skills-group02 input[type=text]:nth-child(1),
+.item-skillsTab-flex-container-skills-group03 input[type=text]:nth-child(1) {
+	max-width: 140px;
+	margin-top: 1px;
+	margin-bottom: 1px;
+	font-size: 13px;
+	text-align: left;
+	margin-left: 4px;
+	margin-right: 1px;
+	padding-left: 1px;
+	padding-right: 1px;
+	border: solid 1px palegoldenrod;
+}
+
+/* Sub-Item: Flex containers for rows */
+.subitem-skillsTab-grid-container-skills-heading-left {
+	grid-template-areas: "skillName skillType rollChance . skillCost";
+	grid-template-columns: 164px 70px 26px 38px 46px;
+	display: grid;
+}
+
+.subitem-skillsTab-grid-container-skills-heading-left-name {
+	grid-area: skillName;
+	padding-left: 5px;
+}
+
+.subitem-skillsTab-grid-container-skills-heading-left-name h2 {
+	text-align: left;
+}
+
+.subitem-skillsTab-grid-container-skills-heading-left-type {
+	grid-area: skillType;
+	text-align: center;
+}
+
+.subitem-skillsTab-grid-container-skills-heading-left-roll {
+	grid-area: rollChance;
+	text-align: center;
+}
+
+.subitem-skillsTab-grid-container-skills-heading-left-cost {
+	grid-area: skillCost;
+	text-align: center;
+}
+
+.subitem-skillsTab-flex-container-skill {
+	text-align: left;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-height: 24px;
+}
+
+.subitem-skillsTab-flex-container {
+	text-align: right;
+}
+
+/* Buttons for skill movers. */
+.skill-mover-plus-minus-enclosure {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.skill-mover-plus-minus-button {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 24px;
+	width: 10px;
+	align-items: center;
+	padding: 0px;
+	margin-right: 2px;
+	margin-left: 2px;
+}
+
+.skill-mover-plus-minus-button button.buttonPlus,
+.skill-mover-plus-minus-button button.buttonMinus {
+	background-color: lemonchiffon;
+	border: solid 1px silver;
+	color: slategray;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	display: inline-block;
+	font-size: 10px;
+	margin: 0px 0px;
+	line-height: 1.25ch;
+	border-radius: 0px;
+	max-width: 10px;
+}
+
+.skill-mover-plus-minus-button button.buttonPlus span,
+.skill-mover-plus-minus-button button.buttonMinus span {
+	display: inline-block;
+	transform: rotate(-90deg);
+	text-align: center;
+}
+
+.skill-mover-plus-minus-button button.buttonPlus:hover,
+.skill-mover-plus-minus-button button.buttonMinus:hover {
+	background-color: gray;
+	color: white;
+	transition: 0.05s;
+} 
+
+/* Item: Skill Container for combat skill flex "columns" */
+.item-skillsTab-grid-container-combat-skills {
+	grid-area: theCombatSkills;
+	display: grid;
+	grid-template-areas: 
+	"skillNames skillLevels skillTypes skillCosts"
+	"skillLevelNames skillLevels . skillCosts";
+	grid-template-columns: 150px 50px 61px 38px;
+	grid-template-rows: 199px 76px;
+	max-width: 292px;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-bottom: 3px;
+	padding-top: 0px;
+	background-color: #fff990; 
+	border: solid 2px goldenrod;
+	border-radius: 3px;
+	line-height: 1.10;
+}
+
+/* Subitem: flex container for combat skill name "column" */
+.subitem-skillsTab-flex-container-combat-skills-names {
+	grid-area: skillNames;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-bottom: 3px;
+	padding-top: 0px;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-names input[type=text] {
+	max-width: 140px;
+	margin-top: 0px;
+	margin-bottom: 3px;
+	font-size: 13px;
+	text-align: left;
+	margin-left: 4px;
+	padding-left: 1px;
+	padding-right: 1px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-names h1 {
+	text-align: left;
+	padding-top: 3px;
+	padding-bottom: 3px;
+	max-height: 18px;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-level-names {
+	grid-area: skillLevelNames;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-bottom: 8px;
+	padding-top: 0px;
+} 
+
+.subitem-skillsTab-flex-container-combat-skills-level-names h1 {
+	text-align: left;
+	padding-top: 3px;
+	padding-bottom: 3px;
+	max-height: 18px;
+	font-weight: bold;
+}
+
+/* Subitem: flex container for combat skill levels "column" */
+.subitem-skillsTab-flex-container-combat-skills-levels {
+	grid-area: skillLevels;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-top: 7px;
+	margin-bottom: 6px;
+	max-height: 264px;
+	margin-top: 3px;
+	padding-bottom: 2px;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-levels input[type=number] {
+	text-align: center;
+	padding-left: 3px;
+	padding-right: 1px; /* Fix for shifting spinners on focus */
+	max-width: 45px;
+	margin-right: 5px;
+	padding-bottom: 1px;
+	max-height: 22px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-levels h1 {
+	text-align: left;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	max-height: 18px;
+	margin-left: 0px;
+}
+
+/* Subitem: flex container for combat skill type "column" */
+.subitem-skillsTab-flex-container-combat-skills-types {
+	grid-area: skillTypes;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-top: 3px;
+	margin-bottom: 5px;
+	margin-left: 0px;
+	height: 189px;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-types h1 {
+	text-align: center;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	max-height: 18px;
+	margin-left: 0px;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-types .custom-select {
+	max-width: 55px;
+	text-align: center;
+	height: 19px;
+	padding-left: 3px;
+}
+
+/* Subitem: flex container for combat skill costs "column" */
+.subitem-skillsTab-flex-container-combat-skills-costs {
+	grid-area: skillCosts;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-bottom: 7px;
+	margin-top: 3px;
+	padding-bottom: 2px;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-costs h1 {
+	text-align: center;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	padding-right: 0px;
+	max-height: 18px;
+	max-width: 40px;
+}
+
+.subitem-skillsTab-flex-container-combat-skills-costs input[readonly] {
+	text-align: center;
+	background-color: #fff990;
+	max-width: 30px;
+	margin-left: 5px;
+}
+
+/* Item: Skill Container for Language Skill "rows" */
+.item-skillsTab-flex-container-languages {
+	grid-area: theLanguageSkills;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	max-width: 292px;
+	background-color: #fff990; 
+	border: solid 2px goldenrod;
+	border-radius: 3px;
+	line-height: 1.10;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-bottom: 3px;
+}
+
+/* Sub-Item: Flex containers for columns */
+.subitem-skillsTab-flex-container-languages-heading {
+	grid-template-areas: "skillName skillFluency literacy skillCost";
+	grid-template-columns: 148px 83px 31px 36px;
+	display: grid;
+	margin-left: 0px;
+}
+
+.subitem-skillsTab-flex-container-languages-heading-name {
+	grid-area: skillName;
+	text-align: left;
+}
+
+.subitem-skillsTab-flex-container-languages-heading-fluency {
+	grid-area: skillFluency;
+	text-align: center;
+}
+
+.subitem-skillsTab-flex-container-languages-heading-literacy {
+	grid-area: literacy;
+	text-align: center;
+}
+
+.subitem-skillsTab-flex-container-languages-heading-cost {
+	grid-area: skillCost;
+	text-align: center;
+}
+
+.subitem-skillsTab-flex-container-language {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-width: 285px;
+	margin-left: 0px;
+	padding: 0px;
+	margin-left: 4px;
+}
+
+.subitem-skillsTab-flex-container-language input[type=text]:nth-child(1) {
+	text-align: left;
+	padding-left: 2px;
+	min-width: 140px;
+	margin-right: 0px;
+	border: solid 1px palegoldenrod;	
+}
+
+.subitem-skillsTab-flex-container-language input[readonly] {
+	text-align: center;
+	background-color: #fff990;
+	max-width: 22px;
+	margin-right: 0px;
+	margin-left: 3px;
+	border: transparent;
+}
+
+.subitem-skillsTab-flex-container-language .container-checkbox-small {
+	margin-top: 3px;
+	margin-left: 10px;
+}
+
+.subitem-skillsTab-flex-container-language .custom-select {
+	min-width: 70px;
+	margin-left: 8px;
+	max-height: 19px;
+	padding-left: 3px;
+}
+
+
+/* Item: Skill Container for Skill Enhancers */
+.item-skillsTab-grid-container-skill-enhancers {
+	grid-area: theEnhancers;
+	display: grid;
+	grid-template-areas: 
+	". skillEnhancersHeading skillEnhancersHeading skillEnhancersHeading"
+	"checkboxes skillNames . skillCosts"
+	". skillNames skillLevels skillCosts";
+	grid-template-columns: 25px 175px 65px 38px;
+	grid-template-rows: 20px 112px 112px;
+	max-width: 295px;
+	padding-left: 5px;
+	grid-gap:0px;
+	background-color: #fff990; 
+	border: solid 2px goldenrod;
+	border-radius: 3px;
+	max-height: 251px;
+}
+
+.item-skillsTab-grid-container-skill-enhancers input[readonly]{
+	background-color: #fff990;
+	text-align: center;
+	height: 18px;
+	max-width: 30px;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-checkboxes {
+	grid-area: checkboxes;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	line-height: 1.2;
+	padding-bottom: 5px;
+	padding-top: 5px;
+	height: 113px;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-heading {
+	grid-area: skillEnhancersHeading;
+	text-align: left;
+	display: flex;
+	flex-direction: row;
+	padding-top: 4px;
+	justify-content: space-between;
+	line-height: 1.15;
+	width: 264px;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-heading h1:nth-child(2) {
+	padding-right: 0px;
+	line-height: 1.15;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-names {
+	grid-area: skillNames;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-evenly;
+	height: 229px;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-names h1 {
+	text-align: left;
+	line-height: 1.15;
+	font-weight: bold;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-levels {
+	grid-area: skillLevels;
+	text-align: left;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	line-height: 1.15;
+	margin-top: 11px;
+	height: 107px;
+	margin-bottom: 4px;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-levels input[type=number]{
+	border: solid 1px palegoldenrod;
+	height: 19px;
+	margin-bottom: 2px;
+}
+
+.subitem-skillsTab-flex-container-skill-enhancers-costs {
+	grid-area: skillCosts;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-evenly;
+	line-height: 1.15;
+	height: 229px;
+}
+
+/* ----------------------------------------------------- */
+/* Gear: armor, weapons, and equipment                   */
+/* Organized into a 3x4 grid of containers               */
+/* ----------------------------------------------------- */
+
+.grid-container-tab-gear {
+	display: grid;
+	grid-template-areas:
+	"theEncumbrance theEncumbrance gearHealth"
+	"theArmor theArmor gearHealth"
+	"theWeapons theWeapons theWeapons"
+	"theEquipment theSlides theSlides";
+	grid-gap: 8px;
+	grid-template-columns: 250px 336px 84px;
+	grid-template-rows: 63px 174px 155px 322px;
+	max-width: 692px;
+	padding: 0px;
+	padding-left: 2px;
+	font-size: 16px;
+	background-color: royalblue;
+	border: 3px solid #fff990;
+	border-radius: 5px;
+	justify-content: middle;
+	min-height: 801px;
+}
+
+.grid-container-tab-gear h1 {
+	display:inline-block;
+	margin-left: 0px;
+	padding-left: 2px;
+	padding-right: 0px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+	margin: 0px;
+	margin-top: 1px;
+	font-size: 13px;
+	font-style: normal;
+	line-height: 1.10;
+	text-align: center;
+}
+
+.grid-container-tab-gear .custom-select {
+	font-size: 13px;
+	max-width: 110px;
+	max-height: 19px;
+}
+
+/* Health status styling grouped with item-health-characteristics */
+
+/* Encumbrance */
+.item-tab-gear-flex-container-encumbrance {
+	grid-area: theEncumbrance;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin-left: 4px;
+	margin-top: 6px;
+	padding: 0px;
+	max-width: 594px;
+	max-height: 56px;
+	padding-left: 20px;
+	padding-right: 20px;
+	text-align: left;
+	vertical-align: middle;
+	background-color: royalblue;
+	border: none;
+}
+
+.item-tab-gear-flex-container-encumbrance h1 {
+	text-align: center;
+	color: white;
+	font-size: 13px;
+}
+
+.item-tab-gear-flex-container-encumbrance input[type=number]{
+	background-color: #fff990;
+	text-align: center;
+	max-width: 70px;
+	background-color: gold;
+	border: solid 1px goldenrod;
+	font-size: 16px;
+	margin-left: 0px;
+	padding-right: 0px;
+	min-height: 22px;
+}
+
+.subitem-tab-gear-flex-container-encumbrance,
+.subitem-tab-gear-flex-container-encumbrance-bonus {
+	display:flex;
+	flex-direction: column;
+	justify-content: space-between;
+	max-width: 80px;
+	align-items: center;
+}
+
+.subitem-tab-gear-flex-container-encumbrance-bonus {
+	margin-left: 0px;
+}
+
+.subitem-tab-gear-plus-minus-enclosure {
+	display: flex;
+	flex-direction: row;
+	background-color: gold;
+	justify-content: space-between;
+	width: 50px;
+	max-height: 20px;
+	border: solid 1px goldenrod;
+	border-radius: 3px;
+}
+
+.subitem-tab-gear-plus-minus-enclosure input[type=text] {
+	max-width: 40px;
+	height: 20px;
+	font-size: 16px;
+	background-color: transparent;
+	text-align: center;
+	vertical-align: center;
+}
+
+.subitem-tab-gear-plus-minus-enclosure input[type=text]:focus{
+	outline: transparent;
+}
+
+.subitem-tab-gear-flex-container-stat {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 20px;
+	width: 10px;
+	align-items: center;
+	padding: 0px;
+}
+
+.subitem-tab-gear-flex-container-stat button.buttonPlus,
+.subitem-tab-gear-flex-container-stat button.buttonMinus {
+	background-color: LemonChiffon;
+	border: solid 1px slategray;
+	color: slategray;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	display: inline-block;
+	font-size: 10px;
+	margin: 0px 0px;
+	line-height: 1.4ch;
+	border-radius: 0px;
+	max-width: 10px;
+}
+
+.subitem-tab-gear-flex-container-stat button.buttonPlus span,
+.subitem-tab-gear-flex-container-stat button.buttonMinus span {
+	display: inline-block;
+	transform: rotate(-90deg);
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-stat button.buttonPlus:hover,
+.subitem-tab-gear-flex-container-stat button.buttonMinus:hover {
+	background-color: gray;
+	color: white;
+	transition: 0.05s;
+} 
+
+/* ------------- */
+/* Item: Armor   */
+/* ------------- */
+.item-tab-gear-grid-container-armor {
+	grid-area: theArmor;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+	max-width: 594px;
+	padding-left: 5px;
+	margin-left: 4px;
+	padding-top: 0px;
+	grid-gap: 3px;
+	background-color: #fff990; 
+	border: solid 2px goldenrod;
+	border-radius: 3px;
+	min-height: 179px;
+}
+
+.subitem-tab-gear-flex-container-armor-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	max-width: 575px;
+	margin-bottom: 1px;
+	height: 24px;
+}
+
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(1) {
+	min-width: 118px;
+	text-align: left;
+}
+
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(2),
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(3),
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(4),
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(5) {
+	min-width: 34px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(6),
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(7) {
+	min-width: 44px;
+}
+
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(8) {
+	min-width: 36px;
+}
+
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(9) {
+	min-width: 98px;
+}
+
+.subitem-tab-gear-flex-container-armor-row h1:nth-child(10) {
+	min-width: 46px;
+}
+
+.subitem-tab-gear-flex-container-armor-row input {
+	max-height: 22px;
+}
+
+.subitem-tab-gear-flex-container-armor-row input[type=number] {
+	text-align: right;
+	padding-left: 2px;
+	max-width: 36px;
+	min-width: 34px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1),
+.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
+	padding-left: 1px;
+	padding-right: 1px;
+	margin-right: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1) {
+	text-align: left;
+	max-width: 120px;
+}
+
+.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
+	text-align: center;
+	max-width: 100px;
+}
+
+.subitem-tab-gear-flex-container-armor-row input[type=number]:nth-child(10) {
+	text-align: right;
+	min-width: 48px;
+}
+
+.subitem-tab-gear-flex-container-armor-row select {
+	text-align-last: center; /* For Chrome */
+	text-align: center; /* Firefox */
+}
+
+/* Shield */
+
+.subitem-tab-gear-flex-container-shield {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-right: 5px;
+	margin-top: 5px;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1 {
+	margin-bottom: 3px;
+	padding: 0px;
+}
+
+.subitem-tab-gear-flex-container-shield-row input {
+	max-height: 21px;
+}
+
+.subitem-tab-gear-flex-container-shield-row label {
+	max-width: 5px;
+	margin-left: 2px;
+	margin-top: 3px;
+	padding-right: 0px;
+}
+
+.subitem-tab-gear-flex-container-shield-row .container-checkbox-small {
+	padding-left: 10px;
+	margin-right: 3px;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(1) {
+	min-width: 120px;
+	text-align: left;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(3) {
+	min-width: 67px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(4) {
+	min-width: 24px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(6) {
+	min-width: 38px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(7) {
+	min-width: 48px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(5),
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(8),
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(9) {
+	min-width: 32px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(2),
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(10),
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(11) {
+	min-width: 40px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row h1:nth-child(12) {
+	min-width: 42px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1),
+.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
+	padding-left: 1px;
+	padding-right: 1px;
+	margin-right: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1) {
+	max-width: 120px;
+	text-align: left;
+}
+
+.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
+	max-width: 65px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-shield-row  input[readonly]:nth-child(9){
+	background-color: inherit;
+	text-align: center;
+	padding-left: 0px;
+	max-width: 24px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	margin-top: 3px;
+	margin-bottom: 2px;
+}
+
+.subitem-tab-gear-flex-container-shield-row input[type=number] {
+	text-align: right;
+	padding-left: 3px;
+	max-width: 38px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-shield-row input[type=number]:nth-child(12) {
+	text-align: right;
+	padding-left: 3px;
+	min-width: 42px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-shield-row{
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-width: 576px;
+}
+
+/* ------------- */
+/* Item: Weapons */
+/* ------------- */
+.item-tab-gear-flex-container-weapons {
+	grid-area: theWeapons;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+	margin-left: 4px;
+	padding: 0px;
+	padding-left: 5px;
+	margin-top: 8px;
+	max-height: 145px;
+	max-width: 655px;
+	background-color: #fff990;
+	border: solid 2px goldenrod;
+	border-radius: 3px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-width: 650px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row input {
+	max-height: 21px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1 {
+	min-width: 39px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-weapon-row label {
+	max-width: 5px;
+	margin-left: 2px;
+	margin-top: 3px;
+	padding-right: 0px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(1) {
+	min-width: 120px;
+	text-align: left;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(2) {
+	min-width: 65px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(3) {
+	min-width: 26px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(4) {
+	min-width: 32px;
+	text-align: left;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(5) {
+	min-width: 36px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(6) {
+	min-width: 40x;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(7) {
+	min-width: 44px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(8) {
+	min-width: 42px;
+	text-align: center;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(9) {
+	min-width: 32px;
+	text-align: right;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(10) {
+	min-width: 34px;
+	text-align: right;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(11) {
+	min-width: 45px;
+	text-align: center;
+	padding-left: 0px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(12) {
+	min-width: 32px;
+	text-align: center;
+	padding: 0px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row h1:nth-child(13) {
+	min-width: 32px;
+	text-align: right;
+	margin-right: 6px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(1) {
+	text-align: left;
+	padding-left: 1px;
+	padding-right: 1px;
+	max-width: 120px;
+	margin-right: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(2) {
+	text-align: center;
+	padding-left: 1px;
+	padding-right: 1px;
+	max-width: 68px;
+	margin-right: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-weapon-row .container-checkbox-small {
+	padding-left: 10px;
+	margin-right: 3px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row button:nth-child(4) {
+	margin-left: 0px;
+	margin-right: 0px;
+}
+
+.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(5),
+.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(6),
+.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(7),
+.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(9) {
+	text-align: right;
+	padding-left: 3px;
+	max-width: 38px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(8),
+.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(11),
+.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(13) {
+	text-align: right;
+	padding-left: 3px;
+	max-width: 46px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	border: solid 1px palegoldenrod;
+}
+
+.subitem-tab-gear-flex-container-weapon-row input[readonly]:nth-child(10){
+	background-color: inherit;
+	text-align: center;
+	padding-left: 0px;
+	max-width: 24px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 0px;
+	margin-top: 3px;
+	margin-bottom: 2px;
+}
+
+/* --------------- */
+/* Item: Equipment */
+/* --------------- */
+.item-tab-gear-flex-container-equipment {
+	grid-area: theEquipment;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	max-width: 248px;
+	padding-left: 5px;
+	margin-left: 4px;
+	padding: 4px;
+	background-color: lightcyan;
+	border: solid 2px lightgray;
+	border-radius: 3px;
+	height: 367px;
+}
+
+.subitem-tab-gear-flex-container-equipment {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.subitem-tab-gear-flex-container-equipment h1 {
+	margin-right: 8px;
+}
+
+.subitem-tab-gear-flex-container-equipment input[type=text] {
+	text-align: left;
+	padding-left: 1px;
+	padding-right: 1px;
+	max-width: 162px;
+	max-height: 21px;
+	margin-right: 0px;
+	border: solid 1px #eaeaea;
+}
+
+.subitem-tab-gear-flex-container-equipment input[type=number] {
+	text-align: right;
+	padding-left: 3px;
+	max-width: 120px;
+	min-width: 50px;
+	max-height: 21px;
+	padding-right: 0px;
+	margin-right: 0px;
+	margin-left: 2px;
+	border: solid 1px #eaeaea;
+}
+
+/* Buttons for equipment movers. */
+
+.gear-mover-plus-minus-enclosure {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	
+}
+
+.gear-mover-plus-minus-button {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 22px;
+	width: 10px;
+	align-items: center;
+	padding: 0px;
+	margin-right: 2px;
+}
+
+.gear-mover-plus-minus-button button.buttonPlus,
+.gear-mover-plus-minus-button button.buttonMinus {
+	background-color: white;
+	border: solid 1px lightgray;
+	color: lightskyblue;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	display: inline-block;
+	font-size: 8px;
+	margin: 0px 0px;
+	line-height: 1.25ch;
+	border-radius: 0px;
+	max-width: 10px;
+}
+
+.gear-mover-plus-minus-button button.buttonPlus span,
+.gear-mover-plus-minus-button button.buttonMinus span {
+	display: inline-block;
+	transform: rotate(-90deg);
+	text-align: center;
+}
+
+.gear-mover-plus-minus-button button.buttonPlus:hover,
+.gear-mover-plus-minus-button button.buttonMinus:hover {
+	background-color: silver;
+	transition: 0.05s;
+	color: white;
+} 
+
+/* ----------------------------------------------------------- */
+/* Item: Attacks and Maneuvers or treasures text box slideshow */
+/* ----------------------------------------------------------- */
+
+.item-tab-gear-slide-container {
+	grid-area: theSlides;
+	position: relative;
+}
+
+.item-tab-gear-slide-container h1 {
+	text-align: left;
+	line-height: 1.2;
+	font-size: 12px;
+	margin: 0px;
+}
+
+.item-tab-gear-slide-container h2 {
+	font-size: 12px;
+	text-align: center;
+	font-weight: 400;
+	line-height: 1.2;
+}
+
+.item-tab-gear-slide-container .button-left-arrow {
+	position: absolute;
+	top: 4.5%;
+	left: 88%;
+	transform: translate(-50%, -50%);
+	color: gray;
+	background-color: lightgray;
+	font-size: 12px;
+	padding: 1px 5px;
+	border: none;
+	cursor: pointer;
+	border-radius: 3px;
+	text-align: center;
+}
+
+.item-tab-gear-slide-container .button-right-arrow {
+	position: absolute;
+	top: 4.5%;
+	left: 92.5%;
+	transform: translate(-50%, -50%);
+	color: gray;
+	background-color: lightgray;
+	font-size: 12px;
+	padding: 1px 5px;
+	border: none;
+	cursor: pointer;
+	border-radius: 3px;
+	text-align: center;
+}
+
+.item-tab-gear-slide-container .button-right-arrow:hover,
+.item-tab-gear-slide-container .button-left-arrow:hover {
+	background-color: gold;
+	color: black;
+}
+
+.item-tab-gear-slide-flex-container-maneuvers,
+.item-tab-gear-slide-flex-container-martial-maneuvers {
+	width: 406px;
+	height: 375px;
+	padding: 0px;
+	margin-left: 0px;
+	margin-bottom: 0px;
+	background-color: lightcyan;
+	border: solid 2px lightgray;
+	border-radius: 3px;
+}
+
+.item-tab-gear-slide-flex-container-martial-maneuvers-block {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-top: 6px;
+	max-height: 310px;
+	min-height: 270px;
+}
+
+.item-tab-gear-slide-flex-container-martial-maneuvers input[type=text] {
+	border: 1px solid lightgray;
+	height: 22px;
+	width: 30px;
+}
+
+.subitem-flex-container-martial-row input {
+	text-align: center;
+	height: 22px;
+	border: solid 1px lightgray;
+	margin: 0px;
+	padding: 0px;
+}
+
+.subitem-flex-container-martial-row input[type=number] {
+	text-align: right;
+	height: 22px;
+	border: solid 1px lightgray;
+	max-width: 38px;
+}
+
+.subitem-flex-container-martial-row input[type=text]:nth-child(2) {
+	width: 220px;
+	margin: 0px;
+	height: 22px;
+	text-align: left;
+	padding-left: 1px;	
+}
+
+.subitem-flex-container-martial-cv-row input[type=text] {
+	width: 30px;
+	border: 1px solid lightgray;
+	text-align: center;
+	padding-left: 2px;
+	height: 18px;
+	margin-left: 3px;
+}
+
+.item-tab-gear-slide-flex-container-martial-maneuvers textarea {
+	width: 244px;
+	border: 1px solid lightgray;
+	max-height: 37px;
+	padding: 0px 3px; 
+	font-size: 12px;
+	margin: 0px;
+}
+
+.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(1),
+.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(1) {
+	width: 108px;
+}
+
+.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(2),
+.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(2),
+.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(3),
+.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(3),
+.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(4),
+.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(4) {
+	width: 40px;
+	padding: 0px;
+	margin: 0px;
+	text-align: center;
+}
+
+.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(5),
+.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(5) {
+	text-align: left;
+	padding-left: 0px;
+	margin-left: 0px;
+}
+
+.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(1) {
+	padding-left: 2px;
+	width: 260px;
+}
+
+.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(2),
+.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(3) {
+	text-align: center;
+	width: 40px;
+}
+
+.subitem-tab-gear-slide-flex-container-maneuvers-heading,
+.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading {
+	flex-direction: row;
+	display: flex;
+	justify-content: flex-start;
+	width: 402px;
+	height: 19px;
+	padding: 0px;
+	margin-left: 0px;
+	padding-top: 5px;
+	padding-left: 4px;
+	margin-bottom: 0px;
+	background-color: lightcyan;
+}
+
+.subitem-tab-gear-slide-flex-container-maneuvers-light-row,
+.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
+	flex-direction: row;
+	display: flex;
+	justify-content: flex-start;
+	width: 402px;
+	height: 19px;
+	padding: 0px;
+	margin-left: 0px;
+	padding-top: 4px;
+	padding-left: 4px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+}
+
+.subitem-tab-gear-slide-flex-container-maneuvers-light-row {
+	background-color: white;
+}
+
+.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
+	background-color: lightcyan;
+}
+
+.subitem-tab-gear-slide-flex-container-martial-maneuvers-row {
+	flex-direction: row;
+	display: flex;
+	justify-content: space-between;
+	width: 397px;
+	height: 40px;
+	padding: 0px;
+	margin-left: 0px;
+	padding-top: 0px;
+	padding-left: 4px;
+	margin-top: 0px;
+	margin-bottom: 0px;
+}
+
+/* Buttons for maneuver movers. */
+.maneuver-mover-plus-minus-enclosure {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.maneuver-mover-plus-minus-button {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 24px;
+	width: 10px;
+	align-items: center;
+	padding: 0px;
+	margin-right: 2px;
+	margin-left: 2px;
+}
+
+.maneuver-mover-plus-minus-button button.buttonPlus,
+.maneuver-mover-plus-minus-button button.buttonMinus {
+	background-color: LemonChiffon;
+	border: solid 1px silver;
+	color: slategray;
+	padding-left: 4px;
+	padding-right: 4px;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	display: inline-block;
+	font-size: 10px;
+	margin: 0px 0px;
+	line-height: 1.25ch;
+	border-radius: 0px;
+	max-width: 10px;
+}
+
+.maneuver-mover-plus-minus-button button.buttonPlus span,
+.maneuver-mover-plus-minus-button button.buttonMinus span {
+	display: inline-block;
+	transform: rotate(-90deg);
+	text-align: center;
+}
+
+.maneuver-mover-plus-minus-button button.buttonPlus:hover,
+.maneuver-mover-plus-minus-button button.buttonMinus:hover {
+	background-color: gray;
+	color: white;
+	transition: 0.05s;
+} 
+
+.item-flex-maneuver {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	width: 399px;
+	padding-left: 4px;
+	margin-top: 2px;
+	padding-bottom: 2px;
+}
+
+.subitem-flex-container-martial-row {
+	text-align: left;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-height: 24px;
+}
+
+/* Update when custom maneuver attack roll made */
+.subitem-flex-container-martial-row .buttonRollAttack {
+	margin-top: 1px;
+	margin-left: 3px;
+}
+
+.subitem-flex-container-martial-ocv-dcv {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	max-height: 40px;
+	max-width: 134px;
+	padding: 0px 0px;
+}
+
+/* Martial Maneuver Details */
+
+.subitem-flex-container-martial-details-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: top;
+	max-width: 397px;
+	height: 48px;
+	padding-left: 23px;
+	padding-top: 0px;
+	padding-bottom: 0px;
+}
+
+.subitem-flex-container-martial-details-row .buttonRollShow {
+	margin-top: 3px;
+}
+
+.subitem-flex-container-martial-details-column {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	height: 48px;
+}
+
+.subitem-flex-container-martial-buttons-column {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	height: 45px;
+	padding-top: 2px;
+	padding-bottom: 1px;
+}
+
+.subitem-flex-container-martial-cv-damage-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	max-height: 21px;
+	align-items: center;
+	padding-right: 1px;
+}
+
+.subitem-flex-container-martial-cv-damage-row h1 {
+	padding-right: 1px;
+}
+
+.subitem-flex-container-martial-cv-damage-row h1:not(:first-child) {
+	padding-left: 7px;
+}
+
+.subitem-flex-container-martial-cv-damage-row input[type=number] {
+	height: 21px;
+	max-width: 38px;
+	border: solid 1px lightgray;
+}
+
+.subitem-flex-container-martial-cv-damage-row input[type=text] {
+	text-align: center;
+	height: 21px;
+	width: 68px;
+	padding-left: 2px;
+	padding-right: 4px;
+}
+
+.subitem-martial-description-row {
+	max-height: 22px;
+	min-width: 321px;
+}
+
+.subitem-martial-description-row input[type=text] {
+	width: 277px;
+	height: 21px;
+	text-align: left;
+	padding-left: 2px;
+	margin-right: 2px;
+}
+
+.subitem-martial-description-row input[type=number] {
+	height: 21px;
+	max-width: 38px;
+	border: solid 1px lightgray;
+	text-align: right;
+	margin-right: 0px;
+}
+
+/* Basic Attack */
+.subitem-tab-gear-slide-flex-container-standard-attack {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin-left: 23px;
+	margin-bottom: 1px;
+	padding-right: 0px;
+	min-width: 376px;
+	align-items: center;
+}
+
+.subitem-tab-gear-slide-flex-container-standard-attack h1 {
+	text-align: left;
+}
+
+.subitem-tab-gear-slide-flex-container-standard-attack input[type=text] {
+	text-align: left;
+	margin-left: 96px;
+	margin-right: 41px;
+	text-align: center;
+}
+
+/* Range Modifier Table */
+.subitem-tab-gear-slide-flex-container-range-modifiers {
+	flex-direction: row;
+	display: flex;
+	justify-content: space-between;
+	width: 397px;
+	height: 30px;
+	padding: 0px;
+	padding-left: 5px;
+	margin-left: 0px;
+	margin-top: 11px;
+	margin-bottom: 2px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container-first,
+.subitem-tab-gear-slide-range-modifier-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	height: 30px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container-first {
+	min-width: 83px;
+	align-items: flex-start;
+}
+
+.subitem-tab-gear-slide-range-modifier-container {
+	min-width: 50px;
+	align-items: center;
+}
+
+.subitem-tab-gear-slide-range-modifier-container h2:nth-child(1) {
+	font-weight: bold;
+}
+
+.subitem-tab-gear-slide-range-modifier-container-first h2 {
+	font-weight: bold;
+}
+
+/* Item: Hit Locations */
+.item-tab-gear-slide-flex-container-hit-locations {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	width: 403px;
+	height: 375px;
+	padding: 0px;
+	padding-left: 3px;
+	background-color: lightcyan;
+	margin-left: 0px;
+	margin-bottom: 0px;
+	border: solid 2px lightgray;
+	border-radius: 3px;
+}
+
+.item-gear-slide-container-hit-locations-flex-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	border-radius: 3px;
+	width: 400px;
+}
+
+/* Special Hit Locations */
+.item-gear-slide-flex-container-hit-locations-special {
+	width: 260px;
+	height: 145px;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+
+.item-gear-slide-flex-container-hit-locations-special label {
+	display: inline-block;
+	margin-left: 14px;
+	margin-right: 4px;
+	margin-top: 2px; /* A fix to get a uniform look with the hit location table */
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-heading {
+	background-color: lightcyan;
+	height: 20px;
+	margin-bottom: 3px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(1){
+	width: 42px;
+	text-align: left;
+	margin-left: 2px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(2){
+	width: 40px;
+	text-align: center;
+	margin-left: 3px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(3){
+	width: 52px;
+	text-align: center;
+	margin-left: 30px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(4){
+	width: 44px;
+	text-align: right;
+	margin-left: 15px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-top-row,
+.subitem-gear-slide-flex-container-hit-locations-special-middle-row,
+.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	background-color: white;
+	border-left: solid 1px lightgray;
+	border-right: solid 1px lightgray;
+	width: 260px;
+	height: 20px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-top-row {
+	border-top: solid 1px lightgray;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	padding-top: 5px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
+	border-bottom: solid 1px lightgray;
+	border-bottom-left-radius: 3px;
+	border-bottom-right-radius: 3px;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-top-row h1,
+.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1,
+.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1 {
+	width: 65px;
+	text-align: center;
+}
+
+.subitem-gear-slide-flex-container-hit-locations-special-top-row h1:nth-child(4),
+.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1:nth-child(4),
+.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1:nth-child(4) {
+	width: 35px;
+	text-align: right;
+	padding-right: 19px;
+}
+
+/* Targeting Options */
+.item-gear-slide-container-hit-locations-options {
+	width: 130px;
+	height: 100px;
+	margin-top: 50px;
+}
+
+.subitem-gear-slide-container-hit-locations-options-top,
+.subitem-gear-slide-container-hit-locations-options-bottom {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-start;
+	width: 115px;
+	margin: 3px;
+	margin-bottom: 15px;
+}
+
+.subitem-gear-slide-container-hit-locations-options-top {
+	margin-left: 10px;
+}
+
+.subitem-gear-slide-container-hit-locations-options-top h1,
+.subitem-gear-slide-container-hit-locations-options-bottom h1 {
+	padding-top: 4px;
+	margin: 0px;
+}
+
+.subitem-gear-slide-container-hit-locations-options-top label {
+	max-width: 0px;
+	margin-left: 2px;
+	margin-right: 0px;
+	margin-top: 3px;
+	padding-right: 0px;
+}
+
+.subitem-gear-slide-container-hit-locations-options-bottom input {
+	margin-left: 5px;
+	border: solid 1px lightgray;
+}
+
+/* Hit Location Table */
+.item-gear-slide-container-hit-locations-table {
+	width: 399px;
+	height: 215px;
+}
+
+.item-gear-slide-container-hit-locations-table h1 {
+	width: 51px;
+	text-align: center;
+}
+
+.item-gear-slide-container-hit-locations-table label {
+	display: inline-block;
+	margin-left: 14px;
+	margin-right: 3px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-heading {
+	background-color: lightcyan;
+	height: 20px;
+	margin-bottom: 3px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-heading h1 {
+	text-align: center;
+	margin-left: 2px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(1){
+	width: 42px;
+	text-align: left;
+}
+
+.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(2){
+	width: 34px;
+	text-align: center;
+	margin-right: 9px;
+	margin-left: 3px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-top-row,
+.subitem-gear-slide-container-hit-locations-table-middle-row,
+.subitem-gear-slide-container-hit-locations-table-bottom-row {
+	height: 19px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
+.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
+.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
+	width: 40x;
+	text-align: center;
+	margin-right: 11px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
+.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
+.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
+	width: 34px;
+	text-align: center;
+	margin-left: 21px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(6),
+.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(6),
+.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(6){
+	width: 45px;
+	text-align: center;
+	margin-left: 6px;
+	margin-right: 0px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(7),
+.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(7),
+.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(7){
+	width: 34px;
+	text-align: right;
+	margin-left: 4px;
+	margin-right: 17px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-top-row {
+	background-color: white;
+	border-top: solid 1px lightgray;
+	border-left: solid 1px lightgray;
+	border-right: solid 1px lightgray;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+}
+
+.subitem-gear-slide-container-hit-locations-table-middle-row {
+	background-color: white;
+	border-left: solid 1px lightgray;
+	border-right: solid 1px lightgray;
+}
+
+.subitem-gear-slide-container-hit-locations-table-bottom-row {
+	background-color: white;
+	border-left: solid 1px lightgray;
+	border-right: solid 1px lightgray;
+	border-bottom: solid 1px lightgray;
+	border-bottom-left-radius: 3px;
+	border-bottom-right-radius: 3px;
+	padding-bottom: 5px;
+}
+
+/* Item: Slide of treasure and notes box  */
+.item-tab-gear-slide-treasure-text {
+	width: 402px;
+	height: 367px;
+	padding: 0px;
+	margin-left: 0px;
+	margin-bottom: 0px;
+}
+
+.item-tab-gear-slide-treasure-text textarea {
+	width: 398px;
+	height: 367px;
+	margin: 0px;
+	border: solid 2px lightgray;
+	border-radius: 3px;
+}
+
+/* hide all gear tab slides by default */
+
+.item-tab-gear-slide-flex-container-maneuvers,
+.item-tab-gear-slide-flex-container-martial-maneuvers,
+.item-tab-gear-slide-flex-container-hit-locations,
+.item-tab-gear-slide-treasure-text {
+	display: none;
+}
+
+/* show the selected gear slide */
+.item-gear-slideshow[value="1"] ~ div.item-tab-gear-slide-flex-container-maneuvers,
+.item-gear-slideshow[value="2"] ~ div.item-tab-gear-slide-flex-container-martial-maneuvers,
+.item-gear-slideshow[value="3"] ~ div.item-tab-gear-slide-flex-container-hit-locations,
+.item-gear-slideshow[value="4"] ~ div.item-tab-gear-slide-treasure-text {
+	display: block;
+	position: relative;
+}
+
+/* ---------------------------------------------------------------- */
+/* Custom radio button from w3 schools.                             */
+/* https://www.w3schools.com/howto/howto_css_custom_checkbox.asp    */
+/* ---------------------------------------------------------------- */
+
+/* Customize the label (the container) */
+.custom-radio-button-container {
+	display: block;
+	position: relative;
+	padding: 0px;
+	margin: 0px;
+	cursor: pointer;
+	font-size: 12px;
+	max-width: 0px;
+	max-height: 0px;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	background-color: orange;
+	/* background-color: orange; */
+}
+
+/* Hide the browser's default radio button */
+.custom-radio-button-container input {
+	position: absolute;
+	opacity: 0;
+	cursor: pointer;
+	height: 0;
+	width: 0;
+}
+
+/* Create a custom radio button */
+.custom-radio-button {
+	position: absolute;
+	top: -2px; /* A fix to get a uniform look with the hit location table */
+	left: 0px;
+	height: 11px;
+	width: 11px;
+	background-color: white;
+	border: solid 2px lightsteelblue;
+	border-radius: 50%;
+	margin-bottom: 0px;
+	padding: 0px;
+}
+
+/* On mouse-over, add a grey background color */
+.custom-radio-button-container:hover input ~ .custom-radio-button {
+	background-color: lightsteelblue;
+}
+
+/* When the radio button is checked, add a blue background */
+.custom-radio-button-container input:checked ~ .custom-radio-button {
+	background-color: indianred;
+	border: solid 2px indianred;
+}
+
+/* Create the indicator (the dot/circle - hidden when not checked) */
+.custom-radio-button:after {
+	content: "";
+	position: absolute;
+	display: none;
+}
+
+/* Show the indicator (dot/circle) when checked */
+.custom-radio-button-container input:checked ~ .custom-radio-button:after {
+	display: block;
+}
+
+/* Style the indicator (dot/circle) */
+.custom-radio-button-container .custom-radio-button:after {
+	top: 0px;
+	left: 0px;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	border: solid 2px white;
+	background: indianred;
+	margin: 0px;
+	padding: 0px;
+}
+
+/* ---------------------------------------------------------------- */
+/* Jackob's Roll Template                                           */
+/* https://wiki.roll20.net/Building_Character_Sheets/Roll_Templates */
+/* ---------------------------------------------------------------- */
+
+/* Three different Templates for attacks, armor activation, and skills ability checks. */
+.sheet-rolltemplate-custom,
+.sheet-rolltemplate-custom-success-roll,
+.sheet-rolltemplate-custom-defense,
+.sheet-rolltemplate-custom-attack,
+.sheet-rolltemplate-custom-normal-attack,
+.sheet-rolltemplate-custom-maneuver,
+.sheet-rolltemplate-custom-normal-maneuver,
+.sheet-rolltemplate-custom-power-attack,
+.sheet-rolltemplate-custom-activate,
+.sheet-rolltemplate-custom-show {
+	margin-left: -37px;
+	color: #181818;
+}
+
+.withoutavatars .sheet-rolltemplate-custom,
+.withoutavatars .sheet-rolltemplate-custom-success-roll,
+.withoutavatars .sheet-rolltemplate-custom-defense,
+.withoutavatars .sheet-rolltemplate-custom-attack,
+.withoutavatars .sheet-rolltemplate-custom-normal-attack,
+.withoutavatars .sheet-rolltemplate-custom-maneuver,
+.withoutavatars .sheet-rolltemplate-custom-normal-maneuver,
+.withoutavatars .sheet-rolltemplate-custom-power-attack,
+.withoutavatars .sheet-rolltemplate-custom-activate,
+.withoutavatars .sheet-rolltemplate-custom-show {
+	margin-left: -7px;
+	color: #181818;
+}
+
+.sheet-rolltemplate-custom .sheet-container,
+.sheet-rolltemplate-custom-success-roll .sheet-container,
+.sheet-rolltemplate-custom-defense .sheet-container,
+.sheet-rolltemplate-custom-attack .sheet-container,
+.sheet-rolltemplate-custom-normal-attack .sheet-container,
+.sheet-rolltemplate-custom-maneuver .sheet-container,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
+.sheet-rolltemplate-custom-power-attack .sheet-container,
+.sheet-rolltemplate-custom-activate .sheet-container,
+.sheet-rolltemplate-custom-show .sheet-container {
+	border: 1px solid;
+	/* by default, the border is the same color as the header. You can change this here, e.g. to black */
+	border-color: var(--header-bg-color);
+}
+
+/* Header formatting - title and subtitle */
+.sheet-rolltemplate-custom .sheet-header,
+.sheet-rolltemplate-custom-success-roll .sheet-header {
+	background-color: #E69F00;
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-defense .sheet-header {
+	background-color: #56B4E9;
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-attack .sheet-header {
+	background-color: #D55E00;
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-normal-attack .sheet-header {
+	background-color: #009E73;
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-maneuver .sheet-header {
+	background-color: #D55E00
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-normal-maneuver .sheet-header {
+	background-color: #009E73;
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-power-attack .sheet-header {
+	background-color: #CC79A7;
+	/* background-color: #56B4E9; */
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-activate .sheet-header {
+	background-color: #0072B2;
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom-show .sheet-header {
+	background-color: #8A8A8A;
+	/* change text-align to center to center the header text */
+	text-align: left;
+	color: var(--header-text-color);
+	padding: 5px;
+}
+
+.sheet-rolltemplate-custom .sheet-title,
+.sheet-rolltemplate-custom-success-roll .sheet-title,
+.sheet-rolltemplate-custom-defense .sheet-title,
+.sheet-rolltemplate-custom-attack .sheet-title,
+.sheet-rolltemplate-custom-normal-attack .sheet-title,
+.sheet-rolltemplate-custom-maneuver .sheet-title,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-title,
+.sheet-rolltemplate-custom-power-attack .sheet-title,
+.sheet-rolltemplate-custom-activate .sheet-title,
+.sheet-rolltemplate-custom-show .sheet-title {
+	font-size:1.2em;
+}
+
+.sheet-rolltemplate-custom .sheet-subtitle,
+.sheet-rolltemplate-custom-success-roll .sheet-subtitle,
+.sheet-rolltemplate-custom-defense .sheet-subtitle,
+.sheet-rolltemplate-custom-attack .sheet-subtitle,
+.sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
+.sheet-rolltemplate-custom-maneuver .sheet-subtitle,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-subtitle,
+.sheet-rolltemplate-custom-power-attack .sheet-subtitle,
+.sheet-rolltemplate-custom-activate .sheet-subtitle,
+.sheet-rolltemplate-custom-show .sheet-subtitle {
+	font-size:1.0em;
+	padding-top: 0.1em;
+}
+
+/* example colors */
+.sheet-rolltemplate-custom .sheet-container,
+.sheet-rolltemplate-custom-success-roll .sheet-container,
+.sheet-rolltemplate-custom-defense .sheet-container,
+.sheet-rolltemplate-custom-attack .sheet-container,
+.sheet-rolltemplate-custom-normal-attack .sheet-container,
+.sheet-rolltemplate-custom-maneuver .sheet-container,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
+.sheet-rolltemplate-custom-power-attack .sheet-container,
+.sheet-rolltemplate-custom-activate .sheet-container,
+.sheet-rolltemplate-custom-show .sheet-container  {
+	/* this is the default color */
+	--header-bg-color: black;
+	--header-text-color: #FFF;
+}
+
+/* Allprops part */
+.sheet-rolltemplate-custom .sheet-content,
+.sheet-rolltemplate-custom-success-roll .sheet-content,
+.sheet-rolltemplate-custom-defense .sheet-content,
+.sheet-rolltemplate-custom-attack .sheet-content,
+.sheet-rolltemplate-custom-normal-attack .sheet-content,
+.sheet-rolltemplate-custom-maneuver .sheet-content,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-content,
+.sheet-rolltemplate-custom-power-attack .sheet-content,
+.sheet-rolltemplate-custom-activate .sheet-content,
+.sheet-rolltemplate-custom-show .sheet-content {
+	display: grid;
+	background: #FFF;
+	/* Header formatting - modify the column layout below */
+	grid-template-columns: auto auto;
+	/* Line height to match default roll template */
+	line-height:1.4em;
+}
+
+.sheet-rolltemplate-custom .sheet-content > div,
+.sheet-rolltemplate-custom-success-roll .sheet-content > div,
+.sheet-rolltemplate-custom-defense .sheet-content > div,
+.sheet-rolltemplate-custom-attack .sheet-content > div,
+.sheet-rolltemplate-custom-normal-attack .sheet-content > div,
+.sheet-rolltemplate-custom-maneuver .sheet-content > div,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-content > div,
+.sheet-rolltemplate-custom-power-attack .sheet-content > div,
+.sheet-rolltemplate-custom-activate .sheet-content > div,
+.sheet-rolltemplate-custom-show .sheet-content > div {
+	padding: 5px;
+}
+
+/* Left column */
+.sheet-rolltemplate-custom .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-success-roll .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-defense .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-attack .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-maneuver .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-activate .sheet-content .sheet-key,
+.sheet-rolltemplate-custom-show .sheet-content .sheet-key {
+	font-weight: bold;
+	padding-right: 10px;
+	text-align: right;
+	color: #222222; /* To fix dark mode in Chrome. */
+}
+
+/* Right column. Color to fix dark mode in Chrome. */
+.sheet-rolltemplate-custom .sheet-value,
+.sheet-rolltemplate-custom-success-roll .sheet-value,
+.sheet-rolltemplate-custom-defense .sheet-value,
+.sheet-rolltemplate-custom-attack .sheet-value,
+.sheet-rolltemplate-custom-normal-attack .sheet-value,
+.sheet-rolltemplate-custom-maneuver .sheet-value,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-value,
+.sheet-rolltemplate-custom-power-attack .sheet-value,
+.sheet-rolltemplate-custom-activate .sheet-value,
+.sheet-rolltemplate-custom-show .sheet-value {
+	color: #222222;
+}
+
+/* Make even-numbered rows grey */
+.sheet-rolltemplate-custom .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n),
+.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n+3),
+.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n) {
+	background:#EEE;
+}
+
+/* Description field */
+.sheet-rolltemplate-custom .sheet-desc,
+.sheet-rolltemplate-custom-success-roll .sheet-desc,
+.sheet-rolltemplate-custom-defense .sheet-desc,
+.sheet-rolltemplate-custom-attack .sheet-desc,
+.sheet-rolltemplate-custom-normal-attack .sheet-desc,
+.sheet-rolltemplate-custom-maneuver .sheet-desc,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-desc,
+.sheet-rolltemplate-custom-power-attack .sheet-desc,
+.sheet-rolltemplate-custom-activate .sheet-desc,
+.sheet-rolltemplate-custom-show .sheet-desc {
+	grid-column: span 2;
+	padding-right: 10px;
+	text-align: left;
+	color: #222222; /* To fix dark mode in Chrome. */
+}
+
+/* Dice roll face colors. Needed to prevent problems with dark mode. */
+.sheet-rolltemplate-custom .inlinerollresult,
+.sheet-rolltemplate-custom-success-roll .inlinerollresult,
+.sheet-rolltemplate-custom-defense .inlinerollresult,
+.sheet-rolltemplate-custom-attack .inlinerollresult,
+.sheet-rolltemplate-custom-normal-attack .inlinerollresult,
+.sheet-rolltemplate-custom-maneuver .inlinerollresult,
+.sheet-rolltemplate-custom-normal-maneuver .inlinerollresult,
+.sheet-rolltemplate-custom-power-attack .inlinerollresult,
+.sheet-rolltemplate-custom-activate .inlinerollresult,
+.sheet-rolltemplate-custom-show .inlinerollresult {
+	display: inline-block;
+	min-width: 1.5em;
+	text-align: center;
+	border: 2px solid palegoldenrod;
+	background: #fff990;
+}
+
+.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult,
+.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult {
+	background-color: #fff990;
+	border: 2px solid palegoldenrod;
+}
+
+.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullcrit,
+.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullcrit {
+	border: 2px solid #228833;
+}
+
+.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullfail,
+.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullfail {
+	border: 2px solid #AA3377;
+}
+
+/* --------------------------------------------------- */
+/* Power block expanding/collapse functionality        */
+/* --------------------------------------------------- */
+
+/* Nominal state for expanded areas */
+.sheet-power-expand-01,
+.sheet-power-expand-02,
+.sheet-power-expand-03,
+.sheet-power-expand-04,
+.sheet-power-expand-05,
+.sheet-power-expand-06,
+.sheet-power-expand-07,
+.sheet-power-expand-08,
+.sheet-power-expand-09,
+.sheet-power-expand-10,
+.sheet-power-expand-11,
+.sheet-power-expand-12,
+.sheet-power-expand-13,
+.sheet-power-expand-14,
+.sheet-power-expand-15,
+.sheet-power-expand-16,
+.sheet-power-expand-17 {
+	display: none;
+}
+
+/* Expand the selected left power block. */
+.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .sheet-power-expand-01,
+.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .sheet-power-expand-02,
+.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .sheet-power-expand-03,
+.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .sheet-power-expand-04,
+.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .sheet-power-expand-05,
+.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .sheet-power-expand-06,
+.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .sheet-power-expand-07,
+.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .sheet-power-expand-08,
+.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .sheet-power-expand-09 {
+	display: block;
+}
+
+/* Expand the selected right power block. */
+.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .sheet-power-expand-10,
+.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .sheet-power-expand-11,
+.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .sheet-power-expand-12,
+.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .sheet-power-expand-13,
+.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .sheet-power-expand-14,
+.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .sheet-power-expand-15,
+.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .sheet-power-expand-16,
+.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .sheet-power-expand-17 {
+	display: block;
+}
+
+/* Turn down the opacity on the left point values to help visibility overall. */
+.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-opacity-power01,
+.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-opacity-power02,
+.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-opacity-power03,
+.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-opacity-power04,
+.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-opacity-power05,
+.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-opacity-power06,
+.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-opacity-power07,
+.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-opacity-power08,
+.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-opacity-power09 {
+	opacity: 0.4;
+}
+
+/* Turn down the opacity on the right point values to help visibility overall. */
+.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-opacity-power10,
+.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-opacity-power11,
+.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-opacity-power12,
+.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-opacity-power13,
+.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-opacity-power14,
+.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-opacity-power15,
+.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-opacity-power16,
+.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-opacity-power17 {
+	opacity: 0.4;
+}
+
+/* Hide the base and active costs for a tidier look. */
+.subitem-visibility-power01,
+.subitem-visibility-power02,
+.subitem-visibility-power03,
+.subitem-visibility-power04,
+.subitem-visibility-power05,
+.subitem-visibility-power06,
+.subitem-visibility-power07,
+.subitem-visibility-power08,
+.subitem-visibility-power09,
+.subitem-visibility-power10,
+.subitem-visibility-power11,
+.subitem-visibility-power12,
+.subitem-visibility-power13,
+.subitem-visibility-power14,
+.subitem-visibility-power15,
+.subitem-visibility-power16,
+.subitem-visibility-power17 {
+	visibility: hidden;
+}
+
+.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power01,
+.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power02,
+.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power03,
+.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power04,
+.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power05,
+.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power06,
+.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power07,
+.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power08,
+.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power09 {
+	visibility: visible;
+}
+
+.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power10,
+.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power11,
+.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power12,
+.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power13,
+.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power14,
+.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power15,
+.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power16,
+.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power17 {
+	visibility: visible;
+}
+
+/* --------------------------------------------------- */
+/* Maneuver block expanding/collapse functionality     */
+/* --------------------------------------------------- */
+
+/* Nominal state for expanded areas */
+.sheet-maneuver-expand-01,
+.sheet-maneuver-expand-02,
+.sheet-maneuver-expand-03,
+.sheet-maneuver-expand-04,
+.sheet-maneuver-expand-05,
+.sheet-maneuver-expand-06,
+.sheet-maneuver-expand-07,
+.sheet-maneuver-expand-08,
+.sheet-maneuver-expand-09  {
+	display: none;
+}
+
+/* Expand the selected maneuver block. */
+.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .sheet-maneuver-expand-01,
+.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .sheet-maneuver-expand-02,
+.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .sheet-maneuver-expand-03,
+.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .sheet-maneuver-expand-04,
+.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .sheet-maneuver-expand-05,
+.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .sheet-maneuver-expand-06,
+.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .sheet-maneuver-expand-07,
+.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08,
+.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .sheet-maneuver-expand-09 {
+	display: block;
+}
+
+/* ---------------------------------------------------------------- */
+/* Custom button for power expand                                   */
+/* ---------------------------------------------------------------- */
+
+.custom-expand-button-container {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin-right: 1px;
+}
+
+.custom-expand-button-container button.buttonExpand {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	height: 24px;
+	width: 10px;
+	align-items: center;
+	padding: 0px;
+	margin-right: 2px;
+	margin-left: 0px;
+	border-color: transparent;
+	background: transparent;
+}
+
+.custom-expand-button-container button.buttonExpand span {
+	display: inline-block;
+	text-align: center;
+}
+
+/* Rotate when expanded */
+.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01,
+.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02,
+.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03,
+.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04,
+.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05,
+.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06,
+.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07,
+.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08,
+.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09,
+.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10,
+.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11,
+.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12,
+.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13,
+.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14,
+.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15,
+.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16,
+.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17,
+.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01,
+.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02,
+.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03,
+.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04,
+.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05,
+.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06,
+.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07,
+.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08,
+.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09
+ {
+	transform: rotate(90deg);
+}
+
+/* Rotate when not expanded, but hover */
+.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01:hover,
+.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02:hover,
+.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03:hover,
+.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04:hover,
+.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05:hover,
+.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06:hover,
+.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07:hover,
+.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08:hover,
+.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09:hover,
+.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10:hover,
+.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11:hover,
+.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12:hover,
+.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13:hover,
+.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14:hover,
+.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15:hover,
+.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16:hover,
+.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand01"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand02"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand03"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand04"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand05"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand06"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand07"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover,
+.sheet-maneuver-toggle:not([value="maneuverExpand09"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09:hover
+{
+	transition: 0.25s;
+	transform: rotate(90deg);
+}
+
+.custom-button-triangle {
+	position: relative; 
+	border-top: 8px solid transparent;
+	border-bottom: 8px solid transparent;
+	border-left: 12px solid silver;
+	border-right: 8px solid transparent;
+	top: 0px;
+	left: 5px;
+}
+
+.subitem-tab-gear-slide-flex-container-standard-attack .custom-button-triangle {
+	left: 3px
+}
+
+.custom-button-triangle:before {
+	content: "";
+	width: 0;
+	height: 0;
+	position: absolute;
+	border-top: 6px solid transparent;
+	border-bottom: 6px solid transparent;
+	border-left: 10px solid #FFF9CF;
+	top: -6px;
+	left: -11px; 
+}
+
+.subitem-flex-container-martial-row .custom-expand-button-container button.buttonExpand {
+	height: 18px;
+}
+
+.custom-button-triangle:hover,
+.custom-button-triangle:after {
+	position: relative; 
+	border-top: 8px solid transparent;
+	border-bottom: 8px solid transparent;
+	border-left: 12px solid #666666;
+	border-right: 8px solid transparent;
+	top: 0px;
+	left: 5px;
+}

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -3914,10 +3914,8 @@ select:focus + .focus {
 	border: solid 1px #eaeaea;
 }
 
-/* .subitem-tab-gear-flex-container-equipment input[type=text]:hover {
-	position: relative;
-} */
 
+/* Close spacing of equipment items means the focus border is clipped unless we move the z position to relative. */
 .subitem-tab-gear-flex-container-equipment input[type=text]:focus {
 	position: relative;
 }

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -4205,7 +4205,7 @@
 		padding: 0px 0px;
 	}
 	
-	/* New Martial Details */
+	/* Martial Maneuver Details */
 	
 	.subitem-flex-container-martial-details-row {
 		display: flex;
@@ -4270,7 +4270,7 @@
 	
 	/* Old Martial Details */
 
-	.subitem-flex-container-martial-cv-row {
+	/* .subitem-flex-container-martial-cv-row {
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
@@ -4278,9 +4278,9 @@
 		max-height: 20px;
 		max-width: 42px;
 		padding: 0px 0px;
-	}
+	} */
 
-	.subitem-tab-gear-slide-flex-container-martial-details-row {
+	/* .subitem-tab-gear-slide-flex-container-martial-details-row {
 		text-align: left;
 		display: flex;
 		flex-direction: row;
@@ -4290,8 +4290,8 @@
 		padding-right: 55px;
 		padding-top: 2px;
 	}
-	
-	.subitem-tab-gear-slide-flex-container-martial-name-and-points-row {
+	 */
+	/* .subitem-tab-gear-slide-flex-container-martial-name-and-points-row {
 		display: flex;
 		flex-direction: row;
 		justify-content: right;
@@ -4305,7 +4305,7 @@
 	
 	.subitem-tab-gear-slide-flex-container-martial-name-and-points-row input[type=number] {
 		max-width: 42px;
-	}
+	} */
 	
 	/* Basic Attack */
 	.subitem-tab-gear-slide-flex-container-standard-attack {
@@ -4315,17 +4315,19 @@
 		margin-left: 27px;
 		margin-right: 0px;
 		min-width: 374px;
-		padding-bottom: 7px;
+		padding-bottom: 4px;
 		align-items: center;
 	}
 	
 	.subitem-tab-gear-slide-flex-container-standard-attack h1 {
-		margin-right: 8px;
+		text-align: left;
 	}
 	
-	.subitem-tab-gear-slide-flex-container-standard-attack h2 {
+	.subitem-tab-gear-slide-flex-container-standard-attack input[type=text] {
 		text-align: left;
-		margin-right: 100px;
+		margin-left: 93px;
+		margin-right: 52px;
+		text-align: center;
 	}
 	
 	.subitem-tab-gear-slide-flex-container-range-modifiers {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1539,7 +1539,6 @@
 	}
 	
 	.item-flex-maneuver .buttonRollAttack {
-		background-color: #009E73;
 		margin-right: 3px;
 		margin-left: 61px;
 		border-radius: 3px;
@@ -4091,8 +4090,8 @@
 	}
 	
 	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(1) {
-		padding-left: 25px;
-		width: 230px;
+		padding-left: 2px;
+		width: 260px;
 	}
 
 	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(2),
@@ -4748,9 +4747,12 @@
 	/* Three different Templates for attacks, armor activation, and skills ability checks. */
 	.sheet-rolltemplate-custom,
 	.sheet-rolltemplate-custom-success-roll,
-	.sheet-rolltemplate-custom-normal-attack,
-	.sheet-rolltemplate-custom-power-attack,
+	.sheet-rolltemplate-custom-defense,
 	.sheet-rolltemplate-custom-attack,
+	.sheet-rolltemplate-custom-normal-attack,
+	.sheet-rolltemplate-custom-maneuver,
+	.sheet-rolltemplate-custom-normal-maneuver,
+	.sheet-rolltemplate-custom-power-attack,
 	.sheet-rolltemplate-custom-activate,
 	.sheet-rolltemplate-custom-show {
 		margin-left: -37px;
@@ -4759,9 +4761,12 @@
 	
 	.withoutavatars .sheet-rolltemplate-custom,
 	.withoutavatars .sheet-rolltemplate-custom-success-roll,
-	.withoutavatars .sheet-rolltemplate-custom-normal-attack,
-	.withoutavatars .sheet-rolltemplate-custom-power-attack,
+	.withoutavatars .sheet-rolltemplate-custom-defense,
 	.withoutavatars .sheet-rolltemplate-custom-attack,
+	.withoutavatars .sheet-rolltemplate-custom-normal-attack,
+	.withoutavatars .sheet-rolltemplate-custom-maneuver,
+	.withoutavatars .sheet-rolltemplate-custom-normal-maneuver,
+	.withoutavatars .sheet-rolltemplate-custom-power-attack,
 	.withoutavatars .sheet-rolltemplate-custom-activate,
 	.withoutavatars .sheet-rolltemplate-custom-show {
 		margin-left: -7px;
@@ -4770,9 +4775,12 @@
 	
 	.sheet-rolltemplate-custom .sheet-container,
 	.sheet-rolltemplate-custom-success-roll .sheet-container,
-	.sheet-rolltemplate-custom-normal-attack .sheet-container,
-	.sheet-rolltemplate-custom-power-attack .sheet-container,
+	.sheet-rolltemplate-custom-defense .sheet-container,
 	.sheet-rolltemplate-custom-attack .sheet-container,
+	.sheet-rolltemplate-custom-normal-attack .sheet-container,
+	.sheet-rolltemplate-custom-maneuver .sheet-container,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
+	.sheet-rolltemplate-custom-power-attack .sheet-container,
 	.sheet-rolltemplate-custom-activate .sheet-container,
 	.sheet-rolltemplate-custom-show .sheet-container {
 		border: 1px solid;
@@ -4781,6 +4789,30 @@
 	}
 	
 	/* Header formatting - title and subtitle */
+	.sheet-rolltemplate-custom .sheet-header,
+	.sheet-rolltemplate-custom-success-roll .sheet-header {
+		background-color: #E69F00;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-defense .sheet-header {
+		background-color: #56B4E9;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-attack .sheet-header {
+		background-color: #D55E00;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
 	
 	.sheet-rolltemplate-custom-normal-attack .sheet-header {
 		background-color: #009E73;
@@ -4790,8 +4822,16 @@
 		padding: 5px;
 	}
 	
-	.sheet-rolltemplate-custom-activate .sheet-header {
-		background-color: #0072B2;
+	.sheet-rolltemplate-custom-maneuver .sheet-header {
+		background-color: #D55E00
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-header {
+		background-color: #009E73;
 		/* change text-align to center to center the header text */
 		text-align: left;
 		color: var(--header-text-color);
@@ -4799,24 +4839,16 @@
 	}
 	
 	.sheet-rolltemplate-custom-power-attack .sheet-header {
-		background-color: #56B4E9; /* lighter than mediumslateblue; */
+		background-color: #CC79A7;
+		/* background-color: #56B4E9; */
 		/* change text-align to center to center the header text */
 		text-align: left;
 		color: var(--header-text-color);
 		padding: 5px;
 	}
 	
-	.sheet-rolltemplate-custom .sheet-header,
-	.sheet-rolltemplate-custom-success-roll .sheet-header {
-		background-color: #E69F00;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-		
-	.sheet-rolltemplate-custom-attack .sheet-header {
-		background-color: #D55E00;
+	.sheet-rolltemplate-custom-activate .sheet-header {
+		background-color: #0072B2;
 		/* change text-align to center to center the header text */
 		text-align: left;
 		color: var(--header-text-color);
@@ -4833,9 +4865,12 @@
 	
 	.sheet-rolltemplate-custom .sheet-title,
 	.sheet-rolltemplate-custom-success-roll .sheet-title,
-	.sheet-rolltemplate-custom-normal-attack .sheet-title,
-	.sheet-rolltemplate-custom-power-attack .sheet-title,
+	.sheet-rolltemplate-custom-defense .sheet-title,
 	.sheet-rolltemplate-custom-attack .sheet-title,
+	.sheet-rolltemplate-custom-normal-attack .sheet-title,
+	.sheet-rolltemplate-custom-maneuver .sheet-title,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-title,
+	.sheet-rolltemplate-custom-power-attack .sheet-title,
 	.sheet-rolltemplate-custom-activate .sheet-title,
 	.sheet-rolltemplate-custom-show .sheet-title {
 		font-size:1.2em;
@@ -4843,9 +4878,12 @@
 	
 	.sheet-rolltemplate-custom .sheet-subtitle,
 	.sheet-rolltemplate-custom-success-roll .sheet-subtitle,
-	.sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
-	.sheet-rolltemplate-custom-power-attack .sheet-subtitle,
+	.sheet-rolltemplate-custom-defense .sheet-subtitle,
 	.sheet-rolltemplate-custom-attack .sheet-subtitle,
+	.sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
+	.sheet-rolltemplate-custom-maneuver .sheet-subtitle,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-subtitle,
+	.sheet-rolltemplate-custom-power-attack .sheet-subtitle,
 	.sheet-rolltemplate-custom-activate .sheet-subtitle,
 	.sheet-rolltemplate-custom-show .sheet-subtitle {
 		font-size:1.0em;
@@ -4855,9 +4893,12 @@
 	/* example colors */
 	.sheet-rolltemplate-custom .sheet-container,
 	.sheet-rolltemplate-custom-success-roll .sheet-container,
-	.sheet-rolltemplate-custom-normal-attack .sheet-container,
-	.sheet-rolltemplate-custom-power-attack .sheet-container,
+	.sheet-rolltemplate-custom-defense .sheet-container,
 	.sheet-rolltemplate-custom-attack .sheet-container,
+	.sheet-rolltemplate-custom-normal-attack .sheet-container,
+	.sheet-rolltemplate-custom-maneuver .sheet-container,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
+	.sheet-rolltemplate-custom-power-attack .sheet-container,
 	.sheet-rolltemplate-custom-activate .sheet-container,
 	.sheet-rolltemplate-custom-show .sheet-container  {
 		/* this is the default color */
@@ -4868,9 +4909,12 @@
 	/* Allprops part */
 	.sheet-rolltemplate-custom .sheet-content,
 	.sheet-rolltemplate-custom-success-roll .sheet-content,
-	.sheet-rolltemplate-custom-normal-attack .sheet-content,
-	.sheet-rolltemplate-custom-power-attack .sheet-content,
+	.sheet-rolltemplate-custom-defense .sheet-content,
 	.sheet-rolltemplate-custom-attack .sheet-content,
+	.sheet-rolltemplate-custom-normal-attack .sheet-content,
+	.sheet-rolltemplate-custom-maneuver .sheet-content,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-content,
+	.sheet-rolltemplate-custom-power-attack .sheet-content,
 	.sheet-rolltemplate-custom-activate .sheet-content,
 	.sheet-rolltemplate-custom-show .sheet-content {
 		display: grid;
@@ -4883,9 +4927,12 @@
 	
 	.sheet-rolltemplate-custom .sheet-content > div,
 	.sheet-rolltemplate-custom-success-roll .sheet-content > div,
-	.sheet-rolltemplate-custom-normal-attack .sheet-content > div,
-	.sheet-rolltemplate-custom-power-attack .sheet-content > div,
+	.sheet-rolltemplate-custom-defense .sheet-content > div,
 	.sheet-rolltemplate-custom-attack .sheet-content > div,
+	.sheet-rolltemplate-custom-normal-attack .sheet-content > div,
+	.sheet-rolltemplate-custom-maneuver .sheet-content > div,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-content > div,
+	.sheet-rolltemplate-custom-power-attack .sheet-content > div,
 	.sheet-rolltemplate-custom-activate .sheet-content > div,
 	.sheet-rolltemplate-custom-show .sheet-content > div {
 		padding: 5px;
@@ -4894,9 +4941,12 @@
 	/* Left column */
 	.sheet-rolltemplate-custom .sheet-content .sheet-key,
 	.sheet-rolltemplate-custom-success-roll .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
-	.sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-defense .sheet-content .sheet-key,
 	.sheet-rolltemplate-custom-attack .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-maneuver .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
 	.sheet-rolltemplate-custom-activate .sheet-content .sheet-key,
 	.sheet-rolltemplate-custom-show .sheet-content .sheet-key {
 		font-weight: bold;
@@ -4908,9 +4958,12 @@
 	/* Right column. Color to fix dark mode in Chrome. */
 	.sheet-rolltemplate-custom .sheet-value,
 	.sheet-rolltemplate-custom-success-roll .sheet-value,
-	.sheet-rolltemplate-custom-normal-attack .sheet-value,
-	.sheet-rolltemplate-custom-power-attack .sheet-value,
+	.sheet-rolltemplate-custom-defense .sheet-value,
 	.sheet-rolltemplate-custom-attack .sheet-value,
+	.sheet-rolltemplate-custom-normal-attack .sheet-value,
+	.sheet-rolltemplate-custom-maneuver .sheet-value,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-value,
+	.sheet-rolltemplate-custom-power-attack .sheet-value,
 	.sheet-rolltemplate-custom-activate .sheet-value,
 	.sheet-rolltemplate-custom-show .sheet-value {
 		color: #222222;
@@ -4921,12 +4974,18 @@
 	.sheet-rolltemplate-custom .sheet-content :nth-child(4n),
 	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n+3),
 	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
-	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
-	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n),
 	.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n+3),
 	.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n),
 	.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n+3),
 	.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n),
 	.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n+3),
@@ -4937,9 +4996,12 @@
 	/* Description field */
 	.sheet-rolltemplate-custom .sheet-desc,
 	.sheet-rolltemplate-custom-success-roll .sheet-desc,
-	.sheet-rolltemplate-custom-normal-attack .sheet-desc,
-	.sheet-rolltemplate-custom-power-attack .sheet-desc,
+	.sheet-rolltemplate-custom-defense .sheet-desc,
 	.sheet-rolltemplate-custom-attack .sheet-desc,
+	.sheet-rolltemplate-custom-normal-attack .sheet-desc,
+	.sheet-rolltemplate-custom-maneuver .sheet-desc,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-desc,
+	.sheet-rolltemplate-custom-power-attack .sheet-desc,
 	.sheet-rolltemplate-custom-activate .sheet-desc,
 	.sheet-rolltemplate-custom-show .sheet-desc {
 		grid-column: span 2;
@@ -4951,9 +5013,12 @@
 	/* Dice roll face colors. Needed to prevent problems with dark mode. */
 	.sheet-rolltemplate-custom .inlinerollresult,
 	.sheet-rolltemplate-custom-success-roll .inlinerollresult,
-	.sheet-rolltemplate-custom-normal-attack .inlinerollresult,
-	.sheet-rolltemplate-custom-power-attack .inlinerollresult,
+	.sheet-rolltemplate-custom-defense .inlinerollresult,
 	.sheet-rolltemplate-custom-attack .inlinerollresult,
+	.sheet-rolltemplate-custom-normal-attack .inlinerollresult,
+	.sheet-rolltemplate-custom-maneuver .inlinerollresult,
+	.sheet-rolltemplate-custom-normal-maneuver .inlinerollresult,
+	.sheet-rolltemplate-custom-power-attack .inlinerollresult,
 	.sheet-rolltemplate-custom-activate .inlinerollresult,
 	.sheet-rolltemplate-custom-show .inlinerollresult {
 		display: inline-block;
@@ -4965,9 +5030,12 @@
 	
 	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult,
 	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
-	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult,
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
 	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult,
 	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult {
 		background-color: #fff990;
@@ -4976,9 +5044,12 @@
 	
 	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullcrit {
 		border: 2px solid #228833;
@@ -4986,9 +5057,12 @@
 	
 	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullfail {
 		border: 2px solid #AA3377;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -80,7 +80,9 @@
 	/* General Styling 										*/
 	/* ----------------------------------------------------	*/
 	
-	/* Okabe and Ito colorblind-safe palette:				*/
+	/* For better color accessibility, the sheet uses the 	*/
+	/* Okabe and Ito palette and its tints and shades.		*/
+	/* 														*/
 	/* Green: 			#009E73								*/
 	/* Blue: 			#0072B2 							*/
 	/* Light blue: 		#56B4E9 							*/
@@ -173,6 +175,17 @@
 		background-image: linear-gradient(to top, #f9f9f9, #fff 33%);
 	}
 	
+	.custom-select-alternate {
+		border: 1px solid #88caef;
+	}
+	
+	.custom-select,
+	.custom-select-skill,
+	.custom-select-alternate-skill,
+	.custom-select-option {
+		border: 1px solid #f2cf7f;
+	}
+	
 	.custom-select,
 	.custom-select-skill,
 	.custom-select-alternate,
@@ -183,7 +196,6 @@
 	
 	.custom-select-option {
 		width: 58px;
-		background-color: red;
 		padding-left: 4px;
 		margin-right: 6px;
 	}
@@ -222,19 +234,17 @@
 	}
 	
 	.custom-select::after,
-	.custom-select-skill::after {
-		/* background-color: olive; */
+	.custom-select-skill::after,
+	.custom-select-alternate::after {
 		background-color: #8A8A8A;
 	}
 	
-	.custom-select-alternate::after,
 	.custom-select-alternate-skill::after {
-		/* background-color: salmon; */
 		background-color: #CC79A7;
 	}
 	
 	.custom-select-option::after  {
-		background-color: dodgerblue;
+		background-color: #56B4E9;
 	}
 	
 	select:focus + .focus {
@@ -243,7 +253,6 @@
 		left: -1px;
 		right: -1px;
 		bottom: -1px;
-		border: 2px solid goldenrod;
 		border-radius: inherit;
 	}
 	
@@ -983,7 +992,8 @@
 	
 	.item-characteristics-portrait .button-right-arrow:hover,
 	.item-characteristics-portrait .button-left-arrow:hover {
-		background-color: #F0E442;	
+		background-color: #F0E442;
+		border: solid 1px #E69F00;	
 	}
 	
 	
@@ -1005,7 +1015,7 @@
 	/* Alternate styling for rule cards instead of portraits */
 	.item-portrait-00 {
 		background-color: white;
-		border: solid 2px gray;
+		border: solid 2px #8A8A8A;
 		height: 250px;
 		width: 250px;
 		margin-left: 5px;
@@ -1188,7 +1198,7 @@
 	
 	.item-characteristics-turn-tracker {
 		grid-area: turnTracker;
-		width: 68px;
+		width: 72px;
 		height: 22px;
 		padding: 0px;
 		line-height: 20px;
@@ -1348,7 +1358,7 @@
 		width: 450px;
 		height: 308px;
 		margin: 0px;
-		border: solid 2px goldenrod;
+		border: solid 2px #f0c566;
 		border-radius: 3px;
 	}
 	
@@ -1365,6 +1375,7 @@
 		flex-direction: row;
 		justify-content: flex-start;
 	}
+	
 	
 	/* --------------------------------------------------- */
 	/* Version Info                                        */
@@ -1383,7 +1394,7 @@
 	}
 	
 	.item-version-information input[readonly] {
-		background-color: #fff990;
+		background-color: transparent;
 		color: black;
 		max-width: 35px;
 		padding-bottom: 1px;
@@ -1438,7 +1449,6 @@
 	}
 	
 	.buttonTracker {
-		/* background-color: #4c9cc9; */
 		background-color: dodgerblue;
 		padding-left: 3px;
 		padding-right: 3px;
@@ -1634,38 +1644,9 @@
 	}
 	
 	.buttonRollPower {
-		/* background-color: #9184E2; lighter than mediumslateblue */
 		background-color: #CC79A7;
 		border-radius: 2.5px;
 	}
-	
-	/* The d6 of dicefontd6 doesn't look good. Let's hold off for a better idea or stick with the label 'Roll' on the buttons.
-	
-	.buttonRollNormalAttack::before {
-		font-family: 'dicefontd6';
-		font-size: 16px;
-		content: 'F';
-	} */
-	
-	.portrait-display-button-left,
-	.portrait-display-button-right {
-		background-color: orange;
-		padding-top: 4px;
-		padding-bottom: 4px;
-		margin: 4px 2px;
-		padding-left: 14px;
-		padding-right: 14px;
-		vertical-align: middle;
-		text-align: center;
-	}
-	
-	.portrait-display-button-left:hover,
-	.portrait-display-button-right:hover {
-		color: black;
-		background-color: limegreen;
-		text-align: center;
-	}
-	
 	
 	/* --------------------------------------------------- */
 	/* Custom Checkbox used for options                    */
@@ -2258,7 +2239,7 @@
 		text-align: left;
 		font-size: 13px;
 		font-weight: bold;
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 	}
 	
 	.item-talent-heading input[type=number] {
@@ -2267,7 +2248,7 @@
 		margin: 0px;
 		padding-right: 0px;
 		text-align: right;
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 	}
 	
 	.item-talent-heading h1 {
@@ -2281,7 +2262,7 @@
 		max-width: 314px;
 		max-height: 36px;
 		padding: 3px;
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 		margin-bottom: 6px;
 	}
 	
@@ -2323,7 +2304,7 @@
 		text-align: left;
 		font-size: 13px;
 		font-weight: bold;
-		border: solid 1px #99d2f1;
+		border: solid 1px #88caef;
 	}
 	
 	.item-complication-heading input[type=number] {
@@ -2332,7 +2313,7 @@
 		margin: 0px;
 		padding-right: 0px;
 		text-align: right;
-		border: solid 1px #99d2f1;
+		border: solid 1px #88caef;
 	}
 	
 	.item-complication-heading h1 {
@@ -2346,7 +2327,7 @@
 		max-width: 314px;
 		max-height: 54px;
 		padding: 3px;
-		border: solid 1px #99d2f1;
+		border: solid 1px #88caef;
 		margin-bottom: 6px;
 	}
 	
@@ -2449,7 +2430,6 @@
 	
 	.flex-container-powers-left textarea,
 	.flex-container-powers-right textarea {
-		/* color: gray;  */
 		height: 54px;
 		padding: 3px;
 		margin: 0px;
@@ -2459,11 +2439,9 @@
 	
 	.flex-container-powers-left textarea {
 		max-width: 316px;
-		/* border: solid 1px #bbe1f6; */
 	}
 	
 	.flex-container-powers-right textarea {
-		/* border: solid 1px #F0E442; */
 		max-width: 315px;
 	}
 	
@@ -2513,11 +2491,6 @@
 		text-align: center;
 	}
 	
-	/* .subitem-flex-power-heading-left input[type=text]:nth-child(4) {
-		background: #ddf0fa;
-		border: solid 1px #99d2f1;
-	} */
-	
 	.subitem-flex-power-heading-left select,
 	.subitem-flex-power-heading-right select {
 		font-size: 13px;
@@ -2565,8 +2538,6 @@
 	/* Powers Tab: Left Powers and general to right. */
 	.flex-container-powers-left {
 		grid-area: leftPowers;
-		/* border: 3px solid lightcyan;
-		background: #99d2f1; */
 		border: 3px solid #66bbeb;
 		background: #aad9f4;
 	}
@@ -2577,22 +2548,22 @@
 	
 	.flex-container-powers-left input[readonly]{
 		background: #ddf0fa;
-		border: solid 1px #99d2f1;
+		border: solid 1px #88caef;
 		line-height: 1.0;
 	}
 	
 	.flex-container-powers-left textarea{
-		border: 1px solid #99d2f1;
+		border: 1px solid #88caef;
 	}
 	
 	.subitem-flex-power-heading-left input[type=text]{
-		border: solid 1px #99d2f1;
+		border: solid 1px #88caef;
 		max-width: 28px;
 	}
 	
 	.subitem-flex-power-effect-left input[type=text],
 	.subitem-flex-power-effect-left input[type=number]{
-		border: solid 1px #99d2f1;
+		border: solid 1px #88caef;
 	}
 	
 	.subitem-flex-power-points-block-left,
@@ -2615,7 +2586,6 @@
 		max-width: 38px;
 		text-align: center;
 		padding: 0px;
-		/* border: none; */
 	}
 	
 	.subitem-flex-power-limitations-left,
@@ -2658,27 +2628,27 @@
 	
 	.flex-container-powers-right input[readonly]{
 		background: #faf6c6;
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 		line-height: 1.0;
 	}
 	
 	.flex-container-powers-right textarea{
-		border: 1px solid #F0E442;
+		border: 1px solid #f2cf7f;
 	}
 	
 	.subitem-flex-power-heading-right input[type=text] {
 		max-width: 28px;
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 	}
 	
 	.subitem-flex-power-effect-right input[type=text],
 	.subitem-flex-power-effect-right input[type=number]{
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 	}
 	
 	.subitem-flex-power-points-block-right input[type=number] {
 		/* Active, Real Cost */
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 	}
 	
 	.subitem-flex-power-points-block-right input[readonly] {
@@ -2689,7 +2659,7 @@
 	
 	.subitem-flex-power-limitations-right input[type=number]{
 		/* Advantages, limitations */
-		border: solid 1px #F0E442;
+		border: solid 1px #f2cf7f;
 		min-width: 50px;
 	}
 	
@@ -2740,16 +2710,16 @@
 	.subitem-flex-power-heading-right .power-mover-plus-minus-button button.buttonPlus,
 	.subitem-flex-power-heading-right .power-mover-plus-minus-button button.buttonMinus,
 	.talent-mover-plus-minus-button button.buttonPlus,
-	.talent-mover-plus-minus-button button.buttonMinus,
-	.complication-mover-plus-minus-button button.buttonPlus,
-	.complication-mover-plus-minus-button button.buttonMinus {
+	.talent-mover-plus-minus-button button.buttonMinus {
 		background-color: white; /* Color Mover */
 		border: solid 1px #a1a1a1; /* Color Mover Border */
 		color: #8A8A8A; /* Color Mover Chevron */
 	}
 	
 	.subitem-flex-power-heading-left .power-mover-plus-minus-button button.buttonPlus,
-	.subitem-flex-power-heading-left .power-mover-plus-minus-button button.buttonMinus {
+	.subitem-flex-power-heading-left .power-mover-plus-minus-button button.buttonMinus,
+	.complication-mover-plus-minus-button button.buttonPlus,
+	.complication-mover-plus-minus-button button.buttonMinus {
 		background-color: white; /* Color Mover */
 		border: solid 1px #56B4E9; /* Color Mover Border */
 		color: #56B4E9; /* Color Mover Chevron */
@@ -4063,6 +4033,7 @@
 	.item-tab-gear-slide-container .button-right-arrow:hover,
 	.item-tab-gear-slide-container .button-left-arrow:hover {
 		background-color: #F0E442;
+		border: solid 1px #8A8A8A;
 		color: black;
 	}
 	
@@ -4790,7 +4761,6 @@
 		-moz-user-select: none;
 		-ms-user-select: none;
 		user-select: none;
-		/* background-color: #E69F00; */
 	}
 	
 	/* Hide the browser's default radio button */
@@ -4931,7 +4901,6 @@
 	
 	.sheet-rolltemplate-custom-power-attack .sheet-header {
 		background-color: #CC79A7;
-		/* background-color: #56B4E9; */
 		/* change text-align to center to center the header text */
 		text-align: left;
 		color: var(--header-text-color);
@@ -5400,7 +5369,6 @@
 	}
 	
 	.custom-button-triangle:before {
-		/* border-left: 10px solid #FFF9CF; /* Color Triangle */
 		border-left: 10px solid white; /* Color Triangle */
 	}
 	
@@ -5417,7 +5385,6 @@
 	.custom-button-triangle-alt,
 	.custom-button-triangle-alt:hover,
 	.custom-button-triangle-alt:after {
-		/* border-left: 12px solid #8A8A8A; Color Triangle Alt Border */
 		border-left: 12px solid #56B4E9; /* Color Triangle Alt Border */
 	}
 	

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -951,10 +951,10 @@
 		width: 100%;
 		height: auto;
 		margin-left: 7px;
-		border-right: solid gray 1px;
-		border-bottom: solid gray 1px;
-		border-left: solid darkgray 1px;
-		border-top: solid darkgray 1px;
+		border-right: solid #959595 1px;
+		border-bottom: solid #959595 1px;
+		border-left: solid #adadad 1px;
+		border-top: solid #adadad 1px;
 	}
 	
 	.item-characteristics-portrait .button-left-arrow,
@@ -983,7 +983,7 @@
 	
 	.item-characteristics-portrait .button-right-arrow:hover,
 	.item-characteristics-portrait .button-left-arrow:hover {
-		background-color: gold;	
+		background-color: #F0E442;	
 	}
 	
 	
@@ -1073,7 +1073,7 @@
 	
 	.item-powers-health {
 		padding: 6px;
-		width: 318px;
+		width: 319px;
 		height: 56px;
 		margin: 0px;
 		align-items: center;
@@ -1081,7 +1081,7 @@
 		justify-content: space-between;
 		flex-direction: row;
 		background-color: royalblue;
-		border: 3px solid #fff990;
+		border: 3px solid #f6ee8d;
 		border-radius: 5px;
 	}
 	
@@ -1404,7 +1404,7 @@
 	}
 		
 	.buttonRecover {
-		background-color: darkseagreen;
+		background-color: #19a781;
 		padding-top: 4px;
 		padding-bottom: 4px;
 		margin-left: 2px;
@@ -1421,7 +1421,7 @@
 	}
 	
 	.buttonReset {
-		background-color: orange;
+		background-color: #E69F00;
 		padding-top: 4px;
 		padding-bottom: 4px;
 		margin-left: 2px;
@@ -1438,6 +1438,7 @@
 	}
 	
 	.buttonTracker {
+		/* background-color: #4c9cc9; */
 		background-color: dodgerblue;
 		padding-left: 3px;
 		padding-right: 3px;
@@ -1542,6 +1543,8 @@
 		border-radius: 2.5px;
 	}
 	
+	.item-talent-heading .buttonRollShow,
+	.item-complication-heading .buttonRollShow,
 	.item-flex-maneuver .buttonRollAttack,
 	.item-flex-maneuver .buttonRollShow,
 	.item-flex-maneuver .buttonManeuverEND {
@@ -1704,29 +1707,29 @@
 		left: 0;
 		height: 20px;
 		width: 20px;
-		background-color: gold;
+		background-color: #f2cf7f;
 	}
 	
 	/* On mouse-over, add a grey background color */
 	.container-checkbox:hover input ~ .checkmark,
 	.container-checkbox-small:hover input ~ .checkmark-small {
-		background-color: goldenrod;
-		border: solid 1px darkgoldenrod;
+		background-color: #edbb4c;
+		border: solid 1px #E69F00;
 	}
 	
 	.container-checkbox-small-gray:hover input ~ .checkmark-small-gray {
-		background-color: lightsteelblue;
-		border: solid 1px darkgray;
+		background-color: #56B4E9;
+		border: solid 1px #4490ba;
 	}
 	
 	/* When the checkbox is checked, add a gold background */
 	.container-checkbox input:checked ~ .checkmark,
 	.container-checkbox-small input:checked ~ .checkmark-small {
-		background-color: gold;
+		background-color: #f2cf7f;
 	}
 	
 	.container-checkbox-small-gray input:checked ~ .checkmark-small-gray {
-		background-color: lightgray;
+		background-color: #99d2f1;
 	}
 	
 	/* Create the checkmark/indicator (hidden when not checked) */
@@ -1735,14 +1738,14 @@
 		content: "";
 		position: absolute;
 		display: none;
-		border: solid 1px darkgoldenrod;
+		border: solid 1px #E69F00;
 	}
 	
 	.checkmark-small-gray:after {
 		content: "";
 		position: absolute;
 		display: none;
-		border: solid 1px gray;
+		border: solid 1px #56B4E9;
 	}
 	
 	/* Show the checkmark when checked */
@@ -1793,7 +1796,7 @@
 		left: 0;
 		height: 15px;
 		width: 15px;
-		background-color: gold;
+		background-color: #f2cf7f;
 	}
 	
 	.checkmark-small-gray {
@@ -1802,7 +1805,7 @@
 		left: 0;
 		height: 15px;
 		width: 15px;
-		background-color: lightgray;
+		background-color: #99d2f1;
 	}
 	
 	/* Style the checkmark/indicator */
@@ -2223,10 +2226,10 @@
 		display: flex;
 		justify-content: space-between;
 		flex-direction: column;
-		border: 3px solid #fff990;
+		border: 3px solid #f0c566;
 		border-radius: 5px;
 		width: 321px;
-		background: #F0E442;
+		background: #f4ec7a;
 		height: 630px;
 		padding: 5px;
 		padding-bottom: 0px;
@@ -2255,7 +2258,7 @@
 		text-align: left;
 		font-size: 13px;
 		font-weight: bold;
-		border: solid 1px darkgray;
+		border: solid 1px #F0E442;
 	}
 	
 	.item-talent-heading input[type=number] {
@@ -2264,7 +2267,7 @@
 		margin: 0px;
 		padding-right: 0px;
 		text-align: right;
-		border: solid 1px darkgray;
+		border: solid 1px #F0E442;
 	}
 	
 	.item-talent-heading h1 {
@@ -2278,7 +2281,7 @@
 		max-width: 314px;
 		max-height: 36px;
 		padding: 3px;
-		border: solid 1px darkgray;
+		border: solid 1px #F0E442;
 		margin-bottom: 6px;
 	}
 	
@@ -2289,10 +2292,10 @@
 		display: flex;
 		justify-content: space-between;
 		flex-direction: column;
-		border: 3px solid lightcyan; /* Color Block Alt */
+		border: 3px solid #66bbeb; /* Color Block Alt */
 		border-radius: 5px;
 		width: 321px;
-		background: #99d2f1;
+		background: #aad9f4;
 		height: 630px;
 		padding: 5px;
 		padding-bottom: 0px;
@@ -2320,7 +2323,7 @@
 		text-align: left;
 		font-size: 13px;
 		font-weight: bold;
-		border: solid 1px darkgray;
+		border: solid 1px #99d2f1;
 	}
 	
 	.item-complication-heading input[type=number] {
@@ -2329,7 +2332,7 @@
 		margin: 0px;
 		padding-right: 0px;
 		text-align: right;
-		border: solid 1px darkgray;
+		border: solid 1px #99d2f1;
 	}
 	
 	.item-complication-heading h1 {
@@ -2343,7 +2346,7 @@
 		max-width: 314px;
 		max-height: 54px;
 		padding: 3px;
-		border: solid 1px darkgray;
+		border: solid 1px #99d2f1;
 		margin-bottom: 6px;
 	}
 	
@@ -2446,7 +2449,7 @@
 	
 	.flex-container-powers-left textarea,
 	.flex-container-powers-right textarea {
-		color: gray; 
+		/* color: gray;  */
 		height: 54px;
 		padding: 3px;
 		margin: 0px;
@@ -2456,10 +2459,11 @@
 	
 	.flex-container-powers-left textarea {
 		max-width: 316px;
+		/* border: solid 1px #bbe1f6; */
 	}
 	
 	.flex-container-powers-right textarea {
-		border: solid 1px goldenrod;
+		/* border: solid 1px #F0E442; */
 		max-width: 315px;
 	}
 	
@@ -2509,6 +2513,11 @@
 		text-align: center;
 	}
 	
+	/* .subitem-flex-power-heading-left input[type=text]:nth-child(4) {
+		background: #ddf0fa;
+		border: solid 1px #99d2f1;
+	} */
+	
 	.subitem-flex-power-heading-left select,
 	.subitem-flex-power-heading-right select {
 		font-size: 13px;
@@ -2523,6 +2532,7 @@
 	.subitem-flex-power-effect-right input[type=text]:nth-child(2){
 		max-width: 130px;
 		max-height: 23px;
+		margin-left: 1px;
 	}
 	
 	/* Dice */
@@ -2555,8 +2565,10 @@
 	/* Powers Tab: Left Powers and general to right. */
 	.flex-container-powers-left {
 		grid-area: leftPowers;
-		border: 3px solid lightcyan;
-		background: #99d2f1;
+		/* border: 3px solid lightcyan;
+		background: #99d2f1; */
+		border: 3px solid #66bbeb;
+		background: #aad9f4;
 	}
 	
 	.flex-container-powers-left textarea {
@@ -2564,23 +2576,23 @@
 	}
 	
 	.flex-container-powers-left input[readonly]{
-		background: lightcyan;
-		border: solid 1px #89abb9;
+		background: #ddf0fa;
+		border: solid 1px #99d2f1;
 		line-height: 1.0;
 	}
 	
 	.flex-container-powers-left textarea{
-		border: 1px solid #89ABB9;
+		border: 1px solid #99d2f1;
 	}
 	
 	.subitem-flex-power-heading-left input[type=text]{
-		border: solid 1px #89ABB9;
+		border: solid 1px #99d2f1;
 		max-width: 28px;
 	}
 	
 	.subitem-flex-power-effect-left input[type=text],
 	.subitem-flex-power-effect-left input[type=number]{
-		border: solid 1px #89ABB9;
+		border: solid 1px #99d2f1;
 	}
 	
 	.subitem-flex-power-points-block-left,
@@ -2595,7 +2607,7 @@
 	
 	.subitem-flex-power-points-block-left input[type=number] {
 		/* Active, Real Cost */
-		border: solid 1px #89ABB9;
+		border: solid 1px #99d2f1;
 	}
 	
 	.subitem-flex-power-points-block-left input[readonly] {
@@ -2603,6 +2615,7 @@
 		max-width: 38px;
 		text-align: center;
 		padding: 0px;
+		/* border: none; */
 	}
 	
 	.subitem-flex-power-limitations-left,
@@ -2617,7 +2630,7 @@
 	
 	.subitem-flex-power-limitations-left input[type=number]{
 		/* Advantages, limitations */
-		border: solid 1px #89ABB9;
+		border: solid 1px #99d2f1;
 		min-width: 50px;
 	}
 	
@@ -2635,8 +2648,8 @@
 	/* Powers Tab: Right Powers */
 	.flex-container-powers-right {
 		grid-area: rightPowers;
-		border: 3px solid #fff990;
-		background: #F0E442; /* Color Block */
+		border: 3px solid #f0c566;
+		background: #f4ec7a; /* Color Block */
 	}
 	
 	.flex-container-powers-right textarea {
@@ -2644,28 +2657,28 @@
 	}
 	
 	.flex-container-powers-right input[readonly]{
-		background: #fff990;
-		border: solid 1px goldenrod;
+		background: #faf6c6;
+		border: solid 1px #F0E442;
 		line-height: 1.0;
 	}
 	
 	.flex-container-powers-right textarea{
-		border: 1px solid goldenrod;
+		border: 1px solid #F0E442;
 	}
 	
 	.subitem-flex-power-heading-right input[type=text] {
 		max-width: 28px;
-		border: solid 1px goldenrod;
+		border: solid 1px #F0E442;
 	}
 	
 	.subitem-flex-power-effect-right input[type=text],
 	.subitem-flex-power-effect-right input[type=number]{
-		border: solid 1px goldenrod;
+		border: solid 1px #F0E442;
 	}
 	
 	.subitem-flex-power-points-block-right input[type=number] {
 		/* Active, Real Cost */
-		border: solid 1px goldenrod;
+		border: solid 1px #F0E442;
 	}
 	
 	.subitem-flex-power-points-block-right input[readonly] {
@@ -2676,7 +2689,7 @@
 	
 	.subitem-flex-power-limitations-right input[type=number]{
 		/* Advantages, limitations */
-		border: solid 1px goldenrod;
+		border: solid 1px #F0E442;
 		min-width: 50px;
 	}
 	
@@ -2704,15 +2717,14 @@
 		margin-left:3px;
 	}
 	
-	.power-mover-plus-minus-button button.buttonPlus,
-	.power-mover-plus-minus-button button.buttonMinus,
+	.subitem-flex-power-heading-right .power-mover-plus-minus-button button.buttonPlus,
+	.subitem-flex-power-heading-right .power-mover-plus-minus-button button.buttonMinus,
+	.subitem-flex-power-heading-left .power-mover-plus-minus-button button.buttonPlus,
+	.subitem-flex-power-heading-left .power-mover-plus-minus-button button.buttonMinus,
 	.talent-mover-plus-minus-button button.buttonPlus,
 	.talent-mover-plus-minus-button button.buttonMinus,
 	.complication-mover-plus-minus-button button.buttonPlus,
 	.complication-mover-plus-minus-button button.buttonMinus {
-		background-color: lemonchiffon; /* Color Mover */
-		border: solid 1px silver; /* Color Mover Border */
-		color: slategray; /* Color Mover Chevron */
 		padding-left: 4px;
 		padding-right: 4px;
 		padding-top: 1px;
@@ -2723,6 +2735,24 @@
 		line-height: 1.25ch;
 		border-radius: 0px;
 		max-width: 10px;
+	}
+	
+	.subitem-flex-power-heading-right .power-mover-plus-minus-button button.buttonPlus,
+	.subitem-flex-power-heading-right .power-mover-plus-minus-button button.buttonMinus,
+	.talent-mover-plus-minus-button button.buttonPlus,
+	.talent-mover-plus-minus-button button.buttonMinus,
+	.complication-mover-plus-minus-button button.buttonPlus,
+	.complication-mover-plus-minus-button button.buttonMinus {
+		background-color: white; /* Color Mover */
+		border: solid 1px #a1a1a1; /* Color Mover Border */
+		color: #8A8A8A; /* Color Mover Chevron */
+	}
+	
+	.subitem-flex-power-heading-left .power-mover-plus-minus-button button.buttonPlus,
+	.subitem-flex-power-heading-left .power-mover-plus-minus-button button.buttonMinus {
+		background-color: white; /* Color Mover */
+		border: solid 1px #56B4E9; /* Color Mover Border */
+		color: #56B4E9; /* Color Mover Chevron */
 	}
 	
 	.power-mover-plus-minus-button button.buttonPlus span,
@@ -2767,8 +2797,8 @@
 		padding-top: 6px;
 		margin-bottom: 0px;
 		font-size: 16px;
-		background-color: gold;
-		border: 3px solid #fff990;
+		background-color: #f2cf7f;
+		border: 3px solid #f6ee8d;
 		border-radius: 5px;
 		justify-content: middle;
 		min-height: 795px;
@@ -2812,8 +2842,8 @@
 		justify-content: space-evenly;
 		max-width: 358px;
 		margin-left: 5px;
-		background-color: #f7f1a0; 
-		border: solid 2px goldenrod;
+		background-color: #f6ee8d; 
+		border: solid 2px #ebb232;
 		border-radius: 3px;
 		line-height: 1.10;
 		padding-left: 1px;
@@ -2845,7 +2875,7 @@
 		padding-right: 0px;
 		margin-top: 0px;
 		margin-bottom: 0px;
-		border: solid 1px palegoldenrod;
+		border: solid 1px #F0E442;
 		max-height: 22px;
 	}
 	
@@ -2853,7 +2883,7 @@
 	.item-skillsTab-flex-container-skills-group02 input[readonly],
 	.item-skillsTab-flex-container-skills-group03 input[readonly] {
 		text-align: center;
-		background-color: #fff990; 
+		background-color: #f6ee8d; 
 		border: transparent;
 		max-width: 24px;
 	}
@@ -2870,7 +2900,7 @@
 		margin-right: 1px;
 		padding-left: 1px;
 		padding-right: 1px;
-		border: solid 1px palegoldenrod;
+		border: solid 1px #F0E442;
 	}
 	
 	/* Sub-Item: Flex containers for rows */
@@ -2980,8 +3010,8 @@
 		padding-right: 4px;
 		padding-bottom: 3px;
 		padding-top: 0px;
-		background-color: #f7f1a0; 
-		border: solid 2px goldenrod;
+		background-color: #f6ee8d; 
+		border: solid 2px #ebb232;
 		border-radius: 3px;
 		line-height: 1.10;
 	}
@@ -3005,7 +3035,7 @@
 		margin-left: 4px;
 		padding-left: 1px;
 		padding-right: 1px;
-		border: solid 1px palegoldenrod;
+		border: solid 1px #F0E442;
 	}
 	
 	.subitem-skillsTab-flex-container-combat-skills-names h1 {
@@ -3053,7 +3083,7 @@
 		margin-right: 5px;
 		padding-bottom: 1px;
 		max-height: 22px;
-		border: solid 1px palegoldenrod;
+		border: solid 1px #F0E442;
 	}
 	
 	.subitem-skillsTab-flex-container-combat-skills-levels h1 {
@@ -3113,7 +3143,7 @@
 	
 	.subitem-skillsTab-flex-container-combat-skills-costs input[readonly] {
 		text-align: center;
-		background-color: #fff990;
+		background-color: #f6ee8d;
 		max-width: 30px;
 		margin-left: 5px;
 	}
@@ -3125,8 +3155,8 @@
 		flex-direction: column;
 		justify-content: space-between;
 		max-width: 292px;
-		background-color: #f7f1a0; 
-		border: solid 2px goldenrod;
+		background-color: #f6ee8d; 
+		border: solid 2px #ebb232;
 		border-radius: 3px;
 		line-height: 1.10;
 		padding-left: 4px;
@@ -3177,12 +3207,12 @@
 		padding-left: 2px;
 		min-width: 140px;
 		margin-right: 0px;
-		border: solid 1px palegoldenrod;	
+		border: solid 1px #F0E442;	
 	}
 	
 	.subitem-skillsTab-flex-container-language input[readonly] {
 		text-align: center;
-		background-color: #f7f1a0;
+		background-color: #f6ee8d;
 		max-width: 22px;
 		margin-right: 0px;
 		margin-left: 3px;
@@ -3215,14 +3245,14 @@
 		max-width: 295px;
 		padding-left: 5px;
 		grid-gap:0px;
-		background-color: #f7f1a0; 
-		border: solid 2px goldenrod;
+		background-color: #f6ee8d; 
+		border: solid 2px #ebb232;
 		border-radius: 3px;
 		max-height: 251px;
 	}
 	
 	.item-skillsTab-grid-container-skill-enhancers input[readonly]{
-		background-color: #fff990;
+		background-color: #f6ee8d;
 		text-align: center;
 		height: 18px;
 		max-width: 30px;
@@ -3283,7 +3313,7 @@
 	}
 	
 	.subitem-skillsTab-flex-container-skill-enhancers-levels input[type=number]{
-		border: solid 1px palegoldenrod;
+		border: solid 1px #F0E442;
 		height: 19px;
 		margin-bottom: 2px;
 	}
@@ -3318,7 +3348,7 @@
 		padding-left: 2px;
 		font-size: 16px;
 		background-color: royalblue;
-		border: 3px solid #fff990;
+		border: 3px solid #f6ee8d;
 		border-radius: 5px;
 		justify-content: middle;
 		min-height: 801px;
@@ -3883,7 +3913,7 @@
 		padding: 4px;
 		padding-top: 3px;
 		background-color: #cce8f8;
-		border: solid 2px #c4c4c4;
+		border: solid 2px #88caef;
 		border-radius: 3px;
 		height: 367px;
 	}
@@ -4044,7 +4074,7 @@
 		margin-left: 0px;
 		margin-bottom: 0px;
 		background-color: #cce8f8;
-		border: solid 2px #c4c4c4;
+		border: solid 2px #88caef;
 		border-radius: 3px;
 	}
 	
@@ -4083,7 +4113,8 @@
 		margin: 0px;
 		height: 22px;
 		text-align: left;
-		padding-left: 1px;
+		font-weight: bold;
+		padding-left: 2px;
 		border: solid 1px #bbe1f6;
 	}
 	
@@ -4465,7 +4496,7 @@
 		background-color: #cce8f8;
 		margin-left: 0px;
 		margin-bottom: 0px;
-		border: solid 2px #c4c4c4;
+		border: solid 2px #88caef;
 		border-radius: 3px;
 	}
 	
@@ -5353,7 +5384,7 @@
 		border-bottom: 8px solid transparent;
 		border-right: 8px solid transparent;
 		top: 0px;
-		left: 4px;
+		left: 5px;
 	}
 	
 	.custom-button-triangle:before,
@@ -5370,23 +5401,24 @@
 	
 	.custom-button-triangle:before {
 		/* border-left: 10px solid #FFF9CF; /* Color Triangle */
-		border-left: 9px solid #FFF9CF; /* Color Triangle */
+		border-left: 10px solid white; /* Color Triangle */
 	}
 	
 	.custom-button-triangle-alt:before {
-		border-left: 9px solid white; /* Color Triangle Alt */
+		border-left: 10px solid white; /* Color Triangle Alt */
 	}
 	
 	.custom-button-triangle,
 	.custom-button-triangle:hover,
 	.custom-button-triangle:after {
-		border-left: 12px solid #b8b8b8; /* Color Triangle Border */
+		border-left: 12px solid #a1a1a1; /* Color Triangle Border */
 	}
 	
 	.custom-button-triangle-alt,
 	.custom-button-triangle-alt:hover,
 	.custom-button-triangle-alt:after {
-		border-left: 12px solid #8A8A8A; /* Color Triangle Alt Border */
+		/* border-left: 12px solid #8A8A8A; Color Triangle Alt Border */
+		border-left: 12px solid #56B4E9; /* Color Triangle Alt Border */
 	}
 	
 	.subitem-flex-container-martial-row .custom-expand-button-container button.buttonExpand {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1354,7 +1354,7 @@ select:focus + .focus {
 	background-color: #fff990;
 	margin: 5px;
 	width: 450px;
-	height: 282px;
+	height: 308px;
 	margin: 0px;
 	border: solid 2px goldenrod;
 	border-radius: 3px;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1547,6 +1547,7 @@ select:focus + .focus {
 	max-width: 38px;
 }
 
+/* Change attack button color to indicate normal damage. */
 .weapon-normal-damage01[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon01"]:not(:hover),
 .weapon-normal-damage02[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon02"]:not(:hover),
 .weapon-normal-damage03[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon03"]:not(:hover),
@@ -1556,6 +1557,7 @@ select:focus + .focus {
 	background-color: #009E73;
 }
 
+/* Change maneuver attack button color to indicate normal damage. */
 .maneuver-normal-damage01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
 .maneuver-normal-damage02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
 .maneuver-normal-damage03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
@@ -1567,6 +1569,20 @@ select:focus + .focus {
 .maneuver-normal-damage09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
 {
 	background-color: #009E73;
+}
+
+/* Change maneuver attack button color to indicate non-damaging defensive function. */
+.maneuver-block01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
+.maneuver-block02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
+.maneuver-block03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
+.maneuver-block04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
+.maneuver-block05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
+.maneuver-block06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
+.maneuver-block07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
+.maneuver-block08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
+.maneuver-block09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
+{
+	background-color: #56B4E9;;
 }
 
 .buttonRollActivate {
@@ -4098,13 +4114,13 @@ select:focus + .focus {
 
 .subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(1) {
 	padding-left: 2px;
-	width: 260px;
+	width: 261px;
 }
 
 .subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(2),
 .subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(3) {
 	text-align: center;
-	width: 40px;
+	width: 39px;
 }
 
 .subitem-tab-gear-slide-flex-container-maneuvers-heading,

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -3980,7 +3980,7 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
-		margin-top: 7px;
+		margin-top: 6px;
 		max-height: 310px;
 		min-height: 270px;
 	}
@@ -4227,7 +4227,7 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
-		height: 47px;
+		height: 49px;
 	}
 	
 	.subitem-flex-container-martial-cv-damage-row {
@@ -4276,9 +4276,8 @@
 		margin-left: 27px;
 		margin-right: 0px;
 		min-width: 374px;
-		padding-bottom: 4px;
+		margin-bottom: 4px;
 		align-items: center;
-		background-color: yellowgreen;
 	}
 	
 	.subitem-tab-gear-slide-flex-container-standard-attack h1 {
@@ -4293,7 +4292,6 @@
 	}
 	
 	/* Range Modifier Table */
-	
 	.subitem-tab-gear-slide-flex-container-range-modifiers {
 		flex-direction: row;
 		display: flex;
@@ -4304,8 +4302,8 @@
 		margin-left: 0px;
 		padding-top: 0px;
 		padding-left: 5px;
-		margin-top: 13px;
-		margin-bottom: 0px;
+		margin-top: 8px;
+		margin-bottom: 2px;
 	}
 	
 	.subitem-tab-gear-slide-range-modifier-container-first,
@@ -5090,9 +5088,7 @@
 	.sheet-maneuver-expand-05,
 	.sheet-maneuver-expand-06,
 	.sheet-maneuver-expand-07,
-	.sheet-maneuver-expand-08,
-	.sheet-maneuver-expand-09,
-	.sheet-maneuver-expand-10 {
+	.sheet-maneuver-expand-08 {
 		display: none;
 	}
 	
@@ -5104,9 +5100,7 @@
 	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .sheet-maneuver-expand-05,
 	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .sheet-maneuver-expand-06,
 	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .sheet-maneuver-expand-07,
-	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08,
-	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .sheet-maneuver-expand-09,
-	.sheet-maneuver-toggle[value="maneuverExpand10"] ~ div.item-flex-maneuver .sheet-maneuver-expand-10 {
+	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08 {
 		display: block;
 	}
 
@@ -5165,8 +5159,7 @@
 	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05,
 	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06,
 	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07,
-	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08,
-	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09
+	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08
  	{
 		transform: rotate(90deg);
 	}
@@ -5196,8 +5189,7 @@
 	.sheet-maneuver-toggle:not([value="maneuverExpand05"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05:hover,
 	.sheet-maneuver-toggle:not([value="maneuverExpand06"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06:hover,
 	.sheet-maneuver-toggle:not([value="maneuverExpand07"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand09"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09:hover
+	.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover
 	{
 		transition: 0.25s;
 		transform: rotate(90deg);
@@ -5228,9 +5220,9 @@
 		top: -6px;
 		left: -11px; 
 	}
-
-	.subitem-tab-gear-slide-flex-container-standard-attack .custom-button-triangle:before {
-		border-left: 10px solid olivedrab
+	
+	.subitem-flex-container-martial-row .custom-expand-button-container button.buttonExpand {
+		height: 18px;
 	}
 	
 	.custom-button-triangle:hover,

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -4815,8 +4815,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense,
 .sheet-rolltemplate-custom-attack,
 .sheet-rolltemplate-custom-normal-attack,
-.sheet-rolltemplate-custom-maneuver,
-.sheet-rolltemplate-custom-normal-maneuver,
 .sheet-rolltemplate-custom-power-attack,
 .sheet-rolltemplate-custom-activate,
 .sheet-rolltemplate-custom-show {
@@ -4829,8 +4827,6 @@ select:focus + .focus {
 .withoutavatars .sheet-rolltemplate-custom-defense,
 .withoutavatars .sheet-rolltemplate-custom-attack,
 .withoutavatars .sheet-rolltemplate-custom-normal-attack,
-.withoutavatars .sheet-rolltemplate-custom-maneuver,
-.withoutavatars .sheet-rolltemplate-custom-normal-maneuver,
 .withoutavatars .sheet-rolltemplate-custom-power-attack,
 .withoutavatars .sheet-rolltemplate-custom-activate,
 .withoutavatars .sheet-rolltemplate-custom-show {
@@ -4843,8 +4839,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-container,
 .sheet-rolltemplate-custom-attack .sheet-container,
 .sheet-rolltemplate-custom-normal-attack .sheet-container,
-.sheet-rolltemplate-custom-maneuver .sheet-container,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
 .sheet-rolltemplate-custom-power-attack .sheet-container,
 .sheet-rolltemplate-custom-activate .sheet-container,
 .sheet-rolltemplate-custom-show .sheet-container {
@@ -4887,22 +4881,6 @@ select:focus + .focus {
 	padding: 5px;
 }
 
-.sheet-rolltemplate-custom-maneuver .sheet-header {
-	background-color: #D55E00
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom-normal-maneuver .sheet-header {
-	background-color: #009E73;
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
 .sheet-rolltemplate-custom-power-attack .sheet-header {
 	background-color: #CC79A7;
 	/* background-color: #56B4E9; */
@@ -4933,8 +4911,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-title,
 .sheet-rolltemplate-custom-attack .sheet-title,
 .sheet-rolltemplate-custom-normal-attack .sheet-title,
-.sheet-rolltemplate-custom-maneuver .sheet-title,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-title,
 .sheet-rolltemplate-custom-power-attack .sheet-title,
 .sheet-rolltemplate-custom-activate .sheet-title,
 .sheet-rolltemplate-custom-show .sheet-title {
@@ -4946,8 +4922,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-subtitle,
 .sheet-rolltemplate-custom-attack .sheet-subtitle,
 .sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
-.sheet-rolltemplate-custom-maneuver .sheet-subtitle,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-subtitle,
 .sheet-rolltemplate-custom-power-attack .sheet-subtitle,
 .sheet-rolltemplate-custom-activate .sheet-subtitle,
 .sheet-rolltemplate-custom-show .sheet-subtitle {
@@ -4961,8 +4935,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-container,
 .sheet-rolltemplate-custom-attack .sheet-container,
 .sheet-rolltemplate-custom-normal-attack .sheet-container,
-.sheet-rolltemplate-custom-maneuver .sheet-container,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-container,
 .sheet-rolltemplate-custom-power-attack .sheet-container,
 .sheet-rolltemplate-custom-activate .sheet-container,
 .sheet-rolltemplate-custom-show .sheet-container  {
@@ -4977,8 +4949,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-content,
 .sheet-rolltemplate-custom-attack .sheet-content,
 .sheet-rolltemplate-custom-normal-attack .sheet-content,
-.sheet-rolltemplate-custom-maneuver .sheet-content,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-content,
 .sheet-rolltemplate-custom-power-attack .sheet-content,
 .sheet-rolltemplate-custom-activate .sheet-content,
 .sheet-rolltemplate-custom-show .sheet-content {
@@ -4995,8 +4965,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-content > div,
 .sheet-rolltemplate-custom-attack .sheet-content > div,
 .sheet-rolltemplate-custom-normal-attack .sheet-content > div,
-.sheet-rolltemplate-custom-maneuver .sheet-content > div,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-content > div,
 .sheet-rolltemplate-custom-power-attack .sheet-content > div,
 .sheet-rolltemplate-custom-activate .sheet-content > div,
 .sheet-rolltemplate-custom-show .sheet-content > div {
@@ -5009,8 +4977,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-content .sheet-key,
 .sheet-rolltemplate-custom-attack .sheet-content .sheet-key,
 .sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-maneuver .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-content .sheet-key,
 .sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
 .sheet-rolltemplate-custom-activate .sheet-content .sheet-key,
 .sheet-rolltemplate-custom-show .sheet-content .sheet-key {
@@ -5026,8 +4992,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-value,
 .sheet-rolltemplate-custom-attack .sheet-value,
 .sheet-rolltemplate-custom-normal-attack .sheet-value,
-.sheet-rolltemplate-custom-maneuver .sheet-value,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-value,
 .sheet-rolltemplate-custom-power-attack .sheet-value,
 .sheet-rolltemplate-custom-activate .sheet-value,
 .sheet-rolltemplate-custom-show .sheet-value {
@@ -5045,10 +5009,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n),
 .sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
 .sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-maneuver .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-normal-maneuver .sheet-content :nth-child(4n),
 .sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
 .sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n),
 .sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n+3),
@@ -5064,8 +5024,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-desc,
 .sheet-rolltemplate-custom-attack .sheet-desc,
 .sheet-rolltemplate-custom-normal-attack .sheet-desc,
-.sheet-rolltemplate-custom-maneuver .sheet-desc,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-desc,
 .sheet-rolltemplate-custom-power-attack .sheet-desc,
 .sheet-rolltemplate-custom-activate .sheet-desc,
 .sheet-rolltemplate-custom-show .sheet-desc {
@@ -5081,8 +5039,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .inlinerollresult,
 .sheet-rolltemplate-custom-attack .inlinerollresult,
 .sheet-rolltemplate-custom-normal-attack .inlinerollresult,
-.sheet-rolltemplate-custom-maneuver .inlinerollresult,
-.sheet-rolltemplate-custom-normal-maneuver .inlinerollresult,
 .sheet-rolltemplate-custom-power-attack .inlinerollresult,
 .sheet-rolltemplate-custom-activate .inlinerollresult,
 .sheet-rolltemplate-custom-show .inlinerollresult {
@@ -5098,8 +5054,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult,
 .sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult,
 .sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult,
 .sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
 .sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult,
 .sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult {
@@ -5112,8 +5066,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullcrit,
 .sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
 .sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullcrit,
 .sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
 .sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullcrit,
 .sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullcrit {
@@ -5125,8 +5077,6 @@ select:focus + .focus {
 .sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullfail,
 .sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,
 .sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-normal-maneuver .sheet-template-wrapper .inlinerollresult.fullfail,
 .sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
 .sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullfail,
 .sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullfail {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -4268,45 +4268,6 @@
 		padding-left: 2px;
 	}
 	
-	/* Old Martial Details */
-
-	/* .subitem-flex-container-martial-cv-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: center;
-		max-height: 20px;
-		max-width: 42px;
-		padding: 0px 0px;
-	} */
-
-	/* .subitem-tab-gear-slide-flex-container-martial-details-row {
-		text-align: left;
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		max-height: 42px;
-		padding-left: 23px;
-		padding-right: 55px;
-		padding-top: 2px;
-	}
-	 */
-	/* .subitem-tab-gear-slide-flex-container-martial-name-and-points-row {
-		display: flex;
-		flex-direction: row;
-		justify-content: right;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-martial-name-and-points-row h1 {
-		padding-right: 0px;
-		padding-left: 30px;
-		padding-top: 4px;
-	}
-	
-	.subitem-tab-gear-slide-flex-container-martial-name-and-points-row input[type=number] {
-		max-width: 42px;
-	} */
-	
 	/* Basic Attack */
 	.subitem-tab-gear-slide-flex-container-standard-attack {
 		display: flex;
@@ -4317,6 +4278,7 @@
 		min-width: 374px;
 		padding-bottom: 4px;
 		align-items: center;
+		background-color: yellowgreen;
 	}
 	
 	.subitem-tab-gear-slide-flex-container-standard-attack h1 {
@@ -4329,6 +4291,8 @@
 		margin-right: 52px;
 		text-align: center;
 	}
+	
+	/* Range Modifier Table */
 	
 	.subitem-tab-gear-slide-flex-container-range-modifiers {
 		flex-direction: row;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1754,6 +1754,11 @@
 	}
 	
 	
+	.subitem-flex-container-martial-cv-damage-row .container-checkbox-small-gray {
+		margin-bottom: 14px;
+		padding: 0px;
+	}
+	
 	/* --------------------------------------------------- */
 	/* Custom Checkboxes used for turn segment indicators  */
 	/* Modification of custom checkbox above               */
@@ -4185,6 +4190,11 @@
 		justify-content: space-between;
 		max-height: 24px;
 	}
+	
+	.subitem-flex-container-martial-row .buttonRollNormalAttack {
+		margin-top: 1px;
+		margin-left: 3px;
+	}
 
 	.subitem-flex-container-martial-ocv-dcv {
 		display: flex;
@@ -4194,6 +4204,71 @@
 		max-width: 134px;
 		padding: 0px 0px;
 	}
+	
+	/* New Martial Details */
+	
+	.subitem-flex-container-martial-details-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: top;
+		max-width: 397px;
+		height: 48px;
+		padding-left: 23px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+	}
+	
+	.subitem-flex-container-martial-details-row .buttonRollShow {
+		margin-top: 3px;
+	}
+	
+	.subitem-flex-container-martial-details-column {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 47px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-height: 21px;
+		max-width: 374px;
+		align-items: center;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row h1:not(:first-child) {
+		padding-left: 8px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row input[type=number] {
+		height: 21px;
+		border: solid 1px lightgray;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row input[type=text] {
+		text-align: center;
+		height: 21px;
+		width: 60px;
+		padding-left: 2px;
+		padding-right: 4px;
+	}
+	
+	.subitem-martial-description-row {
+		max-height: 22px;
+		max-width: 374px;
+	}
+	
+	.subitem-martial-description-row input[type=text] {
+		width: 319px;
+		height: 22px;
+		text-align: left;
+		padding-left: 2px;
+	}
+	
+	/* Old Martial Details */
 
 	.subitem-flex-container-martial-cv-row {
 		display: flex;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -3997,20 +3997,17 @@
 		border: solid 1px lightgray;
 		margin: 0px;
 		padding: 0px;
-		padding-right: 0px;
 	}
 
 	.subitem-flex-container-martial-row input[type=number] {
 		text-align: right;
 		height: 22px;
 		border: solid 1px lightgray;
-		margin: 0px;
-		padding: 0px;
-		padding-right: 0px;
+		max-width: 38px;
 	}
 
 	.subitem-flex-container-martial-row input[type=text]:nth-child(2) {
-		width: 210px;
+		width: 220px;
 		margin: 0px;
 		height: 22px;
 		text-align: left;
@@ -4023,7 +4020,6 @@
 		text-align: center;
 		padding-left: 2px;
 		height: 18px;
-		margin: 0px;
 		margin-left: 3px;
 	}
 	
@@ -4177,9 +4173,9 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
-		width: 397px;
+		width: 399px;
 		padding-left: 4px;
-		margin-top: 3px;
+		margin-top: 2px;
 		padding-bottom: 2px;
 	}
 
@@ -4235,16 +4231,21 @@
 		flex-direction: row;
 		justify-content: space-between;
 		max-height: 21px;
-		max-width: 374px;
 		align-items: center;
+		padding-right: 1px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row h1 {
+		padding-right: 1px;
 	}
 	
 	.subitem-flex-container-martial-cv-damage-row h1:not(:first-child) {
-		padding-left: 8px;
+		padding-left: 7px;
 	}
 	
 	.subitem-flex-container-martial-cv-damage-row input[type=number] {
 		height: 21px;
+		max-width: 38px;
 		border: solid 1px lightgray;
 	}
 	
@@ -4262,7 +4263,7 @@
 	}
 	
 	.subitem-martial-description-row input[type=text] {
-		width: 319px;
+		width: 321px;
 		height: 22px;
 		text-align: left;
 		padding-left: 2px;
@@ -4273,10 +4274,10 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
-		margin-left: 27px;
-		margin-right: 0px;
-		min-width: 374px;
-		margin-bottom: 4px;
+		margin-left: 23px;
+		margin-bottom: 1px;
+		padding-right: 0px;
+		min-width: 376px;
 		align-items: center;
 	}
 	
@@ -4286,8 +4287,8 @@
 	
 	.subitem-tab-gear-slide-flex-container-standard-attack input[type=text] {
 		text-align: left;
-		margin-left: 93px;
-		margin-right: 52px;
+		margin-left: 96px;
+		margin-right: 41px;
 		text-align: center;
 	}
 	
@@ -4299,10 +4300,9 @@
 		width: 397px;
 		height: 30px;
 		padding: 0px;
-		margin-left: 0px;
-		padding-top: 0px;
 		padding-left: 5px;
-		margin-top: 8px;
+		margin-left: 0px;
+		margin-top: 11px;
 		margin-bottom: 2px;
 	}
 	

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -51,6 +51,14 @@ button[type=roll]::before{
 		-webkit-appearance: none;
 		margin: 0;
 	}
+	
+	/* Stop Safari from offering to autofill name fields. */
+	input::-webkit-contacts-auto-fill-button, 
+	input::-webkit-credentials-auto-fill-button {
+	  visibility: hidden;
+	  position: absolute;
+	  top: -50px;
+	}
 }
 
 @-moz-document url-prefix() {
@@ -1479,7 +1487,8 @@ select:focus + .focus {
 .buttonRollNormalAttack,
 .buttonRollShieldAttack,
 .buttonRollShow,
-.buttonRollPower {
+.buttonRollPower,
+.buttonManeuverEND {
 	padding-left: 3px;
 	padding-right: 3px;
 	text-align: center;
@@ -1539,12 +1548,18 @@ select:focus + .focus {
 	border-radius: 2.5px;
 }
 
-.item-flex-maneuver .buttonRollAttack {
+.item-flex-maneuver .buttonRollAttack,
+.item-flex-maneuver .buttonRollShow,
+.item-flex-maneuver .buttonManeuverEND {
 	margin-right: 3px;
-	margin-left: 61px;
+	margin-left: 3px;
 	border-radius: 3px;
 	min-width: 36px;
 	max-width: 38px;
+}
+
+.item-flex-maneuver .buttonRollAttack {
+	margin-left: 61px;
 }
 
 /* Change attack button color to indicate normal damage. */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1562,7 +1562,8 @@
 	.maneuver-normal-damage05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
 	.maneuver-normal-damage06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
 	.maneuver-normal-damage07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
-	.maneuver-normal-damage08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover)
+	.maneuver-normal-damage08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
+	.maneuver-normal-damage09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
 	{
 		background-color: #009E73;
 	}
@@ -5123,7 +5124,8 @@
 	.sheet-maneuver-expand-05,
 	.sheet-maneuver-expand-06,
 	.sheet-maneuver-expand-07,
-	.sheet-maneuver-expand-08 {
+	.sheet-maneuver-expand-08,
+	.sheet-maneuver-expand-09  {
 		display: none;
 	}
 	
@@ -5135,7 +5137,8 @@
 	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .sheet-maneuver-expand-05,
 	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .sheet-maneuver-expand-06,
 	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .sheet-maneuver-expand-07,
-	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08 {
+	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08,
+	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .sheet-maneuver-expand-09 {
 		display: block;
 	}
 
@@ -5194,7 +5197,8 @@
 	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05,
 	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06,
 	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07,
-	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08
+	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08,
+	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09
  	{
 		transform: rotate(90deg);
 	}
@@ -5224,7 +5228,8 @@
 	.sheet-maneuver-toggle:not([value="maneuverExpand05"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05:hover,
 	.sheet-maneuver-toggle:not([value="maneuverExpand06"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06:hover,
 	.sheet-maneuver-toggle:not([value="maneuverExpand07"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07:hover,
-	.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover
+	.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand09"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09:hover
 	{
 		transition: 0.25s;
 		transform: rotate(90deg);

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1,5423 +1,5394 @@
-/* --------------------------------------------------- */
-/* Roll20-specific styling                             */
-/* --------------------------------------------------- */
-
-.charsheet {
-	background: white;
-}
-
-body.sheet-darkmode .charsheet {
-	background: #1f1f1f;
-}
-
-/* Roll20 Roll Button re-styling, Thanks to Scott C. */
-
-button[type=roll] {
-	/* Override Roll20 default styling */
-	border: none;
-	text-shadow: none;
-	line-height: 14px;
-	background-image: none;
-	box-shadow: none;
+	/* --------------------------------------------------- */
+	/* Roll20-specific styling                             */
+	/* --------------------------------------------------- */
 	
-	/* Set global border radius of 'Roll' buttons here. */
-	border-radius: 3px;
-	
-	/* Set global font weight and size here. */
-	font-style: normal;
-	font-weight: bold;
-	font-size: 13px !important;
-}
-
-button[type=roll]::before{
-	/* Remove Roll20 d20 */
-	content: "" !important;
-}
-
-/* --------------------------------------------------- */
-/* Browser-specific Styling                            */
-/* --------------------------------------------------- */
-
-@media screen and (-webkit-min-device-pixel-ratio:0) {
-	/* CSS Statements that only apply on webkit-based browsers (Chrome, Safari, etc.) */
-	
-	input[type=number]:hover,
-	input[type=number]:focus {
-		padding-right: 1px;  /* Keeps some numbers from shifting during mouse hover and click. */
+	.charsheet {
+		background: white;
 	}
 	
-	input:read-only::-webkit-outer-spin-button,
-	input:read-only::-webkit-inner-spin-button {
+	body.sheet-darkmode .charsheet {
+		background: #1f1f1f;
+	}
+	
+	/* Roll20 Roll Button re-styling, Thanks to Scott C. */
+	
+	button[type=roll] {
+		/* Override Roll20 default styling */
+		border: none;
+		text-shadow: none;
+		line-height: 14px;
+		background-image: none;
+		box-shadow: none;
+		
+		/* Set global border radius of 'Roll' buttons here. */
+		border-radius: 3px;
+		
+		/* Set global font weight and size here. */
+		font-style: normal;
+		font-weight: bold;
+		font-size: 13px !important;
+	}
+	
+	button[type=roll]::before{
+		/* Remove Roll20 d20 */
+		content: "" !important;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Browser-specific Styling                            */
+	/* --------------------------------------------------- */
+	
+	@media screen and (-webkit-min-device-pixel-ratio:0) {
+		/* CSS Statements that only apply on webkit-based browsers (Chrome, Safari, etc.) */
+		
+		input[type=number]:hover,
+		input[type=number]:focus {
+			padding-right: 1px;  /* Keeps some numbers from shifting during mouse hover and click. */
+		}
+		
+		input:read-only::-webkit-outer-spin-button,
+		input:read-only::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+		
+		/* Stop Safari from offering to autofill name fields. */
+		input::-webkit-contacts-auto-fill-button, 
+		input::-webkit-credentials-auto-fill-button {
+	  	visibility: hidden;
+	  	position: absolute;
+	  	top: -50px;
+		}
+	}
+	
+	@-moz-document url-prefix() {
+		/* CSS Statements that only apply on Firefox */
+	
+		input[type=number]:hover,
+		input[type=number]:focus {
+			-moz-appearance: number-input;
+			padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. */
+		}
+		
+		input[type=number]:read-only {
+		  	-moz-appearance: textfield;
+		} 
+		
+	}
+	
+	/* ----------------------------------------------------	*/
+	/* General Styling 										*/
+	/* ----------------------------------------------------	*/
+	
+	/* Okabe and Ito colorblind-safe palette:				*/
+	/* Green: 			#009E73								*/
+	/* Blue: 			#0072B2 							*/
+	/* Light blue: 		#56B4E9 							*/
+	/* Yellow: 			#F0E442								*/
+	/* Orange: 			#E69F00								*/
+	/* Orange-red: 		#D55E00								*/
+	/* Violet: 			#CC79A7								*/
+	/* 														*/
+	/* Plus:												*/
+	/* A mid-tone gray:	#8A8A8A								*/
+	
+	textarea {
+		font-size: 14px;
+		resize: none;
+	}
+	
+	input {
+		font-size: 13px;
+		border: hidden;
+		border-radius: 3px;
+		padding: 0px;
+		text-align: center;
+	}
+	
+	input[type=number]:focus {
+		outline: none;
+	}
+	
+	input[type=text]:focus,
+		textarea:focus,
+		button:focus {
+	}
+	
+	input.customCheckbox {
+		width: 20px;
+		height: 20px;
+		vertical-align: middle;
+	}
+	
+	
+	/* --------------------------------------------------------------- */
+	/* Custom select used due to differences between Firefox,          */
+	/* Chrome, and Safari. From:                                       */
+	/* @link https://moderncss.dev/custom-select-styles-with-pure-css/ */
+	/* --------------------------------------------------------------- */
+	
+	
+	select,
+	select::before,
+	select::after {
+  	box-sizing: border-box;
+	}
+		
+	select {
 		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
+		background-color: transparent;
+		border: none;
+		padding: 0 1em 0 0;
 		margin: 0;
+		width: 100%;
+		font-family: inherit;
+		/* font-size: inherit; */
+		font-size: 12px;
+		cursor: inherit;
+		line-height: inherit;
+		z-index: 1;
+		outline: none;
+		max-height: 22px;
 	}
 	
-	/* Stop Safari from offering to autofill name fields. */
-	input::-webkit-contacts-auto-fill-button, 
-	input::-webkit-credentials-auto-fill-button {
-	  visibility: hidden;
-	  position: absolute;
-	  top: -50px;
-	}
-}
-
-@-moz-document url-prefix() {
-	/* CSS Statements that only apply on Firefox */
-
-	input[type=number]:hover,
-	input[type=number]:focus {
-		-moz-appearance: number-input;
-		padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. */
+	.custom-select,
+	.custom-select-skill,
+	.custom-select-alternate,
+	.custom-select-alternate-skill,
+	.custom-select-option {
+		display: grid;
+		grid-template-areas: "select";
+		align-items: center;
+		position: relative;
+		max-height: 20px;
+		border: 1px solid gray;
+		border-radius: 3px;
+		padding: 0px;
+		padding-bottom: 1px;
+		padding-right: 3px;
+		cursor: pointer;
+		background-color: #fff;
+		background-image: linear-gradient(to top, #f9f9f9, #fff 33%);
 	}
 	
-	input[type=number]:read-only {
-		  -moz-appearance: textfield;
+	.custom-select,
+	.custom-select-skill,
+	.custom-select-alternate,
+	.custom-select-alternate-skill {
+		min-width: 34px;
+		padding-left: 0px;
+	}
+	
+	.custom-select-option {
+		width: 58px;
+		background-color: red;
+		padding-left: 4px;
+		margin-right: 6px;
+	}
+	
+	.custom-select-skill,
+	.custom-select-alternate-skill {
+		margin-top: 2px;
+		margin-bottom: 1px;
+		max-height: 20px;
+	}
+	
+	.custom-select select,
+	.custom-select-skill select,
+	.custom-select-alternate select,
+	.custom-select-alternate-skill select,
+	.custom-select-option select,
+	.custom-select::after,
+	.custom-select-skill::after,
+	.custom-select-alternate::after,
+	.custom-select-alternate-skill::after,
+	.custom-select-option::after {
+		grid-area: select;
+	}
+	
+	.custom-select::after,
+	.custom-select-skill::after,
+	.custom-select-alternate::after,
+	.custom-select-alternate-skill::after,
+	.custom-select-option::after {
+		content: "";
+		justify-self: end;
+		width: 12px;
+		height: 8px;
+		-webkit-clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+		clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+	}
+	
+	.custom-select::after,
+	.custom-select-skill::after {
+		/* background-color: olive; */
+		background-color: #8A8A8A;
+	}
+	
+	.custom-select-alternate::after,
+	.custom-select-alternate-skill::after {
+		/* background-color: salmon; */
+		background-color: #CC79A7;
+	}
+	
+	.custom-select-option::after  {
+		background-color: dodgerblue;
+	}
+	
+	select:focus + .focus {
+		position: absolute;
+		top: -1px;
+		left: -1px;
+		right: -1px;
+		bottom: -1px;
+		border: 2px solid goldenrod;
+		border-radius: inherit;
+	}
+	
+	.custom-select--disabled,
+	.custom-select-skill--disabled,
+	.custom-select-alternate--disabled,
+	.custom-select-alternate-skill--disabled,
+	.custom-select-alternate-option--disabled {
+		cursor: not-allowed;
+		background-color: #eee;
+		background-image: linear-gradient(to top, #ddd, #eee 33%);
+	}
+	
+	.custom-select-skill,
+	.custom-select-alternate-skill {
+		width: 64px;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Tab Styling                                         */
+	/* --------------------------------------------------- */
+	.tab {
+		display: flex;
+		justify-content: space-between;
+		height:36px;
+		padding: 0px;
+		widows: 100%;
+		margin-bottom: 0px;
+		margin-left: 0px;
+		margin-right: 0px;
+		width: 680px;
+		background: dodgerblue;
+		border: 8px;
+		border-bottom: 0px;
+		border-radius: 4px;
+		border-bottom-left-radius: 0px;
+		border-bottom-right-radius: 0px;
+		border-color: dodgerblue;
+		border-style: solid;
+	}
+	
+	/* Style the buttons inside the tab */
+	.tab button {
+		background-color: #CCCCFF;
+		float: left;
+		outline: none;
+		cursor: pointer;
+		padding: 10px 10px;
+		margin-right: 0px;
+		transition: 0.3s;
+		font-size: 18px;
+		border: 0px;
+	}
+	
+	/* Change background color of buttons on hover */
+	.tab button:hover {
+		background-color: #F0E442;
+	}
+	
+	/* Create an active/current tab class */
+	.tab button.active {
+		background-color: #F0E442;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Configure sheet and tab buttons                     */
+	/* --------------------------------------------------- */
+	.sheet-characteristics,
+	.sheet-skills,
+	.sheet-powers,
+	.sheet-complications,
+	.sheet-gear,
+	.sheet-options {
+		display: none;
+		width: 680px;
+		background: dodgerblue;
+		border: 8px;
+		border-color: dodgerblue;
+		border-style: solid;
+	}
+	
+	/* show the selected tab */
+	.sheet-tabstoggle[value="characteristics"] ~ div.sheet-characteristics,
+	.sheet-tabstoggle[value="skills"] ~ div.sheet-skills,
+	.sheet-tabstoggle[value="powers"] ~ div.sheet-powers,
+	.sheet-tabstoggle[value="complications"] ~ div.sheet-complications,
+	.sheet-tabstoggle[value="gear"] ~ div.sheet-gear,
+	.sheet-tabstoggle[value="options"] ~ div.sheet-options {
+		display: block;
+	}
+	
+	/* Styling for characteristics tab labels */
+	.sheet-characteristics label {
+		display:inline-block;
+		font-size: 13px;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Tally Bar styling                                   */
+	/* --------------------------------------------------- */
+	
+	.sheet-tallybar {
+		width: 680px;
+		background: dodgerblue;
+		border: 8px;
+		border-top: 0px;
+		border-radius: 4px;
+		border-top-left-radius: 0px;
+		border-top-right-radius: 0px;
+		border-color: dodgerblue;
+		border-style: solid;
+	}
+	
+	.sheet-flex-tallybar {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-evenly;
+		width: 668px;
+		height: 36px;
+		border: 3px solid #f6ee8d;
+		border-radius: 5px;
+		background: royalblue;
+		margin: 0px;
+		padding-left: 3px;
+		padding-right: 3px;
+	}
+	
+	.sheet-flex-tallybar span {
+		color: white;
+	}
+	
+	.sheet-flex-tallybar span:nth-child(1) {
+		color: white;
+	
+	}
+	
+	.sheet-flex-tallybar input[type=number] {
+		min-width: 52px;
+		text-align: right;
+		padding-right: 0px;
+	}
+	
+	.sheet-flex-tallybar input[type=number]:hover,
+	.sheet-flex-tallybar input[type=number]:focus {
+		padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. Both webkit and moz. For some reason. */
+	}
+	
+	.sheet-flex-tallybar input[readonly] {
+		background: #f4ec7a;
+		padding-right: 0px;
+		min-width: 36px;
+		max-width: 40px;
+		text-align: center;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Characteristics Tab styling                         */
+	/* --------------------------------------------------- */
+	
+	.grid-container-tab-characteristics {
+		display: grid;
+		grid-template-areas: "leftGrid rightGrid";
+		grid-template-columns: 335px 335px;
+		max-width: 674px;
+		height: 801px;
+		font-size: 16px;
+		grid-gap: 5px;
+		background-color: royalblue;
+		border: 3px solid #f6ee8d;
+		border-radius: 5px;
+		margin-bottom: 0px;
+	}
+	
+	.grid-container-tab-characteristics input[readonly]{
+		background: #f4ec7a;
+	}
+	
+	/* characteristics tab left side */
+	
+	.grid-container-characteristics-leftGrid {
+		grid-area: leftGrid;
+		display: grid;
+		grid-template-areas:
+		"logo"
+		"bio"
+		"earnings"
+		"primaryAbilities"
+		"combatAbilities"
+		"movementAbilities";
+		grid-template-columns: 329px;
+		grid-gap: 0px;
+		background: royalblue;
+		margin-bottom: 5px;
+	}
+	
+	.grid-container-characteristics-leftGrid  h1 {
+		padding-left: 0px;
+		padding-top: 5px;
+		padding-bottom: 0px;
+		margin: 0px;
+		font-size: 13px;
+		font-style: normal;
+		line-height: 1.40;
+		min-width: 54px;
+	}
+	
+	.grid-container-characteristics-leftGrid  h2 {
+		height: 20px;
+		line-height: 1.6;
+		margin-left: 5px;
+		margin-bottom: 0px;
+		margin-top: 2px;
+		font-size: 13px;
+		font-style: normal;
+	}
+	
+	/* Item: logo graphic bio0 */
+	
+	.item-characteristics-logo {
+		grid-area: logo;
+		padding: 2px;
+		background-color: royalblue;
+		margin-bottom: 4px;
+	}
+	
+	/* Item: character bio bio1*/
+	
+	.item-characteristics-bio {	
+		max-width: 330px;
+		grid-area: bio;
+		display: grid;
+		grid-template-areas:
+		"nameLabel nameText nameText nameText"
+		"titleLabel titleText titleText titleText"
+		"backgroundLabel backgroundText backgroundText backgroundText";
+		grid-template-columns: 85px 105px 57px 73px;
+		grid-template-rows: 30px 30px 48px;
+		margin-left: 6px;
+		margin-bottom: 0px;
+		padding: 5px;
+		padding-bottom: 0px;
+		background-color: #f2cf7f;
+		border: solid 1px #ebb232;
+		border-bottom: none;
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
+		vertical-align: top;
+	}
+	
+	.item-characteristics-bio input[type=text] {
+		text-align:left;
+		width: 222px;
+		padding: 2px;
+		padding-left: 4px;
+		margin-left: 5px;
+		border: solid 1px #ebb232;
+		font-size: 13;
+		font-weight: bold;
+	}
+	
+	.item-characteristics-bio textarea {
+		width: 214px;
+		max-height: 36px;
+		padding: 2px;
+		padding-left: 4px;
+		margin-left: 5px;
+		border: solid 1px black;
+		text-align: left;
+		border: solid 1px #ebb232;
+	}
+	
+	/* Subitem: Character Name Label */
+	.item-characteristics-bio-nameLabel {
+		grid-area: nameLabel;
+	}
+	
+	/* Subitem: Character Name Text */
+	.item-characteristics-bio-name {
+		grid-area: nameText;
+	}
+	
+	/* Subitem: Character Title Label */
+	.item-characteristics-bio-titleLabel {
+		grid-area: titleLabel;
+	}
+	
+	/* Subitem: Character Title Text */
+	.item-characteristics-bio-titleText {
+		grid-area: titleText;
+	}
+	
+	/* Subitem: Character background label */
+	.item-characteristics-bio-backgroundLabel {
+		grid-area: backgroundLabel;
+	}
+	
+	/* Subitem: Character background text */
+	.item-characteristics-bio-backgroundText {
+		grid-area: backgroundText;
+	}
+	
+	/* Item: character bio experience and money*/
+	
+	.item-characteristics-earnings {	
+		max-width: 330px;
+		grid-area: earnings;
+		display: grid;
+		grid-template-areas:
+		"experienceLabel experience moneyLabel money";
+		grid-template-columns: 90px 57px 95px 83px;
+		grid-template-rows: 23px;
+		margin-left: 6px;
+		margin-bottom: 6px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		padding: 5px;
+		padding-bottom: 0px;
+		background-color: #f4ec7a;
+		border: solid 1px #ebb232;
+		border-top: none;
+		border-bottom-left-radius: 3px;
+		border-bottom-right-radius: 3px;
+		vertical-align: top;
+	}
+	
+	.item-characteristics-earnings h1 {
+		margin-bottom: 10px;
+		padding-left: 3px;
+		padding-top: 4px;
+		line-height: 1.3;
+	}
+	
+	.item-characteristics-earnings-experience input {
+		min-width: 54px;
+		padding-right: 0px;
+		padding-top: 0px;
+	}
+	
+	.item-characteristics-earnings input[type=number] {
+		text-align: right;
+		padding-right: 0px;
+		border: solid 1px #F0E442;
+		padding-top: 0px;
+		margin-bottom: 5px;
+	}
+	
+	.item-characteristics-earnings input[type=text] {
+		font-size: 13px;
+		max-width: 90px;
+		text-align: right;
+		background-color: #f4ec7a;
+		font-weight: bold;
+		margin-top: 0px;
+		margin-bottom: 1px;
+		color: black;
+	}
+	
+	/* Subitem: Character Experience */
+	.item-characteristics-earnings-experienceLabel {
+		grid-area: experienceLabel;
+	}
+	
+	/* Subitem: Character Experience */
+	.item-characteristics-earnings-experience {
+		grid-area: experience;
+	}
+	
+	/* Subitem: Character Money */
+	.item-characteristics-earnings-moneyLabel {
+		grid-area: moneyLabel;
+	}
+	
+	/* Subitem: Character Money */
+	.item-characteristics-earnings-money {
+		grid-area: money;
+	}
+	
+	.item-characteristics-earnings-money input[type=number] {
+		min-width: 70px;
+		margin-bottom: 5px;
+	}
+	
+	/* Item: core abilities */
+	.item-characteristics-primary-attributes {
+		grid-area: primaryAbilities;
+		display: grid;
+		grid-template-areas:
+		"primaryAbilityNames primaryAbilityValues primaryAbilityChances primaryAbilityButtons primaryAbilityCosts";
+		grid-template-columns: 126px 49px 50px 45px 45px;
+		min-width: 300px;
+		vertical-align: middle;
+		margin-left: 6px;
+		background-color: #f4ec7a; 
+		border: solid 1px #ebb232;
+		border-bottom: none;
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
+		padding-bottom: 2px;
+	}
+	
+	.item-characteristics-primary-attributes h1 {
+		background: #f2cf7f;
+		padding-left: 5px;
+		padding-right: 6px;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		margin: 0px;
+		margin-top: 0px;
+		font-size: 13px;
+		font-style: normal;
+		line-height: 1.35;
+	}
+	
+	.item-characteristics-primary-attributes h2 {
+		margin-left: 8px;
+	}
+	
+	.item-characteristics-primary-attributes input[type=number] {
+		text-align: right;
+		padding-right: 0px;
+		border: solid 1px #d8cd3b;	
+	}
+	
+	.item-characteristics-primary-attributes input[readonly] {
+		text-align: center;
+		border: none;	
+		max-width: 45px;
+	}
+	
+	/* Sub-Item: core abilities characteristics */
+	.item-characteristics-primary-attributes-names {
+		grid-area: primaryAbilityNames;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		text-align: left;
+		min-height: 130px;
+		max-height: 160px;
+	}
+	
+	/* Sub-Item: core abilities values */
+	.item-characteristics-primary-attributes-values {
+		grid-area: primaryAbilityValues;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		text-align: left;
+		min-height: 130px;
+		max-height: 160px;
+		max-width: 55px;
+	}
+	
+	/* Sub-Item: core abilities values */
+	.item-characteristics-primary-attributes-rollChances {
+		grid-area: primaryAbilityChances;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		text-align: left;
+		min-height: 130px;
+		max-height: 160px;
+	}
+	
+	.item-characteristics-primary-attributes-rollChances h1 {
+		margin-left: 6px;
+	}
+	
+	/* Sub-Item: core abilities values */
+	.item-characteristics-primary-attributes-rollButtons {
+		grid-area: primaryAbilityButtons;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		min-height: 130px;
+		max-height: 160px;
+	}
+	
+	/* Sub-Item: core abilities values */
+	.item-characteristics-primary-attributes-costs {
+		grid-area: primaryAbilityCosts;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		min-height: 130px;
+		max-height: 160px;
+	}
+	
+	.item-characteristics-primary-attributes-costs h1 {
+		margin-left: 8px;
+		text-align: left;
+		min-width: 32px;
+	}
+	
+	/* Item: combat abilities */
+	.item-characteristics-combat-attributes {
+		grid-area: combatAbilities;
+		display: grid;
+		grid-template-areas:
+		"combatAbilityNames combatAbilityValues . . combatAbilityCosts";
+		grid-template-columns: 126px 49px 50px 45px 45px;
+		min-width: 300px;
+		vertical-align: middle;
+		margin-left: 6px;
+		background-color: #f4ec7a; 
+		border: solid 1px #ebb232;
+		border-bottom: none;
+		border-top: none;
+		padding-bottom: 2px;
+	}
+	
+	.item-characteristics-combat-attributes input[type=number] {
+		text-align: right;
+		padding-right: 0px;
+		border: solid 1px #d8cd3b;
+	}
+	
+	.item-characteristics-combat-attributes input[readonly] {
+		text-align: center;
+		padding-right: 2px;
+		border: none;
+		max-width: 45px;
+	}
+	
+	.item-characteristics-combat-attributes h1 {
+		background: #f4ec7a;
+		padding-left: 5px;
+		padding-right: 6px;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		margin: 0px;
+		margin-top: 0px;
+		font-size: 13px;
+		font-style: normal;
+		line-height: 1.35;
+	}
+	
+	.item-characteristics-combat-attributes h2 {
+		margin-left: 8px;
+	}
+	
+	/* Sub-Item: combat abilities characteristics */
+	.item-characteristics-combat-attributes-names {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		text-align: left;
+		grid-area: combatAbilityNames;
+		min-width: 120px;
+	}
+	
+	/* Sub-Item: core abilities values */
+	.item-characteristics-combat-attributes-values {
+		text-align: center;
+		grid-area: combatAbilityValues;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		min-width: 152px;
+		text-align: left;
+	}
+	
+	/* Sub-Item: core abilities values */
+	.item-characteristics-combat-attributes-costs {
+		grid-area: combatAbilityCosts;
+		text-align: right;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+	}
+	
+	.item-characteristics-combat-attributes-costs h1 {
+		margin-left: 8px;
+		text-align: left;
+		min-width: 32px;
+	}
+	
+	/* Item: combat abilities */
+	.item-characteristics-movement-abilities {
+		grid-area: movementAbilities;
+		display: grid;
+		grid-template-areas:
+		"movementNames movementValues . . movementCosts";
+		grid-template-columns: 126px 49px 50px 45px 45px;
+		/* background: purple; */
+		min-width: 300px;
+		margin-left: 6px;
+		padding-bottom: 2px;
+		background-color: #f4ec7a; 
+		border: solid 1px #ebb232;
+		border-top: none;
+		border-bottom-left-radius: 3px;
+		border-bottom-right-radius: 3px;
+	}
+	
+	.item-characteristics-movement-abilities input[type=number] {
+		text-align: right;
+		padding-right: 0px;
+		border: solid 1px #d8cd3b;
+	}
+	
+	.item-characteristics-movement-abilities input[readonly] {
+		text-align: center;
+		padding-right: 0px;
+		border: none; 
+		max-width: 45px;
+	}
+	
+	.item-characteristics-movement-abilities h1 {
+		background: #f2cf7f;
+		padding-left: 5px;
+		padding-right: 6px;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		margin: 0px;
+		margin-top: 0px;
+		font-size: 13px;
+		font-style: normal;
+		line-height: 1.35;
+	}
+	
+	.item-characteristics-movement-abilities h2 {
+		margin-left: 8px;
+	}
+	
+	/* Sub-Item: combat abilities characteristics */
+	.item-characteristics-movement-abilities-names {
+		grid-area: movementNames;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+	}
+	
+	/* Sub-Item: core abilities values */
+	.item-characteristics-movement-abilities-values {
+		grid-area: movementValues;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+	}
+	
+	.item-characteristics-movement-abilities-values h1 {
+		min-width: 141px;
+	}
+	
+	/* Sub-Item: core abilities costs */
+	.item-characteristics-movement-abilities-costs {
+		grid-area: movementCosts;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+	}
+	
+	.item-characteristics-movement-abilities-costs h1 {
+		margin-left: 8px;
+		text-align: left;
+		min-width: 32px;
+	}
+	
+	/* characteristics tab right side */
+	
+	.grid-container-characteristics-rightGrid {
+		grid-area: rightGrid;
+		display: grid;
+		grid-template-areas:
+		"portrait health"
+		"turnSegmentIndicators turnTracker"
+		"perception perception"
+		"history history";
+		grid-template-columns: 264px 68px;
+		grid-template-rows: 260px 22px 100px 419px;
+		background: royalblue;
+		max-height: 800px;
+		max-width: 300px;
+	}
+	
+	
+	/* Item: character portrait graphic */
+	.item-characteristics-portrait {
+		grid-area: portrait;
+		position: relative;
+		width: 100%;
+		max-width: 250px;
+		padding: 0px;
+		height: 250px;
+		margin: 3px;
+		margin-left: 0px;
+		margin-top: 4px;
+		background-color: royalblue;
+	}
+	
+	.item-characteristics-portrait textarea {
+		width: 242px;
+		margin-left: 5px;
+		margin-right: 5px;
+		margin-bottom: 4px;
+		background-color: lavender;
+		height: 242px;
+		font-size: 14px;
+	}
+	
+	.item-characteristics-portrait img {
+		width: 100%;
+		height: auto;
+		margin-left: 7px;
+		border-right: solid gray 1px;
+		border-bottom: solid gray 1px;
+		border-left: solid darkgray 1px;
+		border-top: solid darkgray 1px;
+	}
+	
+	.item-characteristics-portrait .button-left-arrow,
+	.item-characteristics-portrait .button-right-arrow {
+		position: absolute;
+		transform: translate(-50%, -50%);
+		color: transparent;
+		background-color: transparent;
+		font-size: 16px;
+		padding: 12px 12px;
+		border: none;
+		cursor: pointer;
+		border-radius: 5px;
+		text-align: center;
+	}
+	
+	.item-characteristics-portrait .button-left-arrow {
+		top: 50%;
+		left: 11%;
+	}
+	
+	.item-characteristics-portrait .button-right-arrow {
+		top: 50%;
+		left: 95%;
+	}
+	
+	.item-characteristics-portrait .button-right-arrow:hover,
+	.item-characteristics-portrait .button-left-arrow:hover {
+		background-color: gold;	
+	}
+	
+	
+	/* By deafult, hides all portrait images. Add more numbered entries to add more images, notes, or cards. */
+	.item-portrait-00, 
+	.item-portrait-01,
+	.item-portrait-02 {
+		display: none;
+	}
+	
+	/* show the selected portrait frame. Add more numbered entries to add more images, notes, or cards. */
+	.item-portrait-slideshow[value="0"] ~ div.item-portrait-00,
+	.item-portrait-slideshow[value="1"] ~ div.item-portrait-01,
+	.item-portrait-slideshow[value="2"] ~ div.item-portrait-02 {
+		display: block;
+		position: relative;
+	}
+	
+	/* Alternate styling for rule cards instead of portraits */
+	.item-portrait-00 {
+		background-color: white;
+		border: solid 2px gray;
+		height: 250px;
+		width: 250px;
+		margin-left: 5px;
+	}
+	
+	.item-portrait-00 h1 {
+		font-size: 16px;
+		color: white;
+		text-align: center;
+		padding-left: 0px;
+		background-color: crimson;
+	}
+	
+	.item-portrait-flex-container {
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-start;
+		max-height: 240px;
+		padding: 0px;
+	}
+	
+	.item-portrait-rule-description {
+		max-width: 250px;
+		margin: 0px;
+		padding: 0px;
+		line-height: 1.0;
+	}
+	
+	.item-portrait-rule-description h1 {
+		font-size: 16px;
+		color: firebrick;
+		text-align: center;
+		padding-left: 4px;
+		background-color: inherit;
+		line-height: 1.4;
+		padding-bottom: 0px;
+	}
+	
+	.item-portrait-rule-description p {
+		font-size: 13px;
+		padding: 4px;
+		margin: 0px;
+		text-align: left;
+		line-height: 1.2;
+	}
+	
+	/* Item: health status                                     */
+	/* Item: gear tab health status                            */
+	/* Sheet worker used to synchronizes the contents of each  */
+	
+	.item-characteristics-health,
+	.item-gear-health {
+		padding: 0px;
+		width: 68px;
+		background: royalblue;
+		border: white;
+		margin-top: 4px;
+		margin-right: 2px;
+		height: 250px;
+		align-items: center;
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+	}
+	
+	.item-powers-health {
+		padding: 6px;
+		width: 318px;
+		height: 56px;
+		margin: 0px;
+		align-items: center;
+		display: flex;
+		justify-content: space-between;
+		flex-direction: row;
+		background-color: royalblue;
+		border: 3px solid #fff990;
+		border-radius: 5px;
+	}
+	
+	.item-characteristics-health  {
+		grid-area: health;
+	}
+	
+	.item-gear-health {
+		grid-area: gearHealth;
+	}
+	
+	.item-powers-health {
+		grid-area: powerHealth;
+	}
+	
+	.item-gear-health h2,
+	.item-characteristics-health h2,
+	.item-powers-health h2 {
+		color: white;
+		background-color: inherit;
+		text-align: center;
+		font-size: 17px;
+		line-height: 1.0em;
+		margin-top: 0px;
+		margin-bottom: 0px;
+		padding: 0px;
+	}
+	
+	.item-health-stat {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		width: 63px;
+		height: 30px;
+		border-radius: 3px;
+		align-items: center;
+		padding: 0px;
+		margin-right: 1px;
+		margin-bottom: 2px;
+		background-color: #F0E442;
+		border: solid 1px #ebb232;
+	}
+	
+	.item-health-stat-enclosure {
+		padding: none;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 57px;
+	}
+	
+	.item-health-stat-plus-minus-enclosure {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		max-height: 20px;
+		width: 20px;
+		align-items: center;
+		padding: 1px;
+	}
+	
+	.item-health-stat input[type=text] {
+		max-width: 45px;
+		height: 30px;
+		font-size: 20px;
+		background-color: #F0E442;
+	}
+	
+	.item-health-stat input[type=text]:focus{
+		outline: transparent;
+	}
+	
+	.item-health-stat button.buttonPlus,
+	.item-health-stat button.buttonMinus {
+		background-color: LemonChiffon;
+		border: solid 1px slategray;
+		color: slategray;
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		display: inline-block;
+		font-size: 16px;
+		margin: 0px 0px;
+		line-height: 1.4ch;
+		border-radius: 0px;
+	}
+	
+	.item-health-stat button.buttonPlus span,
+	.item-health-stat button.buttonMinus span {
+		display: inline-block;
+		transform: rotate(-90deg);
+		text-align: center;
+	}
+	
+	.item-health-stat button.buttonPlus:hover,
+	.item-health-stat button.buttonMinus:hover {
+		background-color: gray;
+		color: white;
+		transition: 0.05s;
+	}
+	
+	/* Item: Turn Tracker Button Space */
+	
+	.item-characteristics-turn-tracker {
+		grid-area: turnTracker;
+		width: 68px;
+		height: 22px;
+		padding: 0px;
+		line-height: 20px;
+	}
+	
+	/* Item: character history */
+	.item-characteristics-history {
+		grid-area: history;
+		text-align: left;
+		padding: 2px;
+		max-width: 343px;
+		background-color: inherit;
+		margin-bottom: 1px;
+		margin-right: 6px;
+		max-height: 402px;
+		margin-bottom: 6px;
+	}
+	
+	.item-characteristics-history textarea {
+		width: 316px;
+		height: 100%;
+		border: solid 1px #c4c4c4;
+	}
+	
+	/* Item: Speed Phase Indicator Buttons */
+	.item-characteristics-speedIndicatorButtons {
+		grid-area: speedIndicatorButtons;
+		padding-left: 2px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		background-color: royalblue;
+		width: 264px;
+		margin: 0px;
+	}
+	
+	/* Item: Perception */
+	.item-characteristics-perception {
+		grid-area: perception;
+		max-width: 323px;
+		background-color: inherit;
+		max-height: 95px;
+		margin-left: 3px;
+		border: transparent;
+		margin-top: 0px;
+	}
+	
+	.item-characteristics-perception h1 {
+		font-size: 13px;
+		line-height: 1.6;
+		text-align: left;
+		background-color: royalblue;
+		color: white;
+	}
+	
+	.item-characteristics-perception input[type=number] {
+		text-align: right;
+		padding-right: 0px;
+		border: solid 1px palegoldenrod;
+		margin: 0px;
+		margin-bottom: 3px;
+		background-color: white;
+		max-width: 40px;
+	}
+	
+	.subitem-characteristics-perception-stat-container {
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+		background-color: inherit;
+		padding-left: 0px;
+		align-items: center;
+	}
+	
+	.subitem-characteristics-perception-stat-container input[type=text] {
+		font-size: 13px;
+		max-width: 65px;
+		text-align: center;
+		background-color: royalblue;
+		color: white;
+		font-weight: bold;
+		margin-top: 2px;
+	}
+	
+	.subitem-characteristics-perception-column-container {
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+		background-color: #cce8f8;
+		padding: 2px;
+		align-items: center;
+		border-radius: 5px;
+		border: solid #eef7fc 2px;
+	}
+	
+	.subitem-characteristics-perception-column-container input[type=text] {
+		font-size: 13px;
+		max-width: 32px;
+		line-height: 1.3;
+		text-align: center;
+		background-color: #cce8f8;
+		padding: 0px;
+		color: black;
+		font-weight: bold;
+	}
+	
+	.subitem-characteristics-perception-row-container {
+		display: flex;
+		justify-content: space-between;
+		flex-direction: row;
+		margin-top: 2px;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Options Tab                                         */
+	/* --------------------------------------------------- */
+	
+	.grid-container-tab-options {
+		display: grid;
+		grid-template-areas: ". . ." 
+			". options ."
+			". . .";
+		grid-template-columns: 110px 500px 100px;
+		grid-template-rows: 100px 185px 100px;
+		font-size: 16px;
+		background-color: royalblue;
+		border: 3px solid #fff990;
+		border-radius: 5px;
+		margin-bottom: 1px;
+		min-height: 800px;
+		min-width: 674px;
+	}
+	
+	.grid-container-tab-options h1 {
+		font-size: 14px;
+		margin-left: 0px;
+		color: black;
+		padding-bottom: 5px;
+		font-weight: 500;
+	}
+	
+	.grid-container-tab-options label {
+		max-width: 13px;
+		padding: 8px;
+	}
+	
+	/* Sub-Item: options */
+	.item-options {
+		grid-area: options;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-start;
+		padding-left: 2px;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		background-color: #f7f1a0;
+		margin: 5px;
+		width: 450px;
+		height: 308px;
+		margin: 0px;
+		border: solid 2px goldenrod;
+		border-radius: 3px;
+	}
+	
+	.item-options-row,
+	.item-version-row {
+		align-items: baseline;
+		min-width: 400px;
+		max-height: 28px;
+		margin-left: 10px;
+	}
+	
+	.item-options-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Version Info                                        */
+	/* --------------------------------------------------- */
+	
+	.item-version-row {
+		display: grid;
+		grid-template-areas: "versionLabel versionInfo";
+		justify-content: flex-end;
+	}
+	
+	.item-version-label h2 {
+		font-size: 13px;
+		max-height: 28px;
+		color: black;
+	}
+	
+	.item-version-information input[readonly] {
+		background-color: #fff990;
+		color: black;
+		max-width: 35px;
+		padding-bottom: 1px;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Custom buttons                                      */
+	/* --------------------------------------------------- */
+	
+	.button {
+		border: none;
+		color: white;
+		text-decoration: none;
+		display: inline-block;
+		cursor: pointer;
+		transition-duration: 0.2s;
+		text-align: center;
+	}
+		
+	.buttonRecover {
+		background-color: darkseagreen;
+		padding-top: 4px;
+		padding-bottom: 4px;
+		margin-left: 2px;
+		margin-right: 2px;
+		margin-top: 0px;
+		margin-bottom: 0px;
+		padding-left: 4px;
+		padding-right: 3.5px;
+		vertical-align: middle;
+		text-align: right;
+		font-size: 13px;
+		font-weight: bold;
+		border-radius: 3px;
+	}
+	
+	.buttonReset {
+		background-color: orange;
+		padding-top: 4px;
+		padding-bottom: 4px;
+		margin-left: 2px;
+		margin-right: 2px;
+		margin-top: 0px;
+		margin-bottom: 0px;
+		padding-left: 12px;
+		padding-right: 12px;
+		vertical-align: middle;
+		text-align: center;
+		font-size: 13px;
+		font-weight: bold;
+		border-radius: 3px;
+	}
+	
+	.buttonTracker {
+		background-color: dodgerblue;
+		padding-left: 3px;
+		padding-right: 3px;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		font-weight: bold;
+	}
+	
+	.button-Power-END-right,
+	.button-Power-END-left {
+		padding-top: 2px;
+		padding-bottom: 2px;
+		padding-right: 2px;
+		padding-left: 2px;
+		min-height: 16px;
+		max-height: 16px;
+		text-align: middle;
+		font-weight: bold;
+		border-radius: 2.5px;
+	}
+	
+	.button-Power-END-left {
+		/* background-color: olive; */
+		background-color: #8A8A8A;
+		margin-right: 0px;
+		min-width: 34px;
+		max-width: 35px;
+	}
+	
+	.button-Power-END-right {
+		/* background-color: salmon; */
+		background-color: #8A8A8A;
+		margin-right: 0px;
+		min-width: 34px;
+		max-width: 35px;
+	}
+	
+	.buttonRoll,
+	.buttonRollAttack,
+	.buttonRollActivate,
+	.buttonRollNormalAttack,
+	.buttonRollShieldAttack,
+	.buttonRollShow,
+	.buttonRollPower,
+	.buttonManeuverEND {
+		padding-left: 3px;
+		padding-right: 3px;
+		text-align: center;
+		line-height: 13px;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		font-weight: bold;
+		max-height: 16px;
+		min-height: 15px;
+	}
+	
+	.buttonRoll,
+	.buttonRollAttack,
+	.buttonRollActivate,
+	.buttonRollShieldAttack {
+		min-width: 25px;
+		max-width: 26px;
+	}
+	
+	
+	.buttonRollPower {
+		min-width: 32px;
+		max-width: 34px;
+	}
+	
+	.button:hover,
+	.buttonRecover:hover,
+	.buttonReset:hover,
+	.buttonRoll:hover,
+	.buttonRollAttack:hover,
+	.buttonRollActivate:hover,
+	.buttonRollNormalAttack:hover,
+	.buttonRollShieldAttack:hover,
+	.buttonRollShow:hover,
+	.buttonRollPower:hover {
+		color: black;
+		background-color: lightgray;
+		text-align: center;
+	}
+	
+	.button-Power-END-left:hover,
+	.button-Power-END-right:hover,
+	.buttonManeuverEND:hover {
+		background-color: #ff9900;
+		color: black;
+	}
+	
+	.buttonRoll {
+		margin-right: 3px;
+		margin-left: 3px;
+		background-color: #E69F00;
+		border-radius: 3px;
+	}
+	
+	.buttonRollAttack {
+		background-color: #D55E00;
+		border-radius: 2.5px;
+	}
+	
+	.item-flex-maneuver .buttonRollAttack,
+	.item-flex-maneuver .buttonRollShow,
+	.item-flex-maneuver .buttonManeuverEND {
+		margin-right: 3px;
+		margin-left: 3px;
+		border-radius: 3px;
+		min-width: 36px;
+		max-width: 38px;
+	}
+	
+	.item-flex-maneuver .buttonRollAttack {
+		margin-left: 61px;
+	}
+	
+	/* Change attack button color to indicate normal damage. */
+	.weapon-normal-damage01[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon01"]:not(:hover),
+	.weapon-normal-damage02[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon02"]:not(:hover),
+	.weapon-normal-damage03[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon03"]:not(:hover),
+	.weapon-normal-damage04[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon04"]:not(:hover),
+	.weapon-normal-damage05[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon05"]:not(:hover)
+	{
+		background-color: #009E73;
+	}
+	
+	/* Change maneuver attack button color to indicate normal damage. */
+	.maneuver-normal-damage01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
+	.maneuver-normal-damage02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
+	.maneuver-normal-damage03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
+	.maneuver-normal-damage04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
+	.maneuver-normal-damage05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
+	.maneuver-normal-damage06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
+	.maneuver-normal-damage07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
+	.maneuver-normal-damage08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
+	.maneuver-normal-damage09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
+	{
+		background-color: #009E73;
+	}
+	
+	/* Change maneuver attack button color to indicate a non-damaging defensive action. */
+	.maneuver-block01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
+	.maneuver-block02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
+	.maneuver-block03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
+	.maneuver-block04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
+	.maneuver-block05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
+	.maneuver-block06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
+	.maneuver-block07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
+	.maneuver-block08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
+	.maneuver-block09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
+	{
+		background-color: #56B4E9;
+	}
+	
+	.buttonRollActivate {
+		margin-right: 3px;
+		margin-left: 3px;
+		background-color: #0072B2;
+		border-radius: 3px;
+	}
+	
+	.buttonRollNormalAttack,
+	.buttonManeuverEND,
+	.buttonRollShow {
+		margin-right: 3px;
+		margin-left: 3px;
+		border-radius: 3px;
+		min-width: 34px;
+		max-width: 36px;
+	}
+	
+	.buttonRollNormalAttack {
+		margin-left: 61px;
+		background-color: #D55E00;
+	}
+	
+	.buttonManeuverEND {
+		background-color: #8A8A8A;
+		font-weight: bold;
+	}
+	
+	.buttonRollShow {
+		background-color: #8A8A8A;
+	}
+	
+	.buttonRollShieldAttack  {
+		background-color: #56B4E9;
+		border-radius: 2.5px;
+	}
+	
+	.buttonRollPower {
+		/* background-color: #9184E2; lighter than mediumslateblue */
+		background-color: #CC79A7;
+		border-radius: 2.5px;
+	}
+	
+	/* The d6 of dicefontd6 doesn't look good. Let's hold off for a better idea or stick with the label 'Roll' on the buttons.
+	
+	.buttonRollNormalAttack::before {
+		font-family: 'dicefontd6';
+		font-size: 16px;
+		content: 'F';
+	} */
+	
+	.portrait-display-button-left,
+	.portrait-display-button-right {
+		background-color: orange;
+		padding-top: 4px;
+		padding-bottom: 4px;
+		margin: 4px 2px;
+		padding-left: 14px;
+		padding-right: 14px;
+		vertical-align: middle;
+		text-align: center;
+	}
+	
+	.portrait-display-button-left:hover,
+	.portrait-display-button-right:hover {
+		color: black;
+		background-color: limegreen;
+		text-align: center;
+	}
+	
+	
+	/* --------------------------------------------------- */
+	/* Custom Checkbox used for options                    */
+	/* From w3 schools                                     */
+	/* --------------------------------------------------- */
+	
+	/* Customize the label (the container) */
+	.container-checkbox {
+		display: inline-block;
+		position: relative;
+		padding-left: 25px;
+		padding-top: 2px;
+		/* margin-bottom: 10px; */
+		cursor: pointer;
+		max-width: 400px;
+		font-size: 12px;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
+		border: transparent;
+	}
+	
+	/* Hide the browser's default checkbox */
+	.container-checkbox input,
+	.container-checkbox-small input,
+	.container-checkbox-small-gray input {
+		position: absolute;
+		opacity: 0;
+		cursor: pointer;
+		height: 0;
+		width: 0;
+	}
+	
+	/* Create a custom checkbox */
+	.checkmark {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 20px;
+		width: 20px;
+		background-color: gold;
+	}
+	
+	/* On mouse-over, add a grey background color */
+	.container-checkbox:hover input ~ .checkmark,
+	.container-checkbox-small:hover input ~ .checkmark-small {
+		background-color: goldenrod;
+		border: solid 1px darkgoldenrod;
+	}
+	
+	.container-checkbox-small-gray:hover input ~ .checkmark-small-gray {
+		background-color: lightsteelblue;
+		border: solid 1px darkgray;
+	}
+	
+	/* When the checkbox is checked, add a gold background */
+	.container-checkbox input:checked ~ .checkmark,
+	.container-checkbox-small input:checked ~ .checkmark-small {
+		background-color: gold;
+	}
+	
+	.container-checkbox-small-gray input:checked ~ .checkmark-small-gray {
+		background-color: lightgray;
+	}
+	
+	/* Create the checkmark/indicator (hidden when not checked) */
+	.checkmark:after,
+	.checkmark-small:after {
+		content: "";
+		position: absolute;
+		display: none;
+		border: solid 1px darkgoldenrod;
+	}
+	
+	.checkmark-small-gray:after {
+		content: "";
+		position: absolute;
+		display: none;
+		border: solid 1px gray;
+	}
+	
+	/* Show the checkmark when checked */
+	.container-checkbox input:checked ~ .checkmark:after,
+	.container-checkbox-small input:checked ~ .checkmark-small:after,
+	.container-checkbox-small-gray input:checked ~ .checkmark-small-gray:after {
+		display: block;
+	}
+	
+	/* Style the checkmark/indicator */
+	.container-checkbox .checkmark:after {
+		left: 7px;
+		top: 2px;
+		width: 5px;
+		height: 10px;
+		border: solid black;
+		border-width: 0 3px 3px 0;
+		-webkit-transform: rotate(45deg);
+		-ms-transform: rotate(45deg);
+		transform: rotate(45deg);
+	}
+	
+	/* --------------------------------------------------- */
+	/* Custom Checkbox (small) used for skill enhancers    */
+	/* From w3 schools                                     */
+	/* --------------------------------------------------- */
+	
+	/* Customize the label (the container) */
+	.container-checkbox-small,
+	.container-checkbox-small-gray {
+		display: block;
+		position: relative;
+		padding-left: 20px;
+		padding-top: 0px;
+		cursor: pointer;
+		font-size: 12px;
+		max-width: 20px;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
+	}
+	
+	/* Create a custom checkbox */
+	.checkmark-small {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 15px;
+		width: 15px;
+		background-color: gold;
+	}
+	
+	.checkmark-small-gray {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 15px;
+		width: 15px;
+		background-color: lightgray;
+	}
+	
+	/* Style the checkmark/indicator */
+	.container-checkbox-small .checkmark-small:after,
+	.container-checkbox-small-gray .checkmark-small-gray:after {
+		left: 4px;
+		top: 2px;
+		width: 4px;
+		height: 7px;
+		border: solid black;
+		border-width: 0 3px 3px 0;
+		-webkit-transform: rotate(45deg);
+		-ms-transform: rotate(45deg);
+		transform: rotate(45deg);
+	}
+	
+	
+	.subitem-flex-container-martial-cv-damage-row .container-checkbox-small-gray {
+		margin-bottom: 14px;
+		padding: 0px;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Custom Checkboxes used for turn segment indicators  */
+	/* Modification of custom checkbox above               */
+	/* --------------------------------------------------- */
+	
+	.grid-container-container-turn-segments {
+		grid-area: turnSegmentIndicators;
+		display: inline-flex; /* or inline-flex */
+		flex-direction: row;
+		flex-wrap: nowrap;
+		align-items: top;
+		justify-content: space-evenly;
+		width: 264px;
+		height: 24px;
+		background: royalblue;
+		margin-top: 2px;
+		margin-left: 1px;
+		padding: 0px;
+	}
+	
+	.grid-container-container-turn-segments label {
+		display: inline;
+		pointer-events: none;
+		font-style: normal;
+	}
+	
+	/* Custom checkbox indicator */
+	
+	.container-speed-indicator {
+		display: inline-block;
+		position: relative;
+		padding-left: 5px;
+		margin-bottom: 0px;
+		cursor: pointer;
+		font-size: 20px;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
+	}
+		
+	/* Hide the browser's default checkbox */
+	.container-speed-indicator input {
+		position: absolute;
+		opacity: 0;
+		cursor: pointer;
+		height: 0;
+		width: 0;
+	}
+	
+	/* Custom checkbox */
+	
+	.checkmark01,
+	.checkmark02,
+	.checkmark03,
+	.checkmark04,
+	.checkmark05,
+	.checkmark06,
+	.checkmark07,
+	.checkmark08,
+	.checkmark09,
+	.checkmark10,
+	.checkmark11,
+	.checkmark12 {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 20px;
+		width: 20px;
+		background-color: dodgerblue;
+		border: none;
+		border-radius: 5px;
+		pointer-events: none;
+	}
+	
+	/* Custom segment indicator checkbox: Status */
+	.container-speed-indicator input:checked ~ .checkmark01,
+	.container-speed-indicator input:checked ~ .checkmark02,
+	.container-speed-indicator input:checked ~ .checkmark03,
+	.container-speed-indicator input:checked ~ .checkmark04,
+	.container-speed-indicator input:checked ~ .checkmark05,
+	.container-speed-indicator input:checked ~ .checkmark06,
+	.container-speed-indicator input:checked ~ .checkmark07,
+	.container-speed-indicator input:checked ~ .checkmark08,
+	.container-speed-indicator input:checked ~ .checkmark09,
+	.container-speed-indicator input:checked ~ .checkmark10,
+	.container-speed-indicator input:checked ~ .checkmark11,
+	.container-speed-indicator input:checked ~ .checkmark12 {
+		background-color: hotpink;
+		border: none;
+		border-radius: 5px;
+	}
+	
+	/* Custom segment indicator checkbox 01. Active/checked. */
+	.checkmark01:after {
+		content: "1";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 01. Inactive/not checked. */
+	.checkmark01:before {
+		content: "1";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 02. Active/checked. */
+	.checkmark02:after {
+		content: "2";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 02. Inactive/not checked. */
+	.checkmark02:before {
+		content: "2";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 03. Active/checked. */
+	.checkmark03:after {
+		content: "3";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 03. Inactive/not checked. */
+	.checkmark03:before {
+		content: "3";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 04. Active/checked. */
+	.checkmark04:after {
+		content: "4";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 04. Inactive/not checked. */
+	.checkmark04:before {
+		content: "4";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 05. Active/checked. */
+	.checkmark05:after {
+		content: "5";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 05. Inactive/not checked. */
+	.checkmark05:before {
+		content: "5";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 06. Active/checked. */
+	.checkmark06:after {
+		content: "6";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 06. Inactive/not checked. */
+	.checkmark06:before {
+		content: "6";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 07. Active/checked. */
+	.checkmark07:after {
+		content: "7";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 07. Inactive/not checked. */
+	.checkmark07:before {
+		content: "7";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 08. Active/checked. */
+	.checkmark08:after {
+		content: "8";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 08. Inactive/not checked. */
+	.checkmark08:before {
+		content: "8";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 09. Active/checked. */
+	.checkmark09:after {
+		content: "9";
+		color: white;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 09. Inactive/not checked. */
+	.checkmark09:before {
+		content: "9";
+		color: black;
+		position: absolute;
+		padding-left: 6px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 10. Active/checked. */
+	.checkmark10:after {
+		content: "10";
+		color: white;
+		position: absolute;
+		padding-left: 2px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 10. Inactive/not checked. */
+	.checkmark10:before {
+		content: "10";
+		color: black;
+		position: absolute;
+		padding-left: 2px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 11. Active/checked. */
+	.checkmark11:after {
+		content: "11";
+		color: white;
+		position: absolute;
+		padding-left: 3px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 11. Inactive/not checked. */
+	.checkmark11:before {
+		content: "11";
+		color: black;
+		position: absolute;
+		padding-left: 3px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 12. Active/checked. */
+	.checkmark12:after {
+		content: "12";
+		color: white;
+		position: absolute;
+		padding-left: 2px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Custom segment indicator checkbox 12. Inactive/not checked. */
+	.checkmark12:before {
+		content: "12";
+		color: black;
+		position: absolute;
+		padding-left: 2px;
+		padding-top: 1px;
+		display: none;
+	}
+	
+	/* Show the checkmark when checked */
+	.container-speed-indicator input:checked ~ .checkmark01:after,
+	.container-speed-indicator input:checked ~ .checkmark02:after,
+	.container-speed-indicator input:checked ~ .checkmark03:after,
+	.container-speed-indicator input:checked ~ .checkmark04:after,
+	.container-speed-indicator input:checked ~ .checkmark05:after,
+	.container-speed-indicator input:checked ~ .checkmark06:after,
+	.container-speed-indicator input:checked ~ .checkmark07:after,
+	.container-speed-indicator input:checked ~ .checkmark08:after,
+	.container-speed-indicator input:checked ~ .checkmark09:after,
+	.container-speed-indicator input:checked ~ .checkmark10:after,
+	.container-speed-indicator input:checked ~ .checkmark11:after,
+	.container-speed-indicator input:checked ~ .checkmark12:after {
+		display: block;
+	}
+	
+	/* Show the checkmark when checked */
+	.container-speed-indicator input:not(:checked) ~ .checkmark01:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark02:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark03:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark04:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark05:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark06:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark07:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark08:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark09:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark10:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark11:before,
+	.container-speed-indicator input:not(:checked) ~ .checkmark12:before {
+		display: block;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Talents, Perks, and Complications                   */
+	/* --------------------------------------------------- */
+	.grid-container-complications-talents {
+		display: grid;
+		grid-gap: 4px;
+		grid-template-areas: 
+		"theTalentsAndPerks theComplications"
+		"theNotes theNotes";
+		grid-template-columns: 338px 338px;
+		grid-template-rows: 642px 160px;
+		width: 676px;
+		padding: 0px;
+		font-size: 16px;
+		background-color: dodgerblue;
+		justify-content: middle;
+		padding-bottom: 0px;
+		margin-bottom: 1px;
+	}
+	
+	.grid-container-complications-talents h2 {
+		font-size: 18px;
+		line-height: 1.3;
+		text-align: center;
+		font-weight: normal;
+	}
+	
+	/* Complications and Talents Tab: Talents and Perks */
+	.flex-container-complications-talents-left {
+		grid-area: theTalentsAndPerks;
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+		border: 3px solid #fff990;
+		border-radius: 5px;
+		width: 321px;
+		background: #F0E442;
+		height: 630px;
+		padding: 5px;
+		padding-bottom: 0px;
+		margin-bottom: 0px;
+		margin-right: 0px;
+	}
+	
+	.item-talent-heading {
+		display: flex;
+		flex-wrap: nowrap;
+		justify-content: space-between;
+		align-items: center;
+		flex-direction: row;
+		margin-bottom: 0px;
+		padding: 0px;
+		width: 321px;
+	}
+	
+	.item-talent-heading input[type=text] {
+		max-width: 200px;
+		padding: 1px;
+		padding-left: 3px;
+		margin: 0px;
+		margin-right: 0px;
+		margin-left: 2px;
+		text-align: left;
+		font-size: 13px;
+		font-weight: bold;
+		border: solid 1px darkgray;
+	}
+	
+	.item-talent-heading input[type=number] {
+		max-width: 45px;
+		padding: 2px;
+		margin: 0px;
+		padding-right: 0px;
+		text-align: right;
+		border: solid 1px darkgray;
+	}
+	
+	.item-talent-heading h1 {
+		font-size: 12px;
+		line-height: 1.1;
+		padding-right: 2px;
+		padding-left: 6px;
+	}
+	
+	.item-talent-textbox textarea {
+		max-width: 314px;
+		max-height: 36px;
+		padding: 3px;
+		border: solid 1px darkgray;
+		margin-bottom: 6px;
+	}
+	
+	
+	/* Complications and Talents Tab: Complications */
+	.flex-container-complications-talents-right {
+		grid-area: theComplications;
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+		border: 3px solid lightcyan; /* Color Block Alt */
+		border-radius: 5px;
+		width: 321px;
+		background: #99d2f1;
+		height: 630px;
+		padding: 5px;
+		padding-bottom: 0px;
+		margin-bottom: 0px;
+	}
+	
+	.item-complication-heading {
+		display: flex;
+		flex-wrap: nowrap;
+		justify-content: space-between;
+		align-items: center;
+		flex-direction: row;
+		margin-bottom: 0px;
+		padding: 0px;
+		width: 322px;
+	}
+	
+	.item-complication-heading input[type=text] {
+		max-width: 210px;
+		padding: 1px;
+		padding-left: 3px;
+		margin: 0px;
+		margin-right: 0px;
+		margin-left: 2px;
+		text-align: left;
+		font-size: 13px;
+		font-weight: bold;
+		border: solid 1px darkgray;
+	}
+	
+	.item-complication-heading input[type=number] {
+		max-width: 45px;
+		padding: 2px;
+		margin: 0px;
+		padding-right: 0px;
+		text-align: right;
+		border: solid 1px darkgray;
+	}
+	
+	.item-complication-heading h1 {
+		font-size: 12px;
+		line-height: 1.1;
+		padding-right: 2px;
+		padding-left: 6px;
+	}
+	
+	.item-complication-textbox textarea {
+		max-width: 314px;
+		max-height: 54px;
+		padding: 3px;
+		border: solid 1px darkgray;
+		margin-bottom: 6px;
+	}
+	
+	/* Complications Tab: Notes Text Panel */
+	
+	.flex-container-complications-bottom {
+		grid-area: theNotes;
+		display: flex;
+		flex-direction: row;
+		flex-wrap: nowrap;
+		justify-content: space-between;
+		border: none;
+		width: 679px;
+		padding: 0px;
+		margin: 0px;
+		min-height: 155px;
+		background: transparent;
+	}
+	
+	.flex-container-complications-bottom textarea {
+		width: 331px;
+		min-height: 155px;
+		padding: 0px;
+		margin: 0px;
+		border:  3px solid lightgray;
+		border-radius: 5px;
+		background-color: white;
+	}
+	
+	/* ----------------------------------------------------- */
+	/* Powers                                                */
+	/* Organized in two columns with different color styles. */
+	/* ----------------------------------------------------- */
+	.grid-container-powers {
+		display: grid;
+		grid-gap: 5px 5px;
+		grid-template-areas: 
+		"leftPowers powerHealth"
+		"leftPowers rightPowers";
+		grid-template-columns: 337px 336px;
+		grid-template-rows: 74px 727px;
+		width: 679px;
+		padding: 0px;
+		font-size: 16px;
+		background-color: dodgerblue;
+		justify-content: middle;
+		padding-bottom: 0px;
+		margin-bottom: 1px;
+	}
+	
+	.grid-container-powers h1 {
+		display:inline-block;
+		margin-left: 0px;
+		padding-left: 2px;
+		padding-right: 0px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		margin: 0px;
+		margin-top: 1px;
+		font-size: 13px;
+		font-style: normal;
+		line-height: 1.35;
+	}
+	
+	.grid-container-powers input[type=number] {
+		padding-right: 0px;
+		padding-top: 2px;
+		width: 30px;
+		margin: 0px;
+		text-align: right;
+		height: 21px;
+		padding: 1px;
+	}
+	
+	.flex-container-powers-right,
+	.flex-container-powers-left {
+		display: flex;
+		justify-content: space-between;
+		flex-direction: column;
+		border-radius: 5px;
+		width: 323px;
+		padding-left: 4px;
+		padding-right: 4px;
+		margin: 0px;
+	}
+	
+	.flex-container-powers-left,
+	.flex-container-powers-right {
+		padding-top: 3px;
+		padding-bottom: 3px;
+	}
+	
+	.flex-container-powers-left {
+		height: 795px;
+	}
+	
+	.flex-container-powers-right {
+		height: 716px;
+	}
+	
+	.flex-container-powers-left textarea,
+	.flex-container-powers-right textarea {
+		color: gray; 
+		height: 54px;
+		padding: 3px;
+		margin: 0px;
+		margin-top: 1px;
+		font-size: 8;
+	}
+	
+	.flex-container-powers-left textarea {
+		max-width: 316px;
+	}
+	
+	.flex-container-powers-right textarea {
+		border: solid 1px goldenrod;
+		max-width: 315px;
+	}
+	
+	/* Power subitems. */
+	
+	.item-flex-power {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-top: 2px;
+		padding-bottom: 3px;
+	}
+	
+	.subitem-flex-power-heading-left,
+	.subitem-flex-power-heading-right,
+	.subitem-flex-power-effect-left,
+	.subitem-flex-power-effect-right {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		margin-top: 1px;
+		margin-bottom: 0px;
+		align-items: center;
+		max-height: 23px;
+	}
+	
+	.subitem-flex-power-heading-left input[type=text],
+	.subitem-flex-power-heading-right input[type=text],
+	.subitem-flex-power-effect-left input[type=text],
+	.subitem-flex-power-effect-right input[type=text] {
+		min-height: 22px;
+		text-align: left;
+		padding-left: 2px;
+		margin-right: 0px;
+	}
+	
+	.subitem-flex-power-heading-left input[type=text]:nth-child(2),
+	.subitem-flex-power-heading-right input[type=text]:nth-child(2) {
+		font-weight: bold;
+		max-width: 130px;
+		margin-left: 1px;
+	}
+	
+	.subitem-flex-power-heading-left input[type=text]:nth-child(4),
+	.subitem-flex-power-heading-right input[type=text]:nth-child(4) {
+		font-weight: bold;
+		text-align: center;
+	}
+	
+	.subitem-flex-power-heading-left select,
+	.subitem-flex-power-heading-right select {
+		font-size: 13px;
+		height: 19px;
+		width: 98px;
+		margin: 0px;
+		padding-left: 3px;
+	}
+	
+	/* Effect */
+	.subitem-flex-power-effect-left input[type=text]:nth-child(2),
+	.subitem-flex-power-effect-right input[type=text]:nth-child(2){
+		max-width: 130px;
+		max-height: 23px;
+	}
+	
+	/* Dice */
+	.subitem-flex-power-effect-left input[type=text]:nth-child(3),
+	.subitem-flex-power-effect-right input[type=text]:nth-child(3) {
+		max-width: 58px;
+		text-align: center;
+		margin-left: 2px;
+		margin-right: 0px;
+		padding-left: 0px;
+		padding-right: 0px;
+	}
+	
+	/* Roll chance */
+	.subitem-flex-power-effect-left input[type=number]:nth-child(5), 
+	.subitem-flex-power-effect-right input[type=number]:nth-child(5) {
+		max-width: 41px;
+		min-width: 41px;
+		text-align: right;
+		margin-left: 1px;
+		margin-right: 2px;
+	}
+	
+	.subitem-flex-power-activeCost input[type=number]:nth-child(2), /* Advantages */
+	.subitem-flex-power-activeCost input[type=number]:nth-child(4) /* Limitations */ {
+		border: solid 1px #89ABB9;
+		min-width: 55px;
+	}
+	
+	/* Powers Tab: Left Powers and general to right. */
+	.flex-container-powers-left {
+		grid-area: leftPowers;
+		border: 3px solid lightcyan;
+		background: #99d2f1;
+	}
+	
+	.flex-container-powers-left textarea {
+		border: solid 1px black;
+	}
+	
+	.flex-container-powers-left input[readonly]{
+		background: lightcyan;
+		border: solid 1px #89abb9;
+		line-height: 1.0;
+	}
+	
+	.flex-container-powers-left textarea{
+		border: 1px solid #89ABB9;
+	}
+	
+	.subitem-flex-power-heading-left input[type=text]{
+		border: solid 1px #89ABB9;
+		max-width: 28px;
+	}
+	
+	.subitem-flex-power-effect-left input[type=text],
+	.subitem-flex-power-effect-left input[type=number]{
+		border: solid 1px #89ABB9;
+	}
+	
+	.subitem-flex-power-points-block-left,
+	.subitem-flex-power-points-block-right {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+		max-height: 23px;
+		margin-bottom: 2px;
+	}
+	
+	.subitem-flex-power-points-block-left input[type=number] {
+		/* Active, Real Cost */
+		border: solid 1px #89ABB9;
+	}
+	
+	.subitem-flex-power-points-block-left input[readonly] {
+		/* Active, Real Cost */
+		max-width: 38px;
+		text-align: center;
+		padding: 0px;
+	}
+	
+	.subitem-flex-power-limitations-left,
+	.subitem-flex-power-limitations-right {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-width: 333px;
+		margin-bottom: 2px;
+		max-height: 23px;
+	}
+	
+	.subitem-flex-power-limitations-left input[type=number]{
+		/* Advantages, limitations */
+		border: solid 1px #89ABB9;
+		min-width: 50px;
+	}
+	
+	.subitem-flex-power-limitations-left select,
+	.subitem-flex-power-limitations-right select {
+		font-size: 13px;
+		height: 19px;
+		max-width: 115px;
+		margin: 0px;
+		align-items: center;
+		padding-left: 3px;
+	}
+	
+	
+	/* Powers Tab: Right Powers */
+	.flex-container-powers-right {
+		grid-area: rightPowers;
+		border: 3px solid #fff990;
+		background: #F0E442; /* Color Block */
+	}
+	
+	.flex-container-powers-right textarea {
+		border: solid 1px black;
+	}
+	
+	.flex-container-powers-right input[readonly]{
+		background: #fff990;
+		border: solid 1px goldenrod;
+		line-height: 1.0;
+	}
+	
+	.flex-container-powers-right textarea{
+		border: 1px solid goldenrod;
+	}
+	
+	.subitem-flex-power-heading-right input[type=text] {
+		max-width: 28px;
+		border: solid 1px goldenrod;
+	}
+	
+	.subitem-flex-power-effect-right input[type=text],
+	.subitem-flex-power-effect-right input[type=number]{
+		border: solid 1px goldenrod;
+	}
+	
+	.subitem-flex-power-points-block-right input[type=number] {
+		/* Active, Real Cost */
+		border: solid 1px goldenrod;
+	}
+	
+	.subitem-flex-power-points-block-right input[readonly] {
+		/* Active, Real Cost */
+		max-width: 38px;
+		text-align: center;
+	}
+	
+	.subitem-flex-power-limitations-right input[type=number]{
+		/* Advantages, limitations */
+		border: solid 1px goldenrod;
+		min-width: 50px;
+	}
+	
+	
+	/* Buttons for power, talent, and complication movers. */
+	.power-mover-plus-minus-enclosure,
+	.talent-mover-plus-minus-enclosure,
+	.complication-mover-plus-minus-enclosure {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	
+	.power-mover-plus-minus-button,
+	.talent-mover-plus-minus-button,
+	.complication-mover-plus-minus-button {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		height: 24px;
+		width: 10px;
+		align-items: center;
+		padding: 0px;
+		margin-right: 2px;
+		margin-left:3px;
+	}
+	
+	.power-mover-plus-minus-button button.buttonPlus,
+	.power-mover-plus-minus-button button.buttonMinus,
+	.talent-mover-plus-minus-button button.buttonPlus,
+	.talent-mover-plus-minus-button button.buttonMinus,
+	.complication-mover-plus-minus-button button.buttonPlus,
+	.complication-mover-plus-minus-button button.buttonMinus {
+		background-color: lemonchiffon; /* Color Mover */
+		border: solid 1px silver; /* Color Mover Border */
+		color: slategray; /* Color Mover Chevron */
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		display: inline-block;
+		font-size: 10px;
+		margin: 0px 0px;
+		line-height: 1.25ch;
+		border-radius: 0px;
+		max-width: 10px;
+	}
+	
+	.power-mover-plus-minus-button button.buttonPlus span,
+	.power-mover-plus-minus-button button.buttonMinus span,
+	.talent-mover-plus-minus-button button.buttonPlus span,
+	.talent-mover-plus-minus-button button.buttonMinus span,
+	.complication-mover-plus-minus-button button.buttonPlus span,
+	.complication-mover-plus-minus-button button.buttonMinus span {
+		display: inline-block;
+		transform: rotate(-90deg);
+		text-align: center;
+	}
+	
+	.power-mover-plus-minus-button button.buttonPlus:hover,
+	.power-mover-plus-minus-button button.buttonMinus:hover,
+	.talent-mover-plus-minus-button button.buttonPlus:hover,
+	.talent-mover-plus-minus-button button.buttonMinus:hover,
+	.complication-mover-plus-minus-button button.buttonPlus:hover,
+	.complication-mover-plus-minus-button button.buttonMinus:hover {
+		background-color: gray; /* Color Mover Hover */
+		color: white; /* Color Mover Chevron Hover */
+		transition: 0.05s;
 	} 
 	
-}
-
-/* ----------------------------------------------------	*/
-/* General Styling 										*/
-/* ----------------------------------------------------	*/
-
-/* Okabe and Ito colorblind-safe palette:				*/
-/* Green: 			#009E73								*/
-/* Blue: 			#0072B2 							*/
-/* Light blue: 		#56B4E9 							*/
-/* Yellow: 			#F0E442								*/
-/* Orange: 			#E69F00								*/
-/* Orange-red: 		#D55E00								*/
-/* Violet: 			#CC79A7								*/
-/* 														*/
-/* Plus:												*/
-/* A mid-tone gray:	#8A8A8A								*/
-
-textarea {
-	font-size: 14px;
-	resize: none;
-}
-
-input {
-	font-size: 13px;
-	border: hidden;
-	border-radius: 3px;
-	padding: 0px;
-	text-align: center;
-}
-
-input[type=number]:focus {
-	outline: none;
-}
-
-input[type=text]:focus,
-	textarea:focus,
-	button:focus {
-}
-
-input.customCheckbox {
-	width: 20px;
-	height: 20px;
-	vertical-align: middle;
-}
-
-
-/* --------------------------------------------------------------- */
-/* Custom select used due to differences between Firefox,          */
-/* Chrome, and Safari. From:                                       */
-/* @link https://moderncss.dev/custom-select-styles-with-pure-css/ */
-/* --------------------------------------------------------------- */
-
-
-select,
-select::before,
-select::after {
-  box-sizing: border-box;
-}
 	
-select {
-	-webkit-appearance: none;
-	-moz-appearance: none;
-	appearance: none;
-	background-color: transparent;
-	border: none;
-	padding: 0 1em 0 0;
-	margin: 0;
-	width: 100%;
-	font-family: inherit;
-	/* font-size: inherit; */
-	font-size: 12px;
-	cursor: inherit;
-	line-height: inherit;
-	z-index: 1;
-	outline: none;
-	max-height: 22px;
-}
-
-.custom-select,
-.custom-select-skill,
-.custom-select-alternate,
-.custom-select-alternate-skill,
-.custom-select-option {
-	display: grid;
-	grid-template-areas: "select";
-	align-items: center;
-	position: relative;
-	max-height: 20px;
-	border: 1px solid gray;
-	border-radius: 3px;
-	padding: 0px;
-	padding-bottom: 1px;
-	padding-right: 3px;
-	cursor: pointer;
-	background-color: #fff;
-	background-image: linear-gradient(to top, #f9f9f9, #fff 33%);
-}
-
-.custom-select,
-.custom-select-skill,
-.custom-select-alternate,
-.custom-select-alternate-skill {
-	min-width: 34px;
-	padding-left: 0px;
-}
-
-.custom-select-option {
-	width: 58px;
-	background-color: red;
-	padding-left: 4px;
-	margin-right: 6px;
-}
-
-.custom-select-skill,
-.custom-select-alternate-skill {
-	margin-top: 2px;
-	margin-bottom: 1px;
-	max-height: 20px;
-}
-
-.custom-select select,
-.custom-select-skill select,
-.custom-select-alternate select,
-.custom-select-alternate-skill select,
-.custom-select-option select,
-.custom-select::after,
-.custom-select-skill::after,
-.custom-select-alternate::after,
-.custom-select-alternate-skill::after,
-.custom-select-option::after {
-	grid-area: select;
-}
-
-.custom-select::after,
-.custom-select-skill::after,
-.custom-select-alternate::after,
-.custom-select-alternate-skill::after,
-.custom-select-option::after {
-	content: "";
-	justify-self: end;
-	width: 12px;
-	height: 8px;
-	-webkit-clip-path: polygon(100% 0%, 0 0%, 50% 100%);
-	clip-path: polygon(100% 0%, 0 0%, 50% 100%);
-}
-
-.custom-select::after,
-.custom-select-skill::after {
-	/* background-color: olive; */
-	background-color: #8A8A8A;
-}
-
-.custom-select-alternate::after,
-.custom-select-alternate-skill::after {
-	/* background-color: salmon; */
-	background-color: #CC79A7;
-}
-
-.custom-select-option::after  {
-	background-color: dodgerblue;
-}
-
-select:focus + .focus {
-	position: absolute;
-	top: -1px;
-	left: -1px;
-	right: -1px;
-	bottom: -1px;
-	border: 2px solid goldenrod;
-	border-radius: inherit;
-}
-
-.custom-select--disabled,
-.custom-select-skill--disabled,
-.custom-select-alternate--disabled,
-.custom-select-alternate-skill--disabled,
-.custom-select-alternate-option--disabled {
-	cursor: not-allowed;
-	background-color: #eee;
-	background-image: linear-gradient(to top, #ddd, #eee 33%);
-}
-
-.custom-select-skill,
-.custom-select-alternate-skill {
-	width: 64px;
-}
-
-/* --------------------------------------------------- */
-/* Tab Styling                                         */
-/* --------------------------------------------------- */
-.tab {
-	display: flex;
-	justify-content: space-between;
-	height:36px;
-	padding: 0px;
-	widows: 100%;
-	margin-bottom: 0px;
-	margin-left: 0px;
-	margin-right: 0px;
-	width: 680px;
-	background: dodgerblue;
-	border: 8px;
-	border-bottom: 0px;
-	border-radius: 4px;
-	border-bottom-left-radius: 0px;
-	border-bottom-right-radius: 0px;
-	border-color: dodgerblue;
-	border-style: solid;
-}
-
-/* Style the buttons inside the tab */
-.tab button {
-	background-color: #CCCCFF;
-	float: left;
-	outline: none;
-	cursor: pointer;
-	padding: 10px 10px;
-	margin-right: 0px;
-	transition: 0.3s;
-	font-size: 18px;
-	border: 0px;
-}
-
-/* Change background color of buttons on hover */
-.tab button:hover {
-	background-color: yellow;
-}
-
-/* Create an active/current tab class */
-.tab button.active {
-	background-color: yellow;
-}
-
-/* --------------------------------------------------- */
-/* Configure sheet and tab buttons                     */
-/* --------------------------------------------------- */
-.sheet-characteristics,
-.sheet-skills,
-.sheet-powers,
-.sheet-complications,
-.sheet-gear,
-.sheet-options {
-	display: none;
-	width: 680px;
-	background: dodgerblue;
-	border: 8px;
-	border-color: dodgerblue;
-	border-style: solid;
-}
-
-/* show the selected tab */
-.sheet-tabstoggle[value="characteristics"] ~ div.sheet-characteristics,
-.sheet-tabstoggle[value="skills"] ~ div.sheet-skills,
-.sheet-tabstoggle[value="powers"] ~ div.sheet-powers,
-.sheet-tabstoggle[value="complications"] ~ div.sheet-complications,
-.sheet-tabstoggle[value="gear"] ~ div.sheet-gear,
-.sheet-tabstoggle[value="options"] ~ div.sheet-options {
-	display: block;
-}
-
-/* Styling for characteristics tab labels */
-.sheet-characteristics label {
-	display:inline-block;
-	font-size: 13px;
-}
-
-/* --------------------------------------------------- */
-/* Tally Bar styling                                   */
-/* --------------------------------------------------- */
-
-.sheet-tallybar {
-	width: 680px;
-	background: dodgerblue;
-	border: 8px;
-	border-top: 0px;
-	border-radius: 4px;
-	border-top-left-radius: 0px;
-	border-top-right-radius: 0px;
-	border-color: dodgerblue;
-	border-style: solid;
-}
-
-.sheet-flex-tallybar {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	align-items: center;
-	justify-content: space-evenly;
-	width: 668px;
-	height: 36px;
-	border: 3px solid #fff990;
-	border-radius: 5px;
-	background: royalblue;
-	margin: 0px;
-	padding-left: 3px;
-	padding-right: 3px;
-}
-
-.sheet-flex-tallybar span {
-	color: white;
-}
-
-.sheet-flex-tallybar span:nth-child(1) {
-	color: white;
-
-}
-
-.sheet-flex-tallybar input[type=number] {
-	min-width: 52px;
-	text-align: right;
-	padding-right: 0px;
-}
-
-.sheet-flex-tallybar input[type=number]:hover,
-.sheet-flex-tallybar input[type=number]:focus {
-	padding-right: 0px;  /* Keeps some numbers from shifting during mouse hover and click. Both webkit and moz. For some reason. */
-}
-
-.sheet-flex-tallybar input[readonly] {
-	background: #fff990;
-	padding-right: 0px;
-	min-width: 36px;
-	max-width: 40px;
-	text-align: center;
-}
-
-/* --------------------------------------------------- */
-/* Characteristics Tab styling                         */
-/* --------------------------------------------------- */
-
-.grid-container-tab-characteristics {
-	display: grid;
-	grid-template-areas: "leftGrid rightGrid";
-	grid-template-columns: 335px 335px;
-	max-width: 674px;
-	height: 801px;
-	font-size: 16px;
-	grid-gap: 5px;
-	background-color: royalblue;
-	border: 3px solid #fff990;
-	border-radius: 5px;
-	margin-bottom: 0px;
-}
-
-.grid-container-tab-characteristics input[readonly]{
-	background: #fff990;
-}
-
-/* characteristics tab left side */
-
-.grid-container-characteristics-leftGrid {
-	grid-area: leftGrid;
-	display: grid;
-	grid-template-areas:
-	"logo"
-	"bio"
-	"earnings"
-	"primaryAbilities"
-	"combatAbilities"
-	"movementAbilities";
-	grid-template-columns: 329px;
-	grid-gap: 0px;
-	background: royalblue;
-	margin-bottom: 5px;
-}
-
-.grid-container-characteristics-leftGrid  h1 {
-	padding-left: 0px;
-	padding-top: 5px;
-	padding-bottom: 0px;
-	margin: 0px;
-	font-size: 13px;
-	font-style: normal;
-	line-height: 1.40;
-	min-width: 54px;
-}
-
-.grid-container-characteristics-leftGrid  h2 {
-	height: 20px;
-	line-height: 1.6;
-	margin-left: 5px;
-	margin-bottom: 0px;
-	margin-top: 2px;
-	font-size: 13px;
-	font-style: normal;
-}
-
-/* Item: logo graphic bio0 */
-
-.item-characteristics-logo {
-	grid-area: logo;
-	padding: 2px;
-	background-color: royalblue;
-	margin-bottom: 4px;
-}
-
-/* Item: character bio bio1*/
-
-.item-characteristics-bio {	
-	max-width: 330px;
-	grid-area: bio;
-	display: grid;
-	grid-template-areas:
-	"nameLabel nameText nameText nameText"
-	"titleLabel titleText titleText titleText"
-	"backgroundLabel backgroundText backgroundText backgroundText";
-	grid-template-columns: 85px 105px 57px 73px;
-	grid-template-rows: 30px 30px 48px;
-	margin-left: 6px;
-	margin-bottom: 0px;
-	padding: 5px;
-	padding-bottom: 0px;
-	background-color: gold;
-	border-top: solid 1px goldenrod;
-	border-right: solid 1px goldenrod;
-	border-left: solid 1px goldenrod;
-	border-top-left-radius: 3px;
-	border-top-right-radius: 3px;
-	vertical-align: top;
-}
-
-.item-characteristics-bio input[type=text] {
-	text-align:left;
-	width: 222px;
-	padding: 2px;
-	padding-left: 4px;
-	margin-left: 5px;
-	border: solid 1px goldenrod;
-	font-size: 13;
-	font-weight: bold;
-}
-
-.item-characteristics-bio textarea {
-	width: 214px;
-	max-height: 36px;
-	padding: 2px;
-	padding-left: 4px;
-	margin-left: 5px;
-	border: solid 1px black;
-	text-align: left;
-	border: solid 1px goldenrod;
-}
-
-/* Subitem: Character Name Label */
-.item-characteristics-bio-nameLabel {
-	grid-area: nameLabel;
-	background: gold;
-}
-
-/* Subitem: Character Name Text */
-.item-characteristics-bio-name {
-	grid-area: nameText;
-}
-
-/* Subitem: Character Title Label */
-.item-characteristics-bio-titleLabel {
-	grid-area: titleLabel;
-	background: gold;
-}
-
-/* Subitem: Character Title Text */
-.item-characteristics-bio-titleText {
-	grid-area: titleText;
-}
-
-/* Subitem: Character background label */
-.item-characteristics-bio-backgroundLabel {
-	grid-area: backgroundLabel;
-	background: gold;
-}
-
-/* Subitem: Character background text */
-.item-characteristics-bio-backgroundText {
-	grid-area: backgroundText;
-}
-
-/* Item: character bio experience and money*/
-
-.item-characteristics-earnings {	
-	max-width: 330px;
-	grid-area: earnings;
-	display: grid;
-	grid-template-areas:
-	"experienceLabel experience moneyLabel money";
-	grid-template-columns: 90px 57px 95px 83px;
-	grid-template-rows: 23px;
-	margin-left: 6px;
-	margin-bottom: 6px;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	padding: 5px;
-	padding-bottom: 0px;
-	background-color: #fff990;
-	border-left: solid 1px goldenrod;
-	border-right: solid 1px goldenrod;
-	border-bottom: solid 1px goldenrod;
-	border-bottom-left-radius: 3px;
-	border-bottom-right-radius: 3px;
-	vertical-align: top;
-}
-
-.item-characteristics-earnings h1 {
-	margin-bottom: 10px;
-	padding-left: 3px;
-	padding-top: 4px;
-	line-height: 1.3;
-}
-
-.item-characteristics-earnings-experience input {
-	min-width: 54px;
-	padding-right: 0px;
-	padding-top: 0px;
-}
-
-.item-characteristics-earnings input[type=number] {
-	text-align: right;
-	padding-right: 0px;
-	border: solid 1px palegoldenrod;
-	padding-top: 0px;
-	margin-bottom: 5px;
-}
-
-.item-characteristics-earnings input[type=text] {
-	font-size: 13px;
-	max-width: 90px;
-	text-align: right;
-	background-color: #fff990;
-	font-weight: bold;
-	margin-top: 0px;
-	margin-bottom: 1px;
-	color: black;
-}
-
-/* Subitem: Character Experience */
-.item-characteristics-earnings-experienceLabel {
-	grid-area: experienceLabel;
-}
-
-/* Subitem: Character Experience */
-.item-characteristics-earnings-experience {
-	grid-area: experience;
-}
-
-/* Subitem: Character Money */
-.item-characteristics-earnings-moneyLabel {
-	grid-area: moneyLabel;
-}
-
-/* Subitem: Character Money */
-.item-characteristics-earnings-money {
-	grid-area: money;
-}
-
-.item-characteristics-earnings-money input[type=number] {
-	min-width: 70px;
-	margin-bottom: 5px;
-}
-
-/* Item: core abilities */
-.item-characteristics-primary-attributes {
-	grid-area: primaryAbilities;
-	display: grid;
-	grid-template-areas:
-	"primaryAbilityNames primaryAbilityValues primaryAbilityChances primaryAbilityButtons primaryAbilityCosts";
-	grid-template-columns: 126px 49px 50px 45px 45px;
-	min-width: 300px;
-	vertical-align: middle;
-	margin-left: 6px;
-	background-color: #fff990; 
-	border-top: solid 1px goldenrod;
-	border-left: solid 1px goldenrod;
-	border-right: solid 1px goldenrod;
-	border-bottom: 0px;
-	border-top-left-radius: 3px;
-	border-top-right-radius: 3px;
-	padding-bottom: 2px;
-}
-
-.item-characteristics-primary-attributes h1 {
-	background: gold;
-	padding-left: 5px;
-	padding-right: 6px;
-	padding-top: 2px;
-	padding-bottom: 2px;
-	margin: 0px;
-	margin-top: 0px;
-	font-size: 13px;
-	font-style: normal;
-	line-height: 1.35;
-}
-
-.item-characteristics-primary-attributes h2 {
-	margin-left: 8px;
-}
-
-.item-characteristics-primary-attributes input[type=number] {
-	text-align: right;
-	padding-right: 0px;
-	border: solid 1px palegoldenrod;	
-}
-
-.item-characteristics-primary-attributes input[readonly] {
-	text-align: center;
-	border: none;	
-	max-width: 45px;
-}
-
-/* Sub-Item: core abilities characteristics */
-.item-characteristics-primary-attributes-names {
-	grid-area: primaryAbilityNames;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	text-align: left;
-	min-height: 130px;
-	max-height: 160px;
-}
-
-/* Sub-Item: core abilities values */
-.item-characteristics-primary-attributes-values {
-	grid-area: primaryAbilityValues;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	text-align: left;
-	min-height: 130px;
-	max-height: 160px;
-	max-width: 55px;
-}
-
-/* Sub-Item: core abilities values */
-.item-characteristics-primary-attributes-rollChances {
-	grid-area: primaryAbilityChances;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	text-align: left;
-	min-height: 130px;
-	max-height: 160px;
-}
-
-.item-characteristics-primary-attributes-rollChances h1 {
-	margin-left: 6px;
-}
-
-/* Sub-Item: core abilities values */
-.item-characteristics-primary-attributes-rollButtons {
-	grid-area: primaryAbilityButtons;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	min-height: 130px;
-	max-height: 160px;
-}
-
-/* Sub-Item: core abilities values */
-.item-characteristics-primary-attributes-costs {
-	grid-area: primaryAbilityCosts;
-	text-align: center;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	min-height: 130px;
-	max-height: 160px;
-}
-
-.item-characteristics-primary-attributes-costs h1 {
-	margin-left: 8px;
-	text-align: left;
-	min-width: 32px;
-}
-
-/* Item: combat abilities */
-.item-characteristics-combat-attributes {
-	grid-area: combatAbilities;
-	display: grid;
-	grid-template-areas:
-	"combatAbilityNames combatAbilityValues . . combatAbilityCosts";
-	grid-template-columns: 126px 49px 50px 45px 45px;
-	min-width: 300px;
-	vertical-align: middle;
-	margin-left: 6px;
-	background-color: #fff990; 
-	border: solid 1px goldenrod;
-	border-right: solid 1px goldenrod;
-	border-left: solid 1px goldenrod;
-	border-bottom: none;
-	border-top: none;
-	padding-bottom: 2px;
-}
-
-.item-characteristics-combat-attributes input[type=number] {
-	text-align: right;
-	padding-right: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.item-characteristics-combat-attributes input[readonly] {
-	text-align: center;
-	padding-right: 2px;
-	border: none;
-	max-width: 45px;
-}
-
-.item-characteristics-combat-attributes h1 {
-	background: gold;
-	padding-left: 5px;
-	padding-right: 6px;
-	padding-top: 2px;
-	padding-bottom: 2px;
-	margin: 0px;
-	margin-top: 0px;
-	font-size: 13px;
-	font-style: normal;
-	line-height: 1.35;
-}
-
-.item-characteristics-combat-attributes h2 {
-	margin-left: 8px;
-}
-
-/* Sub-Item: combat abilities characteristics */
-.item-characteristics-combat-attributes-names {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	text-align: left;
-	grid-area: combatAbilityNames;
-	min-width: 120px;
-}
-
-/* Sub-Item: core abilities values */
-.item-characteristics-combat-attributes-values {
-	text-align: center;
-	grid-area: combatAbilityValues;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	min-width: 152px;
-	text-align: left;
-}
-
-/* Sub-Item: core abilities values */
-.item-characteristics-combat-attributes-costs {
-	grid-area: combatAbilityCosts;
-	text-align: right;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-}
-
-.item-characteristics-combat-attributes-costs h1 {
-	margin-left: 8px;
-	text-align: left;
-	min-width: 32px;
-}
-
-/* Item: combat abilities */
-.item-characteristics-movement-abilities {
-	grid-area: movementAbilities;
-	display: grid;
-	grid-template-areas:
-	"movementNames movementValues . . movementCosts";
-	grid-template-columns: 126px 49px 50px 45px 45px;
-	background: purple;
-	min-width: 300px;
-	margin-left: 6px;
-	padding-bottom: 2px;
-	background-color: #fff990; 
-	border-right: solid 1px goldenrod;
-	border-left: solid 1px goldenrod;
-	border-bottom: solid 1px goldenrod;
-	border-top: none;
-	border-bottom-left-radius: 3px;
-	border-bottom-right-radius: 3px;
-}
-
-.item-characteristics-movement-abilities input[type=number] {
-	text-align: right;
-	padding-right: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.item-characteristics-movement-abilities input[readonly] {
-	text-align: center;
-	padding-right: 0px;
-	border: none; 
-	max-width: 45px;
-}
-
-.item-characteristics-movement-abilities h1 {
-	background: gold;
-	padding-left: 5px;
-	padding-right: 6px;
-	padding-top: 2px;
-	padding-bottom: 2px;
-	margin: 0px;
-	margin-top: 0px;
-	font-size: 13px;
-	font-style: normal;
-	line-height: 1.35;
-}
-
-.item-characteristics-movement-abilities h2 {
-	margin-left: 8px;
-}
-
-/* Sub-Item: combat abilities characteristics */
-.item-characteristics-movement-abilities-names {
-	grid-area: movementNames;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-}
-
-/* Sub-Item: core abilities values */
-.item-characteristics-movement-abilities-values {
-	grid-area: movementValues;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-}
-
-.item-characteristics-movement-abilities-values h1 {
-	min-width: 141px;
-}
-
-/* Sub-Item: core abilities costs */
-.item-characteristics-movement-abilities-costs {
-	grid-area: movementCosts;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-}
-
-.item-characteristics-movement-abilities-costs h1 {
-	margin-left: 8px;
-	text-align: left;
-	min-width: 32px;
-}
-
-/* characteristics tab right side */
-
-.grid-container-characteristics-rightGrid {
-	grid-area: rightGrid;
-	display: grid;
-	grid-template-areas:
-	"portrait health"
-	"turnSegmentIndicators turnTracker"
-	"perception perception"
-	"history history";
-	grid-template-columns: 264px 68px;
-	grid-template-rows: 260px 22px 100px 419px;
-	background: royalblue;
-	max-height: 800px;
-	max-width: 300px;
-}
-
-
-/* Item: character portrait graphic */
-.item-characteristics-portrait {
-	grid-area: portrait;
-	position: relative;
-	width: 100%;
-	max-width: 250px;
-	padding: 0px;
-	height: 250px;
-	margin: 3px;
-	margin-left: 0px;
-	margin-top: 4px;
-	background-color: royalblue;
-}
-
-.item-characteristics-portrait textarea {
-	width: 242px;
-	margin-left: 5px;
-	margin-right: 5px;
-	margin-bottom: 4px;
-	background-color: lavender;
-	height: 242px;
-	font-size: 14px;
-}
-
-.item-characteristics-portrait img {
-	width: 100%;
-	height: auto;
-	margin-left: 7px;
-	border-right: solid gray 1px;
-	border-bottom: solid gray 1px;
-	border-left: solid darkgray 1px;
-	border-top: solid darkgray 1px;
-}
-
-.item-characteristics-portrait .button-left-arrow,
-.item-characteristics-portrait .button-right-arrow {
-	position: absolute;
-	transform: translate(-50%, -50%);
-	color: transparent;
-	background-color: transparent;
-	font-size: 16px;
-	padding: 12px 12px;
-	border: none;
-	cursor: pointer;
-	border-radius: 5px;
-	text-align: center;
-}
-
-.item-characteristics-portrait .button-left-arrow {
-	top: 50%;
-	left: 11%;
-}
-
-.item-characteristics-portrait .button-right-arrow {
-	top: 50%;
-	left: 95%;
-}
-
-.item-characteristics-portrait .button-right-arrow:hover,
-.item-characteristics-portrait .button-left-arrow:hover {
-	background-color: gold;	
-}
-
-
-/* By deafult, hides all portrait images. Add more numbered entries to add more images, notes, or cards. */
-.item-portrait-00, 
-.item-portrait-01,
-.item-portrait-02 {
-	display: none;
-}
-
-/* show the selected portrait frame. Add more numbered entries to add more images, notes, or cards. */
-.item-portrait-slideshow[value="0"] ~ div.item-portrait-00,
-.item-portrait-slideshow[value="1"] ~ div.item-portrait-01,
-.item-portrait-slideshow[value="2"] ~ div.item-portrait-02 {
-	display: block;
-	position: relative;
-}
-
-/* Alternate styling for rule cards instead of portraits */
-.item-portrait-00 {
-	background-color: white;
-	border: solid 2px gray;
-	height: 250px;
-	width: 250px;
-	margin-left: 5px;
-}
-
-.item-portrait-00 h1 {
-	font-size: 16px;
-	color: white;
-	text-align: center;
-	padding-left: 0px;
-	background-color: crimson;
-}
-
-.item-portrait-flex-container {
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-start;
-	max-height: 240px;
-	padding: 0px;
-}
-
-.item-portrait-rule-description {
-	max-width: 250px;
-	margin: 0px;
-	padding: 0px;
-	line-height: 1.0;
-}
-
-.item-portrait-rule-description h1 {
-	font-size: 16px;
-	color: firebrick;
-	text-align: center;
-	padding-left: 4px;
-	background-color: inherit;
-	line-height: 1.4;
-	padding-bottom: 0px;
-}
-
-.item-portrait-rule-description p {
-	font-size: 13px;
-	padding: 4px;
-	margin: 0px;
-	text-align: left;
-	line-height: 1.2;
-}
-
-/* Item: health status                                     */
-/* Item: gear tab health status                            */
-/* Sheet worker used to synchronizes the contents of each  */
-
-.item-characteristics-health,
-.item-gear-health {
-	padding: 0px;
-	width: 68px;
-	background: royalblue;
-	border: white;
-	margin-top: 4px;
-	margin-right: 2px;
-	height: 250px;
-	align-items: center;
-	display: flex;
-	justify-content: space-between;
-	flex-direction: column;
-}
-
-.item-powers-health {
-	padding: 6px;
-	width: 318px;
-	height: 56px;
-	margin: 0px;
-	align-items: center;
-	display: flex;
-	justify-content: space-between;
-	flex-direction: row;
-	background-color: royalblue;
-	border: 3px solid #fff990;
-	border-radius: 5px;
-}
-
-.item-characteristics-health  {
-	grid-area: health;
-}
-
-.item-gear-health {
-	grid-area: gearHealth;
-}
-
-.item-powers-health {
-	grid-area: powerHealth;
-}
-
-.item-gear-health h2,
-.item-characteristics-health h2,
-.item-powers-health h2 {
-	color: white;
-	background-color: inherit;
-	text-align: center;
-	font-size: 17px;
-	line-height: 1.0em;
-	margin-top: 0px;
-	margin-bottom: 0px;
-	padding: 0px;
-}
-
-.item-health-stat {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	width: 63px;
-	height: 30px;
-	background-color: gold;
-	border-radius: 3px;
-	align-items: center;
-	padding: 0px;
-	margin-right: 1px;
-	margin-bottom: 2px;
-	border: solid 1px darkgoldenrod;
-}
-
-.item-health-stat-enclosure {
-	padding: none;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	height: 57px;
-}
-
-.item-health-stat-plus-minus-enclosure {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	max-height: 20px;
-	width: 20px;
-	align-items: center;
-	padding: 1px;
-}
-
-.item-health-stat input[type=text] {
-	max-width: 45px;
-	height: 30px;
-	font-size: 20px;
-	background-color: gold;
-}
-
-.item-health-stat input[type=text]:focus{
-	outline: transparent;
-}
-
-.item-health-stat button.buttonPlus,
-.item-health-stat button.buttonMinus {
-	background-color: LemonChiffon;
-	border: solid 1px slategray;
-	color: slategray;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	display: inline-block;
-	font-size: 16px;
-	margin: 0px 0px;
-	line-height: 1.4ch;
-	border-radius: 0px;
-}
-
-.item-health-stat button.buttonPlus span,
-.item-health-stat button.buttonMinus span {
-	display: inline-block;
-	transform: rotate(-90deg);
-	text-align: center;
-}
-
-.item-health-stat button.buttonPlus:hover,
-.item-health-stat button.buttonMinus:hover {
-	background-color: gray;
-	color: white;
-	transition: 0.05s;
-}
-
-/* Item: Turn Tracker Button Space */
-
-.item-characteristics-turn-tracker {
-	grid-area: turnTracker;
-	width: 68px;
-	height: 22px;
-	padding: 0px;
-	line-height: 20px;
-}
-
-/* Item: character history */
-.item-characteristics-history {
-	grid-area: history;
-	text-align: left;
-	padding: 2px;
-	max-width: 343px;
-	background-color: inherit;
-	margin-bottom: 1px;
-	margin-right: 6px;
-	max-height: 402px;
-	margin-bottom: 6px;
-}
-
-.item-characteristics-history textarea {
-	width: 316px;
-	height: 100%;
-}
-
-/* Item: Speed Phase Indicator Buttons */
-.item-characteristics-speedIndicatorButtons {
-	grid-area: speedIndicatorButtons;
-	padding-left: 2px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	background-color: royalblue;
-	width: 264px;
-	margin: 0px;
-}
-
-/* Item: Perception */
-.item-characteristics-perception {
-	grid-area: perception;
-	max-width: 323px;
-	background-color: inherit;
-	max-height: 95px;
-	margin-left: 3px;
-	border: transparent;
-	margin-top: 0px;
-}
-
-.item-characteristics-perception h1 {
-	font-size: 13px;
-	line-height: 1.6;
-	text-align: left;
-	background-color: royalblue;
-	color: white;
-}
-
-.item-characteristics-perception input[type=number] {
-	text-align: right;
-	padding-right: 0px;
-	border: solid 1px palegoldenrod;
-	margin: 0px;
-	margin-bottom: 3px;
-	background-color: white;
-	max-width: 40px;
-}
-
-.subitem-characteristics-perception-stat-container {
-	display: flex;
-	justify-content: space-between;
-	flex-direction: column;
-	background-color: inherit;
-	padding-left: 0px;
-	align-items: center;
-}
-
-.subitem-characteristics-perception-stat-container input[type=text] {
-	font-size: 13px;
-	max-width: 65px;
-	text-align: center;
-	background-color: royalblue;
-	color: white;
-	font-weight: bold;
-	margin-top: 2px;
-}
-
-.subitem-characteristics-perception-column-container {
-	display: flex;
-	justify-content: space-between;
-	flex-direction: column;
-	background-color: lightblue;
-	padding: 2px;
-	align-items: center;
-	border-radius: 5px;
-	border: solid lightcyan 2px;
-}
-
-.subitem-characteristics-perception-column-container input[type=text] {
-	font-size: 13px;
-	max-width: 32px;
-	line-height: 1.3;
-	text-align: center;
-	background-color: lightcyan;
-	padding: 0px;
-	color: black;
-	font-weight: normal;
-}
-
-.subitem-characteristics-perception-row-container {
-	display: flex;
-	justify-content: space-between;
-	flex-direction: row;
-	margin-top: 2px;
-}
-
-/* --------------------------------------------------- */
-/* Options Tab                                         */
-/* --------------------------------------------------- */
-
-.grid-container-tab-options {
-	display: grid;
-	grid-template-areas: ". . ." 
-		". options ."
-		". . .";
-	grid-template-columns: 110px 500px 100px;
-	grid-template-rows: 100px 185px 100px;
-	font-size: 16px;
-	background-color: royalblue;
-	border: 3px solid #fff990;
-	border-radius: 5px;
-	margin-bottom: 1px;
-	min-height: 800px;
-	min-width: 674px;
-}
-
-.grid-container-tab-options h1 {
-	font-size: 14px;
-	margin-left: 0px;
-	color: black;
-	padding-bottom: 5px;
-	font-weight: 500;
-}
-
-.grid-container-tab-options label {
-	max-width: 13px;
-	padding: 8px;
-}
-
-/* Sub-Item: options */
-.item-options {
-	grid-area: options;
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-start;
-	padding-left: 2px;
-	padding-top: 2px;
-	padding-bottom: 2px;
-	background-color: #fff990;
-	margin: 5px;
-	width: 450px;
-	height: 308px;
-	margin: 0px;
-	border: solid 2px goldenrod;
-	border-radius: 3px;
-}
-
-.item-options-row,
-.item-version-row {
-	align-items: baseline;
-	min-width: 400px;
-	max-height: 28px;
-	margin-left: 10px;
-}
-
-.item-options-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: flex-start;
-}
-
-/* --------------------------------------------------- */
-/* Version Info                                        */
-/* --------------------------------------------------- */
-
-.item-version-row {
-	display: grid;
-	grid-template-areas: "versionLabel versionInfo";
-	justify-content: flex-end;
-}
-
-.item-version-label h2 {
-	font-size: 13px;
-	max-height: 28px;
-	color: black;
-}
-
-.item-version-information input[readonly] {
-	background-color: #fff990;
-	color: black;
-	max-width: 35px;
-	padding-bottom: 1px;
-}
-
-/* --------------------------------------------------- */
-/* Custom buttons                                      */
-/* --------------------------------------------------- */
-
-.button {
-	border: none;
-	color: white;
-	text-decoration: none;
-	display: inline-block;
-	cursor: pointer;
-	transition-duration: 0.2s;
-	text-align: center;
-}
+	/* ----------------------------------------------------- */
+	/* Skills                                                */
+	/* Organized into a 2x3 grid of containers               */
+	/* ----------------------------------------------------- */
+	.grid-container-skills-tab {
+		display: grid;
+		grid-template-areas:
+		"theSkills1 theCombatSkills"
+		"theSkills2 theLanguageSkills"
+		"theSkills3 theEnhancers";
+		grid-gap: 6px;
+		grid-template-columns: 358px 322px;
+		grid-template-rows: 273px 251px 259px;
+		max-width: 692px;
+		padding: 0px;
+		padding-left: 0px;
+		padding-top: 6px;
+		margin-bottom: 0px;
+		font-size: 16px;
+		background-color: gold;
+		border: 3px solid #fff990;
+		border-radius: 5px;
+		justify-content: middle;
+		min-height: 795px;
+	}
 	
-.buttonRecover {
-	background-color: darkseagreen;
-	padding-top: 4px;
-	padding-bottom: 4px;
-	margin-left: 2px;
-	margin-right: 2px;
-	margin-top: 0px;
-	margin-bottom: 0px;
-	padding-left: 4px;
-	padding-right: 3.5px;
-	vertical-align: middle;
-	text-align: right;
-	font-size: 13px;
-	font-weight: bold;
-	border-radius: 3px;
-}
-
-.buttonReset {
-	background-color: orange;
-	padding-top: 4px;
-	padding-bottom: 4px;
-	margin-left: 2px;
-	margin-right: 2px;
-	margin-top: 0px;
-	margin-bottom: 0px;
-	padding-left: 12px;
-	padding-right: 12px;
-	vertical-align: middle;
-	text-align: center;
-	font-size: 13px;
-	font-weight: bold;
-	border-radius: 3px;
-}
-
-.buttonTracker {
-	background-color: dodgerblue;
-	padding-left: 3px;
-	padding-right: 3px;
-	padding-top: 2px;
-	padding-bottom: 2px;
-	font-weight: bold;
-}
-
-.button-Power-END-right,
-.button-Power-END-left {
-	padding-top: 2px;
-	padding-bottom: 2px;
-	padding-right: 2px;
-	padding-left: 2px;
-	min-height: 16px;
-	max-height: 16px;
-	text-align: middle;
-	font-weight: bold;
-	border-radius: 2.5px;
-}
-
-.button-Power-END-left {
-	/* background-color: olive; */
-	background-color: #8A8A8A;
-	margin-right: 0px;
-	min-width: 34px;
-	max-width: 35px;
-}
-
-.button-Power-END-right {
-	/* background-color: salmon; */
-	background-color: #8A8A8A;
-	margin-right: 0px;
-	min-width: 34px;
-	max-width: 35px;
-}
-
-.buttonRoll,
-.buttonRollAttack,
-.buttonRollActivate,
-.buttonRollNormalAttack,
-.buttonRollShieldAttack,
-.buttonRollShow,
-.buttonRollPower,
-.buttonManeuverEND {
-	padding-left: 3px;
-	padding-right: 3px;
-	text-align: center;
-	line-height: 13px;
-	padding-top: 2px;
-	padding-bottom: 2px;
-	font-weight: bold;
-	max-height: 16px;
-	min-height: 15px;
-}
-
-.buttonRoll,
-.buttonRollAttack,
-.buttonRollActivate,
-.buttonRollShieldAttack {
-	min-width: 25px;
-	max-width: 26px;
-}
-
-
-.buttonRollPower {
-	min-width: 32px;
-	max-width: 34px;
-}
-
-.button:hover,
-.buttonRecover:hover,
-.buttonReset:hover,
-.buttonRoll:hover,
-.buttonRollAttack:hover,
-.buttonRollActivate:hover,
-.buttonRollNormalAttack:hover,
-.buttonRollShieldAttack:hover,
-.buttonRollShow:hover,
-.buttonRollPower:hover {
-	color: black;
-	background-color: lightgray;
-	text-align: center;
-}
-
-.button-Power-END-left:hover,
-.button-Power-END-right:hover,
-.buttonManeuverEND:hover {
-	background-color: #ff9900;
-	color: black;
-}
-
-.buttonRoll {
-	margin-right: 3px;
-	margin-left: 3px;
-	background-color: #E69F00;
-	border-radius: 3px;
-}
-
-.buttonRollAttack {
-	background-color: #D55E00;
-	border-radius: 2.5px;
-}
-
-.item-flex-maneuver .buttonRollAttack,
-.item-flex-maneuver .buttonRollShow,
-.item-flex-maneuver .buttonManeuverEND {
-	margin-right: 3px;
-	margin-left: 3px;
-	border-radius: 3px;
-	min-width: 36px;
-	max-width: 38px;
-}
-
-.item-flex-maneuver .buttonRollAttack {
-	margin-left: 61px;
-}
-
-/* Change attack button color to indicate normal damage. */
-.weapon-normal-damage01[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon01"]:not(:hover),
-.weapon-normal-damage02[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon02"]:not(:hover),
-.weapon-normal-damage03[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon03"]:not(:hover),
-.weapon-normal-damage04[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon04"]:not(:hover),
-.weapon-normal-damage05[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon05"]:not(:hover)
-{
-	background-color: #009E73;
-}
-
-/* Change maneuver attack button color to indicate normal damage. */
-.maneuver-normal-damage01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
-.maneuver-normal-damage02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
-.maneuver-normal-damage03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
-.maneuver-normal-damage04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
-.maneuver-normal-damage05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
-.maneuver-normal-damage06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
-.maneuver-normal-damage07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
-.maneuver-normal-damage08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
-.maneuver-normal-damage09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
-{
-	background-color: #009E73;
-}
-
-/* Change maneuver attack button color to indicate a non-damaging defensive action. */
-.maneuver-block01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
-.maneuver-block02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
-.maneuver-block03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
-.maneuver-block04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
-.maneuver-block05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
-.maneuver-block06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
-.maneuver-block07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
-.maneuver-block08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
-.maneuver-block09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
-{
-	background-color: #56B4E9;
-}
-
-.buttonRollActivate {
-	margin-right: 3px;
-	margin-left: 3px;
-	background-color: #0072B2;
-	border-radius: 3px;
-}
-
-.buttonRollNormalAttack,
-.buttonManeuverEND,
-.buttonRollShow {
-	margin-right: 3px;
-	margin-left: 3px;
-	border-radius: 3px;
-	min-width: 34px;
-	max-width: 36px;
-}
-
-.buttonRollNormalAttack {
-	margin-left: 61px;
-	background-color: #D55E00;
-}
-
-.buttonManeuverEND {
-	background-color: #8A8A8A;
-	font-weight: bold;
-}
-
-.buttonRollShow {
-	background-color: #8A8A8A;
-}
-
-.buttonRollShieldAttack  {
-	background-color: #56B4E9;
-	border-radius: 2.5px;
-}
-
-.buttonRollPower {
-	/* background-color: #9184E2; lighter than mediumslateblue */
-	background-color: #CC79A7;
-	border-radius: 2.5px;
-}
-
-/* The d6 of dicefontd6 doesn't look good. Let's hold off for a better idea or stick with the label 'Roll' on the buttons.
-
-.buttonRollNormalAttack::before {
-	font-family: 'dicefontd6';
-	font-size: 16px;
-	content: 'F';
-} */
-
-.portrait-display-button-left,
-.portrait-display-button-right {
-	background-color: orange;
-	padding-top: 4px;
-	padding-bottom: 4px;
-	margin: 4px 2px;
-	padding-left: 14px;
-	padding-right: 14px;
-	vertical-align: middle;
-	text-align: center;
-}
-
-.portrait-display-button-left:hover,
-.portrait-display-button-right:hover {
-	color: black;
-	background-color: limegreen;
-	text-align: center;
-}
-
-
-/* --------------------------------------------------- */
-/* Custom Checkbox used for options                    */
-/* From w3 schools                                     */
-/* --------------------------------------------------- */
-
-/* Customize the label (the container) */
-.container-checkbox {
-	display: inline-block;
-	position: relative;
-	padding-left: 25px;
-	padding-top: 2px;
-	/* margin-bottom: 10px; */
-	cursor: pointer;
-	max-width: 400px;
-	font-size: 12px;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-	border: transparent;
-}
-
-/* Hide the browser's default checkbox */
-.container-checkbox input,
-.container-checkbox-small input,
-.container-checkbox-small-gray input {
-	position: absolute;
-	opacity: 0;
-	cursor: pointer;
-	height: 0;
-	width: 0;
-}
-
-/* Create a custom checkbox */
-.checkmark {
-	position: absolute;
-	top: 0;
-	left: 0;
-	height: 20px;
-	width: 20px;
-	background-color: gold;
-}
-
-/* On mouse-over, add a grey background color */
-.container-checkbox:hover input ~ .checkmark,
-.container-checkbox-small:hover input ~ .checkmark-small {
-	background-color: goldenrod;
-	border: solid 1px darkgoldenrod;
-}
-
-.container-checkbox-small-gray:hover input ~ .checkmark-small-gray {
-	background-color: lightsteelblue;
-	border: solid 1px darkgray;
-}
-
-/* When the checkbox is checked, add a gold background */
-.container-checkbox input:checked ~ .checkmark,
-.container-checkbox-small input:checked ~ .checkmark-small {
-	background-color: gold;
-}
-
-.container-checkbox-small-gray input:checked ~ .checkmark-small-gray {
-	background-color: lightgray;
-}
-
-/* Create the checkmark/indicator (hidden when not checked) */
-.checkmark:after,
-.checkmark-small:after {
-	content: "";
-	position: absolute;
-	display: none;
-	border: solid 1px darkgoldenrod;
-}
-
-.checkmark-small-gray:after {
-	content: "";
-	position: absolute;
-	display: none;
-	border: solid 1px gray;
-}
-
-/* Show the checkmark when checked */
-.container-checkbox input:checked ~ .checkmark:after,
-.container-checkbox-small input:checked ~ .checkmark-small:after,
-.container-checkbox-small-gray input:checked ~ .checkmark-small-gray:after {
-	display: block;
-}
-
-/* Style the checkmark/indicator */
-.container-checkbox .checkmark:after {
-	left: 7px;
-	top: 2px;
-	width: 5px;
-	height: 10px;
-	border: solid black;
-	border-width: 0 3px 3px 0;
-	-webkit-transform: rotate(45deg);
-	-ms-transform: rotate(45deg);
-	transform: rotate(45deg);
-}
-
-/* --------------------------------------------------- */
-/* Custom Checkbox (small) used for skill enhancers    */
-/* From w3 schools                                     */
-/* --------------------------------------------------- */
-
-/* Customize the label (the container) */
-.container-checkbox-small,
-.container-checkbox-small-gray {
-	display: block;
-	position: relative;
-	padding-left: 20px;
-	padding-top: 0px;
-	cursor: pointer;
-	font-size: 12px;
-	max-width: 20px;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-}
-
-/* Create a custom checkbox */
-.checkmark-small {
-	position: absolute;
-	top: 0;
-	left: 0;
-	height: 15px;
-	width: 15px;
-	background-color: gold;
-}
-
-.checkmark-small-gray {
-	position: absolute;
-	top: 0;
-	left: 0;
-	height: 15px;
-	width: 15px;
-	background-color: lightgray;
-}
-
-/* Style the checkmark/indicator */
-.container-checkbox-small .checkmark-small:after,
-.container-checkbox-small-gray .checkmark-small-gray:after {
-	left: 4px;
-	top: 2px;
-	width: 4px;
-	height: 7px;
-	border: solid black;
-	border-width: 0 3px 3px 0;
-	-webkit-transform: rotate(45deg);
-	-ms-transform: rotate(45deg);
-	transform: rotate(45deg);
-}
-
-
-.subitem-flex-container-martial-cv-damage-row .container-checkbox-small-gray {
-	margin-bottom: 14px;
-	padding: 0px;
-}
-
-/* --------------------------------------------------- */
-/* Custom Checkboxes used for turn segment indicators  */
-/* Modification of custom checkbox above               */
-/* --------------------------------------------------- */
-
-.grid-container-container-turn-segments {
-	grid-area: turnSegmentIndicators;
-	display: inline-flex; /* or inline-flex */
-	flex-direction: row;
-	flex-wrap: nowrap;
-	align-items: top;
-	justify-content: space-evenly;
-	width: 264px;
-	height: 24px;
-	background: royalblue;
-	margin-top: 2px;
-	margin-left: 1px;
-	padding: 0px;
-}
-
-.grid-container-container-turn-segments label {
-	display: inline;
-	pointer-events: none;
-	font-style: normal;
-}
-
-/* Custom checkbox indicator */
-
-.container-speed-indicator {
-	display: inline-block;
-	position: relative;
-	padding-left: 5px;
-	margin-bottom: 0px;
-	cursor: pointer;
-	font-size: 20px;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-}
+	.grid-container-skills-tab h1 {
+		display:inline-block;
+		margin-left: 0px;
+		padding-left: 2px;
+		padding-right: 0px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		margin: 0px;
+		margin-top: 1px;
+		font-size: 13px;
+		font-style: normal;
+		line-height: 1.10;
+		text-align: center;
+	}
 	
-/* Hide the browser's default checkbox */
-.container-speed-indicator input {
-	position: absolute;
-	opacity: 0;
-	cursor: pointer;
-	height: 0;
-	width: 0;
-}
-
-/* Custom checkbox */
-
-.checkmark01,
-.checkmark02,
-.checkmark03,
-.checkmark04,
-.checkmark05,
-.checkmark06,
-.checkmark07,
-.checkmark08,
-.checkmark09,
-.checkmark10,
-.checkmark11,
-.checkmark12 {
-	position: absolute;
-	top: 0;
-	left: 0;
-	height: 20px;
-	width: 20px;
-	background-color: dodgerblue;
-	border: none;
-	border-radius: 5px;
-	pointer-events: none;
-}
-
-/* Custom segment indicator checkbox: Status */
-.container-speed-indicator input:checked ~ .checkmark01,
-.container-speed-indicator input:checked ~ .checkmark02,
-.container-speed-indicator input:checked ~ .checkmark03,
-.container-speed-indicator input:checked ~ .checkmark04,
-.container-speed-indicator input:checked ~ .checkmark05,
-.container-speed-indicator input:checked ~ .checkmark06,
-.container-speed-indicator input:checked ~ .checkmark07,
-.container-speed-indicator input:checked ~ .checkmark08,
-.container-speed-indicator input:checked ~ .checkmark09,
-.container-speed-indicator input:checked ~ .checkmark10,
-.container-speed-indicator input:checked ~ .checkmark11,
-.container-speed-indicator input:checked ~ .checkmark12 {
-	background-color: hotpink;
-	border: none;
-	border-radius: 5px;
-}
-
-/* Custom segment indicator checkbox 01. Active/checked. */
-.checkmark01:after {
-	content: "1";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 01. Inactive/not checked. */
-.checkmark01:before {
-	content: "1";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 02. Active/checked. */
-.checkmark02:after {
-	content: "2";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 02. Inactive/not checked. */
-.checkmark02:before {
-	content: "2";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 03. Active/checked. */
-.checkmark03:after {
-	content: "3";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 03. Inactive/not checked. */
-.checkmark03:before {
-	content: "3";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 04. Active/checked. */
-.checkmark04:after {
-	content: "4";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 04. Inactive/not checked. */
-.checkmark04:before {
-	content: "4";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 05. Active/checked. */
-.checkmark05:after {
-	content: "5";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 05. Inactive/not checked. */
-.checkmark05:before {
-	content: "5";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 06. Active/checked. */
-.checkmark06:after {
-	content: "6";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 06. Inactive/not checked. */
-.checkmark06:before {
-	content: "6";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 07. Active/checked. */
-.checkmark07:after {
-	content: "7";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 07. Inactive/not checked. */
-.checkmark07:before {
-	content: "7";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 08. Active/checked. */
-.checkmark08:after {
-	content: "8";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 08. Inactive/not checked. */
-.checkmark08:before {
-	content: "8";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 09. Active/checked. */
-.checkmark09:after {
-	content: "9";
-	color: white;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 09. Inactive/not checked. */
-.checkmark09:before {
-	content: "9";
-	color: black;
-	position: absolute;
-	padding-left: 6px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 10. Active/checked. */
-.checkmark10:after {
-	content: "10";
-	color: white;
-	position: absolute;
-	padding-left: 2px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 10. Inactive/not checked. */
-.checkmark10:before {
-	content: "10";
-	color: black;
-	position: absolute;
-	padding-left: 2px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 11. Active/checked. */
-.checkmark11:after {
-	content: "11";
-	color: white;
-	position: absolute;
-	padding-left: 3px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 11. Inactive/not checked. */
-.checkmark11:before {
-	content: "11";
-	color: black;
-	position: absolute;
-	padding-left: 3px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 12. Active/checked. */
-.checkmark12:after {
-	content: "12";
-	color: white;
-	position: absolute;
-	padding-left: 2px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Custom segment indicator checkbox 12. Inactive/not checked. */
-.checkmark12:before {
-	content: "12";
-	color: black;
-	position: absolute;
-	padding-left: 2px;
-	padding-top: 1px;
-	display: none;
-}
-
-/* Show the checkmark when checked */
-.container-speed-indicator input:checked ~ .checkmark01:after,
-.container-speed-indicator input:checked ~ .checkmark02:after,
-.container-speed-indicator input:checked ~ .checkmark03:after,
-.container-speed-indicator input:checked ~ .checkmark04:after,
-.container-speed-indicator input:checked ~ .checkmark05:after,
-.container-speed-indicator input:checked ~ .checkmark06:after,
-.container-speed-indicator input:checked ~ .checkmark07:after,
-.container-speed-indicator input:checked ~ .checkmark08:after,
-.container-speed-indicator input:checked ~ .checkmark09:after,
-.container-speed-indicator input:checked ~ .checkmark10:after,
-.container-speed-indicator input:checked ~ .checkmark11:after,
-.container-speed-indicator input:checked ~ .checkmark12:after {
-	display: block;
-}
-
-/* Show the checkmark when checked */
-.container-speed-indicator input:not(:checked) ~ .checkmark01:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark02:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark03:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark04:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark05:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark06:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark07:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark08:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark09:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark10:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark11:before,
-.container-speed-indicator input:not(:checked) ~ .checkmark12:before {
-	display: block;
-}
-
-/* --------------------------------------------------- */
-/* Talents, Perks, and Complications                   */
-/* --------------------------------------------------- */
-.grid-container-complications-talents {
-	display: grid;
-	grid-gap: 4px;
-	grid-template-areas: 
-	"theTalentsAndPerks theComplications"
-	"theNotes theNotes";
-	grid-template-columns: 338px 338px;
-	grid-template-rows: 642px 160px;
-	max-width: 685px;
-	padding: 0px;
-	font-size: 16px;
-	background-color: dodgerblue;
-	justify-content: middle;
-	padding-bottom: 0px;
-	margin-bottom: 1px;
-}
-
-.grid-container-complications-talents h2 {
-	font-size: 18px;
-	line-height: 1.3;
-	text-align: center;
-	font-weight: normal;
-}
-
-/* Complications and Talents Tab: Talents and Perks */
-.flex-container-complications-talents-left {
-	grid-area: theTalentsAndPerks;
-	display: flex;
-	justify-content: space-between;
-	flex-direction: column;
-	border: 3px solid #fff990;
-	border-radius: 5px;
-	max-width: 333px;
-	background: gold;
-	height: 630px;
-	padding: 5px;
-	padding-bottom: 0px;
-	margin-bottom: 0px;
-}
-
-.item-talent-heading {
-	display: flex;
-	flex-wrap: nowrap;
-	justify-content: space-between;
-	align-items: center;
-	flex-direction: row;
-	margin-bottom: 0px;
-	padding: 0px;
-	max-width: 333px;
-}
-
-.item-talent-heading input[type=text] {
-	max-width: 200px;
-	padding: 1px;
-	padding-left: 3px;
-	margin: 0px;
-	margin-right: 0px;
-	margin-left: 2px;
-	text-align: left;
-	font-size: 13px;
-	font-weight: bold;
-	border: solid 1px darkgray;
-}
-
-.item-talent-heading input[type=number] {
-	max-width: 45px;
-	padding: 2px;
-	margin: 0px;
-	padding-right: 0px;
-	text-align: right;
-	border: solid 1px darkgray;
-}
-
-.item-talent-heading h1 {
-	font-size: 12px;
-	line-height: 1.1;
-	padding-right: 2px;
-	padding-left: 6px;
-}
-
-.item-talent-textbox textarea {
-	max-width: 314px;
-	max-height: 36px;
-	padding: 3px;
-	border: solid 1px darkgray;
-	margin-bottom: 6px;
-}
-
-
-/* Complications and Talents Tab: Complications */
-.flex-container-complications-talents-right {
-	grid-area: theComplications;
-	display: flex;
-	justify-content: space-between;
-	flex-direction: column;
-	border: 3px solid lightcyan;
-	border-radius: 5px;
-	max-width: 333px;
-	background: lightblue;
-	height: 630px;
-	padding: 5px;
-	padding-bottom: 0px;
-	margin-bottom: 0px;
-}
-
-.item-complication-heading {
-	display: flex;
-	flex-wrap: nowrap;
-	justify-content: space-between;
-	align-items: center;
-	flex-direction: row;
-	margin-bottom: 0px;
-	padding: 0px;
-	max-width: 333px;
-}
-
-.item-complication-heading input[type=text] {
-	max-width: 210px;
-	padding: 1px;
-	padding-left: 3px;
-	margin: 0px;
-	margin-right: 0px;
-	margin-left: 2px;
-	text-align: left;
-	font-size: 13px;
-	font-weight: bold;
-	border: solid 1px darkgray;
-}
-
-.item-complication-heading input[type=number] {
-	max-width: 45px;
-	padding: 2px;
-	margin: 0px;
-	padding-right: 0px;
-	text-align: right;
-	border: solid 1px darkgray;
-}
-
-.item-complication-heading h1 {
-	font-size: 12px;
-	line-height: 1.1;
-	padding-right: 2px;
-	padding-left: 6px;
-}
-
-.item-complication-textbox textarea {
-	max-width: 314px;
-	max-height: 54px;
-	padding: 3px;
-	border: solid 1px darkgray;
-	margin-bottom: 6px;
-}
-
-/* Complications Tab: Notes Text Panel */
-
-.flex-container-complications-bottom {
-	grid-area: theNotes;
-	display: flex;
-	flex-direction: row;
-	flex-wrap: nowrap;
-	justify-content: space-between;
-	border: 3px solid lightgray;
-	border-radius: 5px;
-	max-width: 674px;
-	padding: 5px;
-	margin: 0px;
-	height: 145px;
-	background: white;
-}
-
-.flex-container-complications-bottom textarea {
-	width: 322px;
-	max-height: 143px;
-	padding: 0px;
-	margin: 0px;
-	border: transparent;
-}
-
-/* ----------------------------------------------------- */
-/* Powers                                                */
-/* Organized in two columns with different color styles. */
-/* ----------------------------------------------------- */
-.grid-container-powers {
-	display: grid;
-	grid-gap: 5px 5px;
-	grid-template-areas: 
-	"leftPowers powerHealth"
-	"leftPowers rightPowers";
-	grid-template-columns: 338px 336px;
-	grid-template-rows: 74px 727px;
-	max-width: 686px;
-	min-width: 676px;
-	padding: 0px;
-	font-size: 16px;
-	background-color: dodgerblue;
-	justify-content: middle;
-	padding-bottom: 0px;
-	margin-bottom: 1px;
-}
-
-.grid-container-powers h1 {
-	display:inline-block;
-	margin-left: 0px;
-	padding-left: 2px;
-	padding-right: 0px;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	margin: 0px;
-	margin-top: 1px;
-	font-size: 13px;
-	font-style: normal;
-	line-height: 1.35;
-}
-
-.grid-container-powers input[type=number] {
-	padding-right: 0px;
-	padding-top: 2px;
-	width: 30px;
-	margin: 0px;
-	text-align: right;
-	height: 21px;
-	padding: 1px;
-}
-
-.flex-container-powers-right,
-.flex-container-powers-left {
-	display: flex;
-	justify-content: space-between;
-	flex-direction: column;
-	border-radius: 5px;
-	max-width: 333px;
-	padding-left: 4px;
-	padding-right: 4px;
-	margin: 0px;
-}
-
-.flex-container-powers-left,
-.flex-container-powers-right {
-	padding-top: 3px;
-	padding-bottom: 3px;
-}
-
-.flex-container-powers-left {
-	height: 795px;
-}
-
-.flex-container-powers-right {
-	height: 716px;
-}
-
-.flex-container-powers-left textarea,
-.flex-container-powers-right textarea {
-	color: gray; 
-	height: 54px;
-	padding: 3px;
-	margin: 0px;
-	margin-top: 1px;
-	font-size: 8;
-}
-
-.flex-container-powers-left textarea {
-	max-width: 316px;
-}
-
-.flex-container-powers-right textarea {
-	border: solid 1px goldenrod;
-	max-width: 315px;
-}
-
-/* Power subitems. */
-
-.item-flex-power {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-top: 2px;
-	padding-bottom: 3px;
-}
-
-.subitem-flex-power-heading-left,
-.subitem-flex-power-heading-right,
-.subitem-flex-power-effect-left,
-.subitem-flex-power-effect-right {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	margin-top: 1px;
-	margin-bottom: 0px;
-	align-items: center;
-	max-height: 23px;
-}
-
-.subitem-flex-power-heading-left input[type=text],
-.subitem-flex-power-heading-right input[type=text],
-.subitem-flex-power-effect-left input[type=text],
-.subitem-flex-power-effect-right input[type=text] {
-	min-height: 22px;
-	text-align: left;
-	padding-left: 2px;
-	margin-right: 0px;
-}
-
-.subitem-flex-power-heading-left input[type=text]:nth-child(2),
-.subitem-flex-power-heading-right input[type=text]:nth-child(2) {
-	font-weight: bold;
-	max-width: 130px;
-	margin-left: 1px;
-}
-
-.subitem-flex-power-heading-left input[type=text]:nth-child(4),
-.subitem-flex-power-heading-right input[type=text]:nth-child(4) {
-	font-weight: bold;
-	text-align: center;
-}
-
-.subitem-flex-power-heading-left select,
-.subitem-flex-power-heading-right select {
-	font-size: 13px;
-	height: 19px;
-	width: 98px;
-	margin: 0px;
-	padding-left: 3px;
-}
-
-/* Effect */
-.subitem-flex-power-effect-left input[type=text]:nth-child(2),
-.subitem-flex-power-effect-right input[type=text]:nth-child(2){
-	max-width: 130px;
-	max-height: 23px;
-}
-
-/* Dice */
-.subitem-flex-power-effect-left input[type=text]:nth-child(3),
-.subitem-flex-power-effect-right input[type=text]:nth-child(3) {
-	max-width: 58px;
-	text-align: center;
-	margin-left: 2px;
-	margin-right: 0px;
-	padding-left: 0px;
-	padding-right: 0px;
-}
-
-/* Roll chance */
-.subitem-flex-power-effect-left input[type=number]:nth-child(5), 
-.subitem-flex-power-effect-right input[type=number]:nth-child(5) {
-	max-width: 41px;
-	min-width: 41px;
-	text-align: right;
-	margin-left: 1px;
-	margin-right: 2px;
-}
-
-.subitem-flex-power-activeCost input[type=number]:nth-child(2), /* Advantages */
-.subitem-flex-power-activeCost input[type=number]:nth-child(4) /* Limitations */ {
-	border: solid 1px gray;
-	min-width: 55px;
-}
-
-/* Powers Tab: Left Powers and general to right. */
-.flex-container-powers-left {
-	grid-area: leftPowers;
-	border: 3px solid lightcyan;
-	background: lightblue;
-}
-
-.flex-container-powers-left textarea {
-	border: solid 1px black;
-}
-
-.flex-container-powers-left input[readonly]{
-	background: lightcyan;
-	border: solid 1px #89abb9;
-	line-height: 1.0;
-}
-
-.flex-container-powers-left textarea{
-	border: 1px solid #89ABB9;
-}
-
-.subitem-flex-power-heading-left input[type=text]{
-	border: solid 1px #89ABB9;
-	max-width: 28px;
-}
-
-.subitem-flex-power-effect-left input[type=text],
-.subitem-flex-power-effect-left input[type=number]{
-	border: solid 1px #89ABB9;
-}
-
-.subitem-flex-power-points-block-left,
-.subitem-flex-power-points-block-right {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: center;
-	max-height: 23px;
-	margin-bottom: 2px;
-}
-
-.subitem-flex-power-points-block-left input[type=number] {
-	/* Active, Real Cost */
-	border: solid 1px #89ABB9;
-}
-
-.subitem-flex-power-points-block-left input[readonly] {
-	/* Active, Real Cost */
-	max-width: 38px;
-	text-align: center;
-	padding: 0px;
-}
-
-.subitem-flex-power-limitations-left,
-.subitem-flex-power-limitations-right {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	max-width: 333px;
-	margin-bottom: 2px;
-	max-height: 23px;
-}
-
-.subitem-flex-power-limitations-left input[type=number]{
-	/* Advantages, limitations */
-	border: solid 1px #89ABB9;
-	min-width: 50px;
-}
-
-.subitem-flex-power-limitations-left select,
-.subitem-flex-power-limitations-right select {
-	font-size: 13px;
-	height: 19px;
-	max-width: 115px;
-	margin: 0px;
-	align-items: center;
-	padding-left: 3px;
-}
-
-
-/* Powers Tab: Right Powers */
-.flex-container-powers-right {
-	grid-area: rightPowers;
-	border: 3px solid #fff990;
-	background: gold;
-}
-
-.flex-container-powers-right textarea {
-	border: solid 1px black;
-}
-
-.flex-container-powers-right input[readonly]{
-	background: #fff990;
-	border: solid 1px goldenrod;
-	line-height: 1.0;
-}
-
-.flex-container-powers-right textarea{
-	border: 1px solid goldenrod;
-}
-
-.subitem-flex-power-heading-right input[type=text] {
-	max-width: 28px;
-	border: solid 1px goldenrod;
-}
-
-.subitem-flex-power-effect-right input[type=text],
-.subitem-flex-power-effect-right input[type=number]{
-	border: solid 1px goldenrod;
-}
-
-.subitem-flex-power-points-block-right input[type=number] {
-	/* Active, Real Cost */
-	border: solid 1px goldenrod;
-}
-
-.subitem-flex-power-points-block-right input[readonly] {
-	/* Active, Real Cost */
-	max-width: 38px;
-	text-align: center;
-}
-
-.subitem-flex-power-limitations-right input[type=number]{
-	/* Advantages, limitations */
-	border: solid 1px goldenrod;
-	min-width: 50px;
-}
-
-
-/* Buttons for power, talent, and complication movers. */
-.power-mover-plus-minus-enclosure,
-.talent-mover-plus-minus-enclosure,
-.complication-mover-plus-minus-enclosure {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-}
-
-.power-mover-plus-minus-button,
-.talent-mover-plus-minus-button,
-.complication-mover-plus-minus-button {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	height: 24px;
-	width: 10px;
-	align-items: center;
-	padding: 0px;
-	margin-right: 2px;
-	margin-left:3px;
-}
-
-.power-mover-plus-minus-button button.buttonPlus,
-.power-mover-plus-minus-button button.buttonMinus,
-.talent-mover-plus-minus-button button.buttonPlus,
-.talent-mover-plus-minus-button button.buttonMinus,
-.complication-mover-plus-minus-button button.buttonPlus,
-.complication-mover-plus-minus-button button.buttonMinus {
-	background-color: LemonChiffon;
-	border: solid 1px silver;
-	color: slategray;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	display: inline-block;
-	font-size: 10px;
-	margin: 0px 0px;
-	line-height: 1.25ch;
-	border-radius: 0px;
-	max-width: 10px;
-}
-
-.power-mover-plus-minus-button button.buttonPlus span,
-.power-mover-plus-minus-button button.buttonMinus span,
-.talent-mover-plus-minus-button button.buttonPlus span,
-.talent-mover-plus-minus-button button.buttonMinus span,
-.complication-mover-plus-minus-button button.buttonPlus span,
-.complication-mover-plus-minus-button button.buttonMinus span {
-	display: inline-block;
-	transform: rotate(-90deg);
-	text-align: center;
-}
-
-.power-mover-plus-minus-button button.buttonPlus:hover,
-.power-mover-plus-minus-button button.buttonMinus:hover,
-.talent-mover-plus-minus-button button.buttonPlus:hover,
-.talent-mover-plus-minus-button button.buttonMinus:hover,
-.complication-mover-plus-minus-button button.buttonPlus:hover,
-.complication-mover-plus-minus-button button.buttonMinus:hover {
-	background-color: gray;
-	color: white;
-	transition: 0.05s;
-} 
-
-
-/* ----------------------------------------------------- */
-/* Skills                                                */
-/* Organized into a 2x3 grid of containers               */
-/* ----------------------------------------------------- */
-.grid-container-skills-tab {
-	display: grid;
-	grid-template-areas:
-	"theSkills1 theCombatSkills"
-	"theSkills2 theLanguageSkills"
-	"theSkills3 theEnhancers";
-	grid-gap: 6px;
-	grid-template-columns: 358px 322px;
-	grid-template-rows: 273px 251px 259px;
-	max-width: 692px;
-	padding: 0px;
-	padding-left: 0px;
-	padding-top: 6px;
-	margin-bottom: 0px;
-	font-size: 16px;
-	background-color: gold;
-	border: 3px solid #fff990;
-	border-radius: 5px;
-	justify-content: middle;
-	min-height: 795px;
-}
-
-.grid-container-skills-tab h1 {
-	display:inline-block;
-	margin-left: 0px;
-	padding-left: 2px;
-	padding-right: 0px;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	margin: 0px;
-	margin-top: 1px;
-	font-size: 13px;
-	font-style: normal;
-	line-height: 1.10;
-	text-align: center;
-}
-
-.grid-container-skills-tab input[type=text] {
-	height: 22px;
-}
-
-.grid-container-skills-tab .custom-select,
-.grid-container-skills-tab .custom-select-skill,
-.grid-container-skills-tab .custom-select-alternate,
-.grid-container-skills-tab .custom-select-alternate-skill {
-	font-size: 13px;
-	max-width: 110px;
-	margin-left: 3px;
-	padding-left: 3px;
-}
-
-/* Item: Skill Containers for Skill Groups 01, 02, and 03 */
-.item-skillsTab-flex-container-skills-group01,
-.item-skillsTab-flex-container-skills-group02,
-.item-skillsTab-flex-container-skills-group03 {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-evenly;
-	max-width: 358px;
-	margin-left: 5px;
-	background-color: #fff990; 
-	border: solid 2px goldenrod;
-	border-radius: 3px;
-	line-height: 1.10;
-	padding-left: 1px;
-	padding-right: 4px;
-}
-
-.item-skillsTab-flex-container-skills-group01 {
-	grid-area: theSkills1;
-	padding-bottom: 2px;
-}
-
-.item-skillsTab-flex-container-skills-group02 {
-	grid-area: theSkills2;
-	padding-top: 3px;
-	padding-bottom: 2px;
-}
-
-.item-skillsTab-flex-container-skills-group03 {
-	grid-area: theSkills3;
-	padding-top: 3px;
-	padding-bottom: 2px;
-	margin-bottom: 4px;
-}
-
-.item-skillsTab-flex-container-skills-group01 input[type=number],
-.item-skillsTab-flex-container-skills-group02 input[type=number],
-.item-skillsTab-flex-container-skills-group03 input[type=number] {
-	text-align: right;
-	padding-right: 0px;
-	margin-top: 0px;
-	margin-bottom: 0px;
-	border: solid 1px palegoldenrod;
-	max-height: 22px;
-}
-
-.item-skillsTab-flex-container-skills-group01 input[readonly],
-.item-skillsTab-flex-container-skills-group02 input[readonly],
-.item-skillsTab-flex-container-skills-group03 input[readonly] {
-	text-align: center;
-	background-color: #fff990; 
-	border: transparent;
-	max-width: 24px;
-}
-
-.item-skillsTab-flex-container-skills-group01 input[type=text]:nth-child(1),
-.item-skillsTab-flex-container-skills-group02 input[type=text]:nth-child(1),
-.item-skillsTab-flex-container-skills-group03 input[type=text]:nth-child(1) {
-	max-width: 140px;
-	margin-top: 1px;
-	margin-bottom: 1px;
-	font-size: 13px;
-	text-align: left;
-	margin-left: 4px;
-	margin-right: 1px;
-	padding-left: 1px;
-	padding-right: 1px;
-	border: solid 1px palegoldenrod;
-}
-
-/* Sub-Item: Flex containers for rows */
-.subitem-skillsTab-grid-container-skills-heading-left {
-	grid-template-areas: "skillName skillType rollChance . skillCost";
-	grid-template-columns: 164px 70px 26px 38px 46px;
-	display: grid;
-}
-
-.subitem-skillsTab-grid-container-skills-heading-left-name {
-	grid-area: skillName;
-	padding-left: 5px;
-}
-
-.subitem-skillsTab-grid-container-skills-heading-left-name h2 {
-	text-align: left;
-}
-
-.subitem-skillsTab-grid-container-skills-heading-left-type {
-	grid-area: skillType;
-	text-align: center;
-}
-
-.subitem-skillsTab-grid-container-skills-heading-left-roll {
-	grid-area: rollChance;
-	text-align: center;
-}
-
-.subitem-skillsTab-grid-container-skills-heading-left-cost {
-	grid-area: skillCost;
-	text-align: center;
-}
-
-.subitem-skillsTab-flex-container-skill {
-	text-align: left;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	max-height: 24px;
-}
-
-.subitem-skillsTab-flex-container {
-	text-align: right;
-}
-
-/* Buttons for skill movers. */
-.skill-mover-plus-minus-enclosure {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-}
-
-.skill-mover-plus-minus-button {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	height: 24px;
-	width: 10px;
-	align-items: center;
-	padding: 0px;
-	margin-right: 2px;
-	margin-left: 2px;
-}
-
-.skill-mover-plus-minus-button button.buttonPlus,
-.skill-mover-plus-minus-button button.buttonMinus {
-	background-color: lemonchiffon;
-	border: solid 1px silver;
-	color: slategray;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	display: inline-block;
-	font-size: 10px;
-	margin: 0px 0px;
-	line-height: 1.25ch;
-	border-radius: 0px;
-	max-width: 10px;
-}
-
-.skill-mover-plus-minus-button button.buttonPlus span,
-.skill-mover-plus-minus-button button.buttonMinus span {
-	display: inline-block;
-	transform: rotate(-90deg);
-	text-align: center;
-}
-
-.skill-mover-plus-minus-button button.buttonPlus:hover,
-.skill-mover-plus-minus-button button.buttonMinus:hover {
-	background-color: gray;
-	color: white;
-	transition: 0.05s;
-} 
-
-/* Item: Skill Container for combat skill flex "columns" */
-.item-skillsTab-grid-container-combat-skills {
-	grid-area: theCombatSkills;
-	display: grid;
-	grid-template-areas: 
-	"skillNames skillLevels skillTypes skillCosts"
-	"skillLevelNames skillLevels . skillCosts";
-	grid-template-columns: 150px 50px 61px 38px;
-	grid-template-rows: 199px 76px;
-	max-width: 292px;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-bottom: 3px;
-	padding-top: 0px;
-	background-color: #fff990; 
-	border: solid 2px goldenrod;
-	border-radius: 3px;
-	line-height: 1.10;
-}
-
-/* Subitem: flex container for combat skill name "column" */
-.subitem-skillsTab-flex-container-combat-skills-names {
-	grid-area: skillNames;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-bottom: 3px;
-	padding-top: 0px;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-names input[type=text] {
-	max-width: 140px;
-	margin-top: 0px;
-	margin-bottom: 3px;
-	font-size: 13px;
-	text-align: left;
-	margin-left: 4px;
-	padding-left: 1px;
-	padding-right: 1px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-names h1 {
-	text-align: left;
-	padding-top: 3px;
-	padding-bottom: 3px;
-	max-height: 18px;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-level-names {
-	grid-area: skillLevelNames;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-bottom: 8px;
-	padding-top: 0px;
-} 
-
-.subitem-skillsTab-flex-container-combat-skills-level-names h1 {
-	text-align: left;
-	padding-top: 3px;
-	padding-bottom: 3px;
-	max-height: 18px;
-	font-weight: bold;
-}
-
-/* Subitem: flex container for combat skill levels "column" */
-.subitem-skillsTab-flex-container-combat-skills-levels {
-	grid-area: skillLevels;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-top: 7px;
-	margin-bottom: 6px;
-	max-height: 264px;
-	margin-top: 3px;
-	padding-bottom: 2px;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-levels input[type=number] {
-	text-align: center;
-	padding-left: 3px;
-	padding-right: 1px; /* Fix for shifting spinners on focus */
-	max-width: 45px;
-	margin-right: 5px;
-	padding-bottom: 1px;
-	max-height: 22px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-levels h1 {
-	text-align: left;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	max-height: 18px;
-	margin-left: 0px;
-}
-
-/* Subitem: flex container for combat skill type "column" */
-.subitem-skillsTab-flex-container-combat-skills-types {
-	grid-area: skillTypes;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-top: 3px;
-	margin-bottom: 5px;
-	margin-left: 0px;
-	height: 189px;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-types h1 {
-	text-align: center;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	max-height: 18px;
-	margin-left: 0px;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-types .custom-select {
-	max-width: 55px;
-	text-align: center;
-	height: 19px;
-	padding-left: 3px;
-}
-
-/* Subitem: flex container for combat skill costs "column" */
-.subitem-skillsTab-flex-container-combat-skills-costs {
-	grid-area: skillCosts;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-bottom: 7px;
-	margin-top: 3px;
-	padding-bottom: 2px;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-costs h1 {
-	text-align: center;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	padding-right: 0px;
-	max-height: 18px;
-	max-width: 40px;
-}
-
-.subitem-skillsTab-flex-container-combat-skills-costs input[readonly] {
-	text-align: center;
-	background-color: #fff990;
-	max-width: 30px;
-	margin-left: 5px;
-}
-
-/* Item: Skill Container for Language Skill "rows" */
-.item-skillsTab-flex-container-languages {
-	grid-area: theLanguageSkills;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	max-width: 292px;
-	background-color: #fff990; 
-	border: solid 2px goldenrod;
-	border-radius: 3px;
-	line-height: 1.10;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-bottom: 3px;
-}
-
-/* Sub-Item: Flex containers for columns */
-.subitem-skillsTab-flex-container-languages-heading {
-	grid-template-areas: "skillName skillFluency literacy skillCost";
-	grid-template-columns: 148px 83px 31px 36px;
-	display: grid;
-	margin-left: 0px;
-}
-
-.subitem-skillsTab-flex-container-languages-heading-name {
-	grid-area: skillName;
-	text-align: left;
-}
-
-.subitem-skillsTab-flex-container-languages-heading-fluency {
-	grid-area: skillFluency;
-	text-align: center;
-}
-
-.subitem-skillsTab-flex-container-languages-heading-literacy {
-	grid-area: literacy;
-	text-align: center;
-}
-
-.subitem-skillsTab-flex-container-languages-heading-cost {
-	grid-area: skillCost;
-	text-align: center;
-}
-
-.subitem-skillsTab-flex-container-language {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	max-width: 285px;
-	margin-left: 0px;
-	padding: 0px;
-	margin-left: 4px;
-}
-
-.subitem-skillsTab-flex-container-language input[type=text]:nth-child(1) {
-	text-align: left;
-	padding-left: 2px;
-	min-width: 140px;
-	margin-right: 0px;
-	border: solid 1px palegoldenrod;	
-}
-
-.subitem-skillsTab-flex-container-language input[readonly] {
-	text-align: center;
-	background-color: #fff990;
-	max-width: 22px;
-	margin-right: 0px;
-	margin-left: 3px;
-	border: transparent;
-}
-
-.subitem-skillsTab-flex-container-language .container-checkbox-small {
-	margin-top: 3px;
-	margin-left: 10px;
-}
-
-.subitem-skillsTab-flex-container-language .custom-select {
-	min-width: 70px;
-	margin-left: 8px;
-	max-height: 19px;
-	padding-left: 3px;
-}
-
-
-/* Item: Skill Container for Skill Enhancers */
-.item-skillsTab-grid-container-skill-enhancers {
-	grid-area: theEnhancers;
-	display: grid;
-	grid-template-areas: 
-	". skillEnhancersHeading skillEnhancersHeading skillEnhancersHeading"
-	"checkboxes skillNames . skillCosts"
-	". skillNames skillLevels skillCosts";
-	grid-template-columns: 25px 175px 65px 38px;
-	grid-template-rows: 20px 112px 112px;
-	max-width: 295px;
-	padding-left: 5px;
-	grid-gap:0px;
-	background-color: #fff990; 
-	border: solid 2px goldenrod;
-	border-radius: 3px;
-	max-height: 251px;
-}
-
-.item-skillsTab-grid-container-skill-enhancers input[readonly]{
-	background-color: #fff990;
-	text-align: center;
-	height: 18px;
-	max-width: 30px;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-checkboxes {
-	grid-area: checkboxes;
-	text-align: center;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	line-height: 1.2;
-	padding-bottom: 5px;
-	padding-top: 5px;
-	height: 113px;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-heading {
-	grid-area: skillEnhancersHeading;
-	text-align: left;
-	display: flex;
-	flex-direction: row;
-	padding-top: 4px;
-	justify-content: space-between;
-	line-height: 1.15;
-	width: 264px;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-heading h1:nth-child(2) {
-	padding-right: 0px;
-	line-height: 1.15;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-names {
-	grid-area: skillNames;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-evenly;
-	height: 229px;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-names h1 {
-	text-align: left;
-	line-height: 1.15;
-	font-weight: bold;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-levels {
-	grid-area: skillLevels;
-	text-align: left;
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	line-height: 1.15;
-	margin-top: 11px;
-	height: 107px;
-	margin-bottom: 4px;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-levels input[type=number]{
-	border: solid 1px palegoldenrod;
-	height: 19px;
-	margin-bottom: 2px;
-}
-
-.subitem-skillsTab-flex-container-skill-enhancers-costs {
-	grid-area: skillCosts;
-	text-align: center;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-evenly;
-	line-height: 1.15;
-	height: 229px;
-}
-
-/* ----------------------------------------------------- */
-/* Gear: armor, weapons, and equipment                   */
-/* Organized into a 3x4 grid of containers               */
-/* ----------------------------------------------------- */
-
-.grid-container-tab-gear {
-	display: grid;
-	grid-template-areas:
-	"theEncumbrance theEncumbrance gearHealth"
-	"theArmor theArmor gearHealth"
-	"theWeapons theWeapons theWeapons"
-	"theEquipment theSlides theSlides";
-	grid-gap: 8px;
-	grid-template-columns: 250px 336px 84px;
-	grid-template-rows: 63px 174px 155px 322px;
-	max-width: 692px;
-	padding: 0px;
-	padding-left: 2px;
-	font-size: 16px;
-	background-color: royalblue;
-	border: 3px solid #fff990;
-	border-radius: 5px;
-	justify-content: middle;
-	min-height: 801px;
-}
-
-.grid-container-tab-gear h1 {
-	display:inline-block;
-	margin-left: 0px;
-	padding-left: 2px;
-	padding-right: 0px;
-	padding-top: 0px;
-	padding-bottom: 0px;
-	margin: 0px;
-	margin-top: 1px;
-	font-size: 13px;
-	font-style: normal;
-	line-height: 1.10;
-	text-align: center;
-}
-
-.grid-container-tab-gear .custom-select {
-	font-size: 13px;
-	max-width: 110px;
-	max-height: 19px;
-}
-
-/* Health status styling grouped with item-health-characteristics */
-
-/* Encumbrance */
-.item-tab-gear-flex-container-encumbrance {
-	grid-area: theEncumbrance;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	margin-left: 4px;
-	margin-top: 6px;
-	padding: 0px;
-	max-width: 594px;
-	max-height: 56px;
-	padding-left: 20px;
-	padding-right: 20px;
-	text-align: left;
-	vertical-align: middle;
-	background-color: royalblue;
-	border: none;
-}
-
-.item-tab-gear-flex-container-encumbrance h1 {
-	text-align: center;
-	color: white;
-	font-size: 13px;
-}
-
-.item-tab-gear-flex-container-encumbrance input[type=number]{
-	background-color: #fff990;
-	text-align: center;
-	max-width: 70px;
-	background-color: gold;
-	border: solid 1px goldenrod;
-	font-size: 16px;
-	margin-left: 0px;
-	padding-right: 0px;
-	min-height: 22px;
-}
-
-.subitem-tab-gear-flex-container-encumbrance,
-.subitem-tab-gear-flex-container-encumbrance-bonus {
-	display:flex;
-	flex-direction: column;
-	justify-content: space-between;
-	max-width: 80px;
-	align-items: center;
-}
-
-.subitem-tab-gear-flex-container-encumbrance-bonus {
-	margin-left: 0px;
-}
-
-.subitem-tab-gear-plus-minus-enclosure {
-	display: flex;
-	flex-direction: row;
-	background-color: gold;
-	justify-content: space-between;
-	width: 50px;
-	max-height: 20px;
-	border: solid 1px goldenrod;
-	border-radius: 3px;
-}
-
-.subitem-tab-gear-plus-minus-enclosure input[type=text] {
-	max-width: 40px;
-	height: 20px;
-	font-size: 16px;
-	background-color: transparent;
-	text-align: center;
-	vertical-align: center;
-}
-
-.subitem-tab-gear-plus-minus-enclosure input[type=text]:focus{
-	outline: transparent;
-}
-
-.subitem-tab-gear-flex-container-stat {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	height: 20px;
-	width: 10px;
-	align-items: center;
-	padding: 0px;
-}
-
-.subitem-tab-gear-flex-container-stat button.buttonPlus,
-.subitem-tab-gear-flex-container-stat button.buttonMinus {
-	background-color: LemonChiffon;
-	border: solid 1px slategray;
-	color: slategray;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	display: inline-block;
-	font-size: 10px;
-	margin: 0px 0px;
-	line-height: 1.4ch;
-	border-radius: 0px;
-	max-width: 10px;
-}
-
-.subitem-tab-gear-flex-container-stat button.buttonPlus span,
-.subitem-tab-gear-flex-container-stat button.buttonMinus span {
-	display: inline-block;
-	transform: rotate(-90deg);
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-stat button.buttonPlus:hover,
-.subitem-tab-gear-flex-container-stat button.buttonMinus:hover {
-	background-color: gray;
-	color: white;
-	transition: 0.05s;
-} 
-
-/* ------------- */
-/* Item: Armor   */
-/* ------------- */
-.item-tab-gear-grid-container-armor {
-	grid-area: theArmor;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-around;
-	max-width: 594px;
-	padding-left: 5px;
-	margin-left: 4px;
-	padding-top: 0px;
-	grid-gap: 3px;
-	background-color: #fff990; 
-	border: solid 2px goldenrod;
-	border-radius: 3px;
-	min-height: 179px;
-}
-
-.subitem-tab-gear-flex-container-armor-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: center;
-	max-width: 575px;
-	margin-bottom: 1px;
-	height: 24px;
-}
-
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(1) {
-	min-width: 118px;
-	text-align: left;
-}
-
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(2),
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(3),
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(4),
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(5) {
-	min-width: 34px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(6),
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(7) {
-	min-width: 44px;
-}
-
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(8) {
-	min-width: 36px;
-}
-
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(9) {
-	min-width: 98px;
-}
-
-.subitem-tab-gear-flex-container-armor-row h1:nth-child(10) {
-	min-width: 46px;
-}
-
-.subitem-tab-gear-flex-container-armor-row input {
-	max-height: 22px;
-}
-
-.subitem-tab-gear-flex-container-armor-row input[type=number] {
-	text-align: right;
-	padding-left: 2px;
-	max-width: 36px;
-	min-width: 34px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1),
-.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
-	padding-left: 1px;
-	padding-right: 1px;
-	margin-right: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1) {
-	text-align: left;
-	max-width: 120px;
-}
-
-.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
-	text-align: center;
-	max-width: 100px;
-}
-
-.subitem-tab-gear-flex-container-armor-row input[type=number]:nth-child(10) {
-	text-align: right;
-	min-width: 48px;
-}
-
-.subitem-tab-gear-flex-container-armor-row select {
-	text-align-last: center; /* For Chrome */
-	text-align: center; /* Firefox */
-}
-
-/* Shield */
-
-.subitem-tab-gear-flex-container-shield {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-right: 5px;
-	margin-top: 5px;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1 {
-	margin-bottom: 3px;
-	padding: 0px;
-}
-
-.subitem-tab-gear-flex-container-shield-row input {
-	max-height: 21px;
-}
-
-.subitem-tab-gear-flex-container-shield-row label {
-	max-width: 5px;
-	margin-left: 2px;
-	margin-top: 3px;
-	padding-right: 0px;
-}
-
-.subitem-tab-gear-flex-container-shield-row .container-checkbox-small {
-	padding-left: 10px;
-	margin-right: 3px;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(1) {
-	min-width: 120px;
-	text-align: left;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(3) {
-	min-width: 67px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(4) {
-	min-width: 24px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(6) {
-	min-width: 38px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(7) {
-	min-width: 48px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(5),
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(8),
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(9) {
-	min-width: 32px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(2),
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(10),
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(11) {
-	min-width: 40px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row h1:nth-child(12) {
-	min-width: 42px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1),
-.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
-	padding-left: 1px;
-	padding-right: 1px;
-	margin-right: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1) {
-	max-width: 120px;
-	text-align: left;
-}
-
-.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
-	max-width: 65px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-shield-row  input[readonly]:nth-child(9){
-	background-color: inherit;
-	text-align: center;
-	padding-left: 0px;
-	max-width: 24px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	margin-top: 3px;
-	margin-bottom: 2px;
-}
-
-.subitem-tab-gear-flex-container-shield-row input[type=number] {
-	text-align: right;
-	padding-left: 3px;
-	max-width: 38px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-shield-row input[type=number]:nth-child(12) {
-	text-align: right;
-	padding-left: 3px;
-	min-width: 42px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-shield-row{
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	max-width: 576px;
-}
-
-/* ------------- */
-/* Item: Weapons */
-/* ------------- */
-.item-tab-gear-flex-container-weapons {
-	grid-area: theWeapons;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-around;
-	margin-left: 4px;
-	padding: 0px;
-	padding-left: 5px;
-	margin-top: 8px;
-	max-height: 145px;
-	max-width: 655px;
-	background-color: #fff990;
-	border: solid 2px goldenrod;
-	border-radius: 3px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	max-width: 650px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row input {
-	max-height: 21px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1 {
-	min-width: 39px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-weapon-row label {
-	max-width: 5px;
-	margin-left: 2px;
-	margin-top: 3px;
-	padding-right: 0px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(1) {
-	min-width: 120px;
-	text-align: left;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(2) {
-	min-width: 65px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(3) {
-	min-width: 26px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(4) {
-	min-width: 32px;
-	text-align: left;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(5) {
-	min-width: 36px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(6) {
-	min-width: 40x;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(7) {
-	min-width: 44px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(8) {
-	min-width: 42px;
-	text-align: center;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(9) {
-	min-width: 32px;
-	text-align: right;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(10) {
-	min-width: 34px;
-	text-align: right;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(11) {
-	min-width: 45px;
-	text-align: center;
-	padding-left: 0px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(12) {
-	min-width: 32px;
-	text-align: center;
-	padding: 0px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row h1:nth-child(13) {
-	min-width: 32px;
-	text-align: right;
-	margin-right: 6px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(1) {
-	text-align: left;
-	padding-left: 1px;
-	padding-right: 1px;
-	max-width: 120px;
-	margin-right: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(2) {
-	text-align: center;
-	padding-left: 1px;
-	padding-right: 1px;
-	max-width: 68px;
-	margin-right: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-weapon-row .container-checkbox-small {
-	padding-left: 10px;
-	margin-right: 3px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row button:nth-child(4) {
-	margin-left: 0px;
-	margin-right: 0px;
-}
-
-.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(5),
-.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(6),
-.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(7),
-.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(9) {
-	text-align: right;
-	padding-left: 3px;
-	max-width: 38px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(8),
-.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(11),
-.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(13) {
-	text-align: right;
-	padding-left: 3px;
-	max-width: 46px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	border: solid 1px palegoldenrod;
-}
-
-.subitem-tab-gear-flex-container-weapon-row input[readonly]:nth-child(10){
-	background-color: inherit;
-	text-align: center;
-	padding-left: 0px;
-	max-width: 24px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 0px;
-	margin-top: 3px;
-	margin-bottom: 2px;
-}
-
-/* --------------- */
-/* Item: Equipment */
-/* --------------- */
-.item-tab-gear-flex-container-equipment {
-	grid-area: theEquipment;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	max-width: 248px;
-	margin-left: 4px;
-	padding: 4px;
-	padding-top: 3px;
-	background-color: lightcyan;
-	border: solid 2px lightgray;
-	border-radius: 3px;
-	height: 367px;
-}
-
-.subitem-tab-gear-flex-container-equipment {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-}
-
-.subitem-tab-gear-flex-container-equipment h1 {
-	margin-right: 8px;
-	margin-bottom: 2px;
-}
-
-.subitem-tab-gear-flex-container-equipment input[type=text] {
-	text-align: left;
-	padding-left: 1px;
-	padding-right: 1px;
-	max-width: 162px;
-	max-height: 21px;
-	margin-right: 0px;
-	border: solid 1px #eaeaea;
-}
-
-
-/* Close spacing of equipment items means the focus border is clipped unless we move the z position to relative. */
-.subitem-tab-gear-flex-container-equipment input[type=text]:focus {
-	position: relative;
-}
-
-.subitem-tab-gear-flex-container-equipment input[type=number] {
-	text-align: right;
-	padding-left: 3px;
-	max-width: 120px;
-	min-width: 50px;
-	max-height: 21px;
-	padding-right: 0px;
-	margin-right: 0px;
-	margin-left: 2px;
-	border: solid 1px #eaeaea;
-}
-
-/* Buttons for equipment movers. */
-
-.gear-mover-plus-minus-enclosure {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
+	.grid-container-skills-tab input[type=text] {
+		height: 22px;
+	}
 	
-}
-
-.gear-mover-plus-minus-button {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	height: 22px;
-	width: 10px;
-	align-items: center;
-	padding: 0px;
-	margin-right: 2px;
-}
-
-.gear-mover-plus-minus-button button.buttonPlus,
-.gear-mover-plus-minus-button button.buttonMinus {
-	background-color: white;
-	border: solid 1px lightgray;
-	color: lightskyblue;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	display: inline-block;
-	font-size: 8px;
-	margin: 0px 0px;
-	line-height: 1.25ch;
-	border-radius: 0px;
-	max-width: 10px;
-}
-
-.gear-mover-plus-minus-button button.buttonPlus span,
-.gear-mover-plus-minus-button button.buttonMinus span {
-	display: inline-block;
-	transform: rotate(-90deg);
-	text-align: center;
-}
-
-.gear-mover-plus-minus-button button.buttonPlus:hover,
-.gear-mover-plus-minus-button button.buttonMinus:hover {
-	background-color: silver;
-	transition: 0.05s;
-	color: white;
-} 
-
-/* ----------------------------------------------------------- */
-/* Item: Attacks and Maneuvers or treasures text box slideshow */
-/* ----------------------------------------------------------- */
-
-.item-tab-gear-slide-container {
-	grid-area: theSlides;
-	position: relative;
-}
-
-.item-tab-gear-slide-container h1 {
-	text-align: left;
-	line-height: 1.2;
-	font-size: 12px;
-	margin: 0px;
-}
-
-.item-tab-gear-slide-container h2 {
-	font-size: 12px;
-	text-align: center;
-	font-weight: 400;
-	line-height: 1.2;
-}
-
-.item-tab-gear-slide-container .button-left-arrow {
-	position: absolute;
-	top: 4.5%;
-	left: 88%;
-	transform: translate(-50%, -50%);
-	color: gray;
-	background-color: lightgray;
-	font-size: 12px;
-	padding: 1px 5px;
-	border: none;
-	cursor: pointer;
-	border-radius: 3px;
-	text-align: center;
-}
-
-.item-tab-gear-slide-container .button-right-arrow {
-	position: absolute;
-	top: 4.5%;
-	left: 92.5%;
-	transform: translate(-50%, -50%);
-	color: gray;
-	background-color: lightgray;
-	font-size: 12px;
-	padding: 1px 5px;
-	border: none;
-	cursor: pointer;
-	border-radius: 3px;
-	text-align: center;
-}
-
-.item-tab-gear-slide-container .button-right-arrow:hover,
-.item-tab-gear-slide-container .button-left-arrow:hover {
-	background-color: gold;
-	color: black;
-}
-
-.item-tab-gear-slide-flex-container-maneuvers,
-.item-tab-gear-slide-flex-container-martial-maneuvers {
-	width: 406px;
-	height: 375px;
-	padding: 0px;
-	margin-left: 0px;
-	margin-bottom: 0px;
-	background-color: lightcyan;
-	border: solid 2px lightgray;
-	border-radius: 3px;
-}
-
-.item-tab-gear-slide-flex-container-martial-maneuvers-block {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	margin-top: 6px;
-	max-height: 310px;
-	min-height: 270px;
-}
-
-.item-tab-gear-slide-flex-container-martial-maneuvers input[type=text] {
-	border: solid 1px #eaeaea;
-	height: 22px;
-	width: 30px;
-}
-
-.subitem-flex-container-martial-row input {
-	text-align: center;
-	height: 22px;
-	border: solid 1px #eaeaea;
-	margin: 0px;
-	padding: 0px;
-}
-
-.subitem-flex-container-martial-row input[type=number] {
-	text-align: right;
-	height: 22px;
-	border: solid 1px #eaeaea;
-	max-width: 35px;
-}
-
-.subitem-flex-container-martial-row input[type=text]:nth-child(2) {
-	width: 220px;
-	margin: 0px;
-	height: 22px;
-	text-align: left;
-	padding-left: 1px;
-	border: solid 1px #eaeaea;
-}
-
-.subitem-flex-container-martial-cv-row input[type=text] {
-	width: 30px;
-	border: 1px solid lightgray;
-	text-align: center;
-	padding-left: 2px;
-	height: 18px;
-	margin-left: 3px;
-}
-
-.item-tab-gear-slide-flex-container-martial-maneuvers textarea {
-	width: 244px;
-	border: 1px solid lightgray;
-	max-height: 37px;
-	padding: 0px 3px; 
-	font-size: 12px;
-	margin: 0px;
-}
-
-.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(1),
-.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(1) {
-	width: 108px;
-}
-
-.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(2),
-.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(2),
-.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(3),
-.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(3),
-.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(4),
-.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(4) {
-	width: 40px;
-	padding: 0px;
-	margin: 0px;
-	text-align: center;
-}
-
-.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(5),
-.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(5) {
-	text-align: left;
-	padding-left: 0px;
-	margin-left: 0px;
-}
-
-.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(1) {
-	padding-left: 2px;
-	width: 261px;
-}
-
-.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(2),
-.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(3) {
-	text-align: center;
-	width: 39px;
-}
-
-.subitem-tab-gear-slide-flex-container-maneuvers-heading,
-.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading {
-	flex-direction: row;
-	display: flex;
-	justify-content: flex-start;
-	width: 402px;
-	height: 19px;
-	padding: 0px;
-	margin-left: 0px;
-	padding-top: 5px;
-	padding-left: 4px;
-	margin-bottom: 0px;
-	background-color: lightcyan;
-}
-
-.subitem-tab-gear-slide-flex-container-maneuvers-light-row,
-.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
-	flex-direction: row;
-	display: flex;
-	justify-content: flex-start;
-	width: 402px;
-	height: 19px;
-	padding: 0px;
-	margin-left: 0px;
-	padding-top: 4px;
-	padding-left: 4px;
-	margin-top: 0px;
-	margin-bottom: 0px;
-}
-
-.subitem-tab-gear-slide-flex-container-maneuvers-light-row {
-	background-color: white;
-}
-
-.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
-	background-color: lightcyan;
-}
-
-.subitem-tab-gear-slide-flex-container-martial-maneuvers-row {
-	flex-direction: row;
-	display: flex;
-	justify-content: space-between;
-	width: 397px;
-	height: 40px;
-	padding: 0px;
-	margin-left: 0px;
-	padding-top: 0px;
-	padding-left: 4px;
-	margin-top: 0px;
-	margin-bottom: 0px;
-}
-
-/* Buttons for maneuver movers. */
-.maneuver-mover-plus-minus-enclosure {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-}
-
-.maneuver-mover-plus-minus-button {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	height: 24px;
-	width: 10px;
-	align-items: center;
-	padding: 0px;
-	margin-right: 2px;
-	margin-left: 2px;
-}
-
-.maneuver-mover-plus-minus-button button.buttonPlus,
-.maneuver-mover-plus-minus-button button.buttonMinus {
-	background-color: white;
-	border: solid 1px lightgray;
-	color: lightskyblue;
-	padding-left: 4px;
-	padding-right: 4px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	display: inline-block;
-	font-size: 10px;
-	margin: 0px 0px;
-	line-height: 1.25ch;
-	border-radius: 0px;
-	max-width: 10px;
-}
-
-.maneuver-mover-plus-minus-button button.buttonPlus span,
-.maneuver-mover-plus-minus-button button.buttonMinus span {
-	display: inline-block;
-	transform: rotate(-90deg);
-	text-align: center;
-}
-
-.maneuver-mover-plus-minus-button button.buttonPlus:hover,
-.maneuver-mover-plus-minus-button button.buttonMinus:hover {
-	background-color: gray;
-	color: white;
-	transition: 0.05s;
-} 
-
-.item-flex-maneuver {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	width: 399px;
-	padding-left: 4px;
-	margin-top: 1px;
-	padding-bottom: 3px;
-}
-
-.subitem-flex-container-martial-row {
-	text-align: left;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	max-height: 24px;
-}
-
-/* Update when custom maneuver attack roll made */
-.subitem-flex-container-martial-row .buttonRollAttack {
-	margin-top: 1px;
-	margin-left: 3px;
-}
-
-.subitem-flex-container-martial-ocv-dcv {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	max-height: 40px;
-	max-width: 134px;
-	padding: 0px 0px;
-}
-
-/* Martial Maneuver Details */
-
-.subitem-flex-container-martial-details-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: top;
-	max-width: 397px;
-	height: 48px;
-	margin-top: 3px;
-	margin-bottom: 3px;
-	padding: 0px;
-	padding-left: 24px;
-}
-
-.subitem-flex-container-martial-details-row .buttonRollShow {
-	margin-top: 3px;
-}
-
-.subitem-flex-container-martial-details-column {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	height: 48px;
-}
-
-.subitem-flex-container-martial-buttons-column {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	height: 45px;
-	padding-top: 2px;
-	padding-bottom: 1px;
-}
-
-.subitem-flex-container-martial-cv-damage-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	max-height: 21px;
-	align-items: center;
-	padding-right: 1px;
-	margin: 0px;
-}
-
-.subitem-flex-container-martial-cv-damage-row h1 {
-	padding-right: 1px;
-}
-
-.subitem-flex-container-martial-cv-damage-row h1:not(:first-child) {
-	padding-left: 2px;
-}
-
-.subitem-flex-container-martial-cv-damage-row input[type=number] {
-	height: 21px;
-	max-width: 35px;
-	border: solid 1px #eaeaea;
-	text-align: right;
-	padding-right: 1px;
-}
-
-.subitem-flex-container-martial-cv-damage-row input[type=text] {
-	text-align: center;
-	height: 21px;
-	width: 68px;
-	padding-left: 2px;
-	padding-right: 4px;
-	border: solid 1px #eaeaea;
-}
-
-.subitem-martial-description-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: bottom;
-	max-height: 22px;
-	min-width: 320px;
-	padding: 0px;
-	margin: 0px;
-}
-
-.subitem-martial-description-row input[type=text] {
-	width: 220px;
-	height: 22px;
-	text-align: left;
-	padding-left: 2px;
-	margin-right: 0px;
-	border: solid 1px #eaeaea;
-}
-
-.subitem-martial-description-row h1 {
-	padding-top: 5px;
-}
-
-.subitem-martial-description-row input[type=number] {
-	height: 22px;
-	max-width: 35px;
-	border: solid 1px #eaeaea;
-	text-align: right;
-	margin-right: 0px;
-}
-
-		
-/* Range Modifier Table */
-.subitem-tab-gear-slide-flex-container-range-modifiers {
-	flex-direction: row;
-	display: flex;
-	justify-content: space-between;
-	width: 391px;
-	height: 28px;
-	padding: 3px;
-	margin-top: 1px;
-	margin-bottom: 7px;
-	margin-right: 0px;
-	margin-left: 4px;
-	background-color: white;
-	border-radius: 3px;
-	border: solid 1px #eaeaea;
-}
-
-.subitem-tab-gear-slide-range-modifier-container {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	height: 33px;
-	align-items: top;
-	padding: 0px;
-	margin: 0px;
-}
-
-.subitem-tab-gear-slide-range-modifier-container:nth-child(1) {
-	width: 60px;
-}
-
-.subitem-tab-gear-slide-range-modifier-container:nth-child(2) {
-	width: 37px;
-}
-
-.subitem-tab-gear-slide-range-modifier-container:nth-child(3) {
-	width: 43px;
-}
-
-.subitem-tab-gear-slide-range-modifier-container:nth-child(4) {
-	width: 49px;
-}
-
-.subitem-tab-gear-slide-range-modifier-container:nth-child(5) {
-	width: 50px;
-}
-
-.subitem-tab-gear-slide-range-modifier-container:nth-child(6) {
-	width: 57px;
-}
-
-.subitem-range-modifier-container-column h2:nth-child(1) {
-	font-weight: bold;
-}
-
-.subitem-range-modifier-container-column {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	height: 30px;
-	padding-top: 0px;
-}
-
-.subitem-range-modifier-button-container {
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-start;
-	height: 30px;
-	padding-top: 1px;
-}
-
-.subitem-tab-gear-slide-range-modifier-container:nth-child(1) .subitem-range-modifier-container-column {
-	margin-bottom: 3px;
-	height: 30px;
-}
-
-/* Item: Hit Locations */
-.item-tab-gear-slide-flex-container-hit-locations {
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	width: 403px;
-	height: 375px;
-	padding: 0px;
-	padding-left: 3px;
-	background-color: lightcyan;
-	margin-left: 0px;
-	margin-bottom: 0px;
-	border: solid 2px lightgray;
-	border-radius: 3px;
-}
-
-.item-gear-slide-container-hit-locations-flex-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	border-radius: 3px;
-	width: 400px;
-}
-
-/* Special Hit Locations */
-.item-gear-slide-flex-container-hit-locations-special {
-	width: 260px;
-	height: 145px;
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-}
-
-.item-gear-slide-flex-container-hit-locations-special label {
-	display: inline-block;
-	margin-left: 14px;
-	margin-right: 4px;
-	margin-top: 2px; /* A fix to get a uniform look with the hit location table */
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-heading {
-	background-color: lightcyan;
-	height: 20px;
-	margin-bottom: 3px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(1){
-	width: 42px;
-	text-align: left;
-	margin-left: 2px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(2){
-	width: 40px;
-	text-align: center;
-	margin-left: 3px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(3){
-	width: 52px;
-	text-align: center;
-	margin-left: 30px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(4){
-	width: 44px;
-	text-align: right;
-	margin-left: 15px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-top-row,
-.subitem-gear-slide-flex-container-hit-locations-special-middle-row,
-.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	background-color: white;
-	border-left: solid 1px lightgray;
-	border-right: solid 1px lightgray;
-	width: 260px;
-	height: 20px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-top-row {
-	border-top: solid 1px lightgray;
-	border-top-left-radius: 3px;
-	border-top-right-radius: 3px;
-	padding-top: 5px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
-	border-bottom: solid 1px lightgray;
-	border-bottom-left-radius: 3px;
-	border-bottom-right-radius: 3px;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-top-row h1,
-.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1,
-.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1 {
-	width: 65px;
-	text-align: center;
-}
-
-.subitem-gear-slide-flex-container-hit-locations-special-top-row h1:nth-child(4),
-.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1:nth-child(4),
-.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1:nth-child(4) {
-	width: 35px;
-	text-align: right;
-	padding-right: 19px;
-}
-
-/* Targeting Options */
-.item-gear-slide-container-hit-locations-options {
-	width: 130px;
-	height: 100px;
-	margin-top: 50px;
-}
-
-.subitem-gear-slide-container-hit-locations-options-top,
-.subitem-gear-slide-container-hit-locations-options-bottom {
-	display: flex;
-	flex-direction: row;
-	justify-content: flex-start;
-	width: 115px;
-	margin: 3px;
-	margin-bottom: 15px;
-}
-
-.subitem-gear-slide-container-hit-locations-options-top {
-	margin-left: 10px;
-}
-
-.subitem-gear-slide-container-hit-locations-options-top h1,
-.subitem-gear-slide-container-hit-locations-options-bottom h1 {
-	padding-top: 4px;
-	margin: 0px;
-}
-
-.subitem-gear-slide-container-hit-locations-options-top label {
-	max-width: 0px;
-	margin-left: 2px;
-	margin-right: 0px;
-	margin-top: 3px;
-	padding-right: 0px;
-}
-
-.subitem-gear-slide-container-hit-locations-options-bottom input {
-	margin-left: 5px;
-	border: solid 1px lightgray;
-}
-
-/* Hit Location Table */
-.item-gear-slide-container-hit-locations-table {
-	width: 399px;
-	height: 215px;
-}
-
-.item-gear-slide-container-hit-locations-table h1 {
-	width: 51px;
-	text-align: center;
-}
-
-.item-gear-slide-container-hit-locations-table label {
-	display: inline-block;
-	margin-left: 14px;
-	margin-right: 3px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-heading {
-	background-color: lightcyan;
-	height: 20px;
-	margin-bottom: 3px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-heading h1 {
-	text-align: center;
-	margin-left: 2px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(1){
-	width: 42px;
-	text-align: left;
-}
-
-.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(2){
-	width: 34px;
-	text-align: center;
-	margin-right: 9px;
-	margin-left: 3px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-top-row,
-.subitem-gear-slide-container-hit-locations-table-middle-row,
-.subitem-gear-slide-container-hit-locations-table-bottom-row {
-	height: 19px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
-.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
-.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
-	width: 40x;
-	text-align: center;
-	margin-right: 11px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
-.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
-.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
-	width: 34px;
-	text-align: center;
-	margin-left: 21px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(6),
-.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(6),
-.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(6){
-	width: 45px;
-	text-align: center;
-	margin-left: 6px;
-	margin-right: 0px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(7),
-.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(7),
-.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(7){
-	width: 34px;
-	text-align: right;
-	margin-left: 4px;
-	margin-right: 17px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-top-row {
-	background-color: white;
-	border-top: solid 1px lightgray;
-	border-left: solid 1px lightgray;
-	border-right: solid 1px lightgray;
-	border-top-left-radius: 3px;
-	border-top-right-radius: 3px;
-}
-
-.subitem-gear-slide-container-hit-locations-table-middle-row {
-	background-color: white;
-	border-left: solid 1px lightgray;
-	border-right: solid 1px lightgray;
-}
-
-.subitem-gear-slide-container-hit-locations-table-bottom-row {
-	background-color: white;
-	border-left: solid 1px lightgray;
-	border-right: solid 1px lightgray;
-	border-bottom: solid 1px lightgray;
-	border-bottom-left-radius: 3px;
-	border-bottom-right-radius: 3px;
-	padding-bottom: 5px;
-}
-
-/* Item: Slide of treasure and notes box  */
-.item-tab-gear-slide-treasure-text {
-	width: 402px;
-	height: 367px;
-	padding: 0px;
-	margin-left: 0px;
-	margin-bottom: 0px;
-}
-
-.item-tab-gear-slide-treasure-text textarea {
-	width: 398px;
-	height: 367px;
-	margin: 0px;
-	border: solid 2px lightgray;
-	border-radius: 3px;
-}
-
-/* hide all gear tab slides by default */
-
-.item-tab-gear-slide-flex-container-maneuvers,
-.item-tab-gear-slide-flex-container-martial-maneuvers,
-.item-tab-gear-slide-flex-container-hit-locations,
-.item-tab-gear-slide-treasure-text {
-	display: none;
-}
-
-/* show the selected gear slide */
-.item-gear-slideshow[value="1"] ~ div.item-tab-gear-slide-flex-container-maneuvers,
-.item-gear-slideshow[value="2"] ~ div.item-tab-gear-slide-flex-container-martial-maneuvers,
-.item-gear-slideshow[value="3"] ~ div.item-tab-gear-slide-flex-container-hit-locations,
-.item-gear-slideshow[value="4"] ~ div.item-tab-gear-slide-treasure-text {
-	display: block;
-	position: relative;
-}
-
-/* ---------------------------------------------------------------- */
-/* Custom radio button from w3 schools.                             */
-/* https://www.w3schools.com/howto/howto_css_custom_checkbox.asp    */
-/* ---------------------------------------------------------------- */
-
-/* Customize the label (the container) */
-.custom-radio-button-container {
-	display: block;
-	position: relative;
-	padding: 0px;
-	margin: 0px;
-	cursor: pointer;
-	font-size: 12px;
-	max-width: 0px;
-	max-height: 0px;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-	background-color: orange;
-}
-
-/* Hide the browser's default radio button */
-.custom-radio-button-container input {
-	position: absolute;
-	opacity: 0;
-	cursor: pointer;
-	height: 0;
-	width: 0;
-}
-
-/* Create a custom radio button */
-.custom-radio-button {
-	position: absolute;
-	top: -2px; /* A fix to get a uniform look with the hit location table */
-	left: 0px;
-	height: 11px;
-	width: 11px;
-	background-color: white;
-	border: solid 2px lightsteelblue;
-	border-radius: 50%;
-	margin-bottom: 0px;
-	padding: 0px;
-}
-
-/* On mouse-over, add a grey background color */
-.custom-radio-button-container:hover input ~ .custom-radio-button {
-	background-color: lightsteelblue;
-}
-
-/* When the radio button is checked, add a blue background */
-.custom-radio-button-container input:checked ~ .custom-radio-button {
-	background-color: indianred;
-	border: solid 2px indianred;
-}
-
-/* Create the indicator (the dot/circle - hidden when not checked) */
-.custom-radio-button:after {
-	content: "";
-	position: absolute;
-	display: none;
-}
-
-/* Show the indicator (dot/circle) when checked */
-.custom-radio-button-container input:checked ~ .custom-radio-button:after {
-	display: block;
-}
-
-/* Style the indicator (dot/circle) */
-.custom-radio-button-container .custom-radio-button:after {
-	top: 0px;
-	left: 0px;
-	width: 7px;
-	height: 7px;
-	border-radius: 50%;
-	border: solid 2px white;
-	background: indianred;
-	margin: 0px;
-	padding: 0px;
-}
-
-/* ---------------------------------------------------------------- */
-/* Jackob's Roll Template                                           */
-/* https://wiki.roll20.net/Building_Character_Sheets/Roll_Templates */
-/* ---------------------------------------------------------------- */
-
-/* Three different Templates for attacks, armor activation, and skills ability checks. */
-.sheet-rolltemplate-custom,
-.sheet-rolltemplate-custom-success-roll,
-.sheet-rolltemplate-custom-defense,
-.sheet-rolltemplate-custom-attack,
-.sheet-rolltemplate-custom-normal-attack,
-.sheet-rolltemplate-custom-power-attack,
-.sheet-rolltemplate-custom-activate,
-.sheet-rolltemplate-custom-show {
-	margin-left: -37px;
-	color: #181818;
-}
-
-.withoutavatars .sheet-rolltemplate-custom,
-.withoutavatars .sheet-rolltemplate-custom-success-roll,
-.withoutavatars .sheet-rolltemplate-custom-defense,
-.withoutavatars .sheet-rolltemplate-custom-attack,
-.withoutavatars .sheet-rolltemplate-custom-normal-attack,
-.withoutavatars .sheet-rolltemplate-custom-power-attack,
-.withoutavatars .sheet-rolltemplate-custom-activate,
-.withoutavatars .sheet-rolltemplate-custom-show {
-	margin-left: -7px;
-	color: #181818;
-}
-
-.sheet-rolltemplate-custom .sheet-container,
-.sheet-rolltemplate-custom-success-roll .sheet-container,
-.sheet-rolltemplate-custom-defense .sheet-container,
-.sheet-rolltemplate-custom-attack .sheet-container,
-.sheet-rolltemplate-custom-normal-attack .sheet-container,
-.sheet-rolltemplate-custom-power-attack .sheet-container,
-.sheet-rolltemplate-custom-activate .sheet-container,
-.sheet-rolltemplate-custom-show .sheet-container {
-	border: 1px solid;
-	/* by default, the border is the same color as the header. You can change this here, e.g. to black */
-	border-color: var(--header-bg-color);
-}
-
-/* Header formatting - title and subtitle */
-.sheet-rolltemplate-custom .sheet-header,
-.sheet-rolltemplate-custom-success-roll .sheet-header {
-	background-color: #E69F00;
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom-defense .sheet-header {
-	background-color: #56B4E9;
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom-attack .sheet-header {
-	background-color: #D55E00;
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom-normal-attack .sheet-header {
-	background-color: #009E73;
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom-power-attack .sheet-header {
-	background-color: #CC79A7;
-	/* background-color: #56B4E9; */
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom-activate .sheet-header {
-	background-color: #0072B2;
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom-show .sheet-header {
-	background-color: #8A8A8A;
-	/* change text-align to center to center the header text */
-	text-align: left;
-	color: var(--header-text-color);
-	padding: 5px;
-}
-
-.sheet-rolltemplate-custom .sheet-title,
-.sheet-rolltemplate-custom-success-roll .sheet-title,
-.sheet-rolltemplate-custom-defense .sheet-title,
-.sheet-rolltemplate-custom-attack .sheet-title,
-.sheet-rolltemplate-custom-normal-attack .sheet-title,
-.sheet-rolltemplate-custom-power-attack .sheet-title,
-.sheet-rolltemplate-custom-activate .sheet-title,
-.sheet-rolltemplate-custom-show .sheet-title {
-	font-size:1.2em;
-}
-
-.sheet-rolltemplate-custom .sheet-subtitle,
-.sheet-rolltemplate-custom-success-roll .sheet-subtitle,
-.sheet-rolltemplate-custom-defense .sheet-subtitle,
-.sheet-rolltemplate-custom-attack .sheet-subtitle,
-.sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
-.sheet-rolltemplate-custom-power-attack .sheet-subtitle,
-.sheet-rolltemplate-custom-activate .sheet-subtitle,
-.sheet-rolltemplate-custom-show .sheet-subtitle {
-	font-size:1.0em;
-	padding-top: 0.1em;
-}
-
-/* example colors */
-.sheet-rolltemplate-custom .sheet-container,
-.sheet-rolltemplate-custom-success-roll .sheet-container,
-.sheet-rolltemplate-custom-defense .sheet-container,
-.sheet-rolltemplate-custom-attack .sheet-container,
-.sheet-rolltemplate-custom-normal-attack .sheet-container,
-.sheet-rolltemplate-custom-power-attack .sheet-container,
-.sheet-rolltemplate-custom-activate .sheet-container,
-.sheet-rolltemplate-custom-show .sheet-container  {
-	/* this is the default color */
-	--header-bg-color: black;
-	--header-text-color: #FFF;
-}
-
-/* Allprops part */
-.sheet-rolltemplate-custom .sheet-content,
-.sheet-rolltemplate-custom-success-roll .sheet-content,
-.sheet-rolltemplate-custom-defense .sheet-content,
-.sheet-rolltemplate-custom-attack .sheet-content,
-.sheet-rolltemplate-custom-normal-attack .sheet-content,
-.sheet-rolltemplate-custom-power-attack .sheet-content,
-.sheet-rolltemplate-custom-activate .sheet-content,
-.sheet-rolltemplate-custom-show .sheet-content {
-	display: grid;
-	background: #FFF;
-	/* Header formatting - modify the column layout below */
-	grid-template-columns: auto auto;
-	/* Line height to match default roll template */
-	line-height:1.4em;
-}
-
-.sheet-rolltemplate-custom .sheet-content > div,
-.sheet-rolltemplate-custom-success-roll .sheet-content > div,
-.sheet-rolltemplate-custom-defense .sheet-content > div,
-.sheet-rolltemplate-custom-attack .sheet-content > div,
-.sheet-rolltemplate-custom-normal-attack .sheet-content > div,
-.sheet-rolltemplate-custom-power-attack .sheet-content > div,
-.sheet-rolltemplate-custom-activate .sheet-content > div,
-.sheet-rolltemplate-custom-show .sheet-content > div {
-	padding: 5px;
-}
-
-/* Left column */
-.sheet-rolltemplate-custom .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-success-roll .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-defense .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-attack .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-activate .sheet-content .sheet-key,
-.sheet-rolltemplate-custom-show .sheet-content .sheet-key {
-	font-weight: bold;
-	padding-right: 10px;
-	text-align: right;
-	color: #222222; /* To fix dark mode in Chrome. */
-}
-
-/* Right column. Color to fix dark mode in Chrome. */
-.sheet-rolltemplate-custom .sheet-value,
-.sheet-rolltemplate-custom-success-roll .sheet-value,
-.sheet-rolltemplate-custom-defense .sheet-value,
-.sheet-rolltemplate-custom-attack .sheet-value,
-.sheet-rolltemplate-custom-normal-attack .sheet-value,
-.sheet-rolltemplate-custom-power-attack .sheet-value,
-.sheet-rolltemplate-custom-activate .sheet-value,
-.sheet-rolltemplate-custom-show .sheet-value {
-	color: #222222;
-}
-
-/* Make even-numbered rows grey */
-.sheet-rolltemplate-custom .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n),
-.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n+3),
-.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n) {
-	background:#EEE;
-}
-
-/* Description field */
-.sheet-rolltemplate-custom .sheet-desc,
-.sheet-rolltemplate-custom-success-roll .sheet-desc,
-.sheet-rolltemplate-custom-defense .sheet-desc,
-.sheet-rolltemplate-custom-attack .sheet-desc,
-.sheet-rolltemplate-custom-normal-attack .sheet-desc,
-.sheet-rolltemplate-custom-power-attack .sheet-desc,
-.sheet-rolltemplate-custom-activate .sheet-desc,
-.sheet-rolltemplate-custom-show .sheet-desc {
-	grid-column: span 2;
-	padding-right: 10px;
-	text-align: left;
-	color: #222222; /* To fix dark mode in Chrome. */
-}
-
-/* Dice roll face colors. Needed to prevent problems with dark mode. */
-.sheet-rolltemplate-custom .inlinerollresult,
-.sheet-rolltemplate-custom-success-roll .inlinerollresult,
-.sheet-rolltemplate-custom-defense .inlinerollresult,
-.sheet-rolltemplate-custom-attack .inlinerollresult,
-.sheet-rolltemplate-custom-normal-attack .inlinerollresult,
-.sheet-rolltemplate-custom-power-attack .inlinerollresult,
-.sheet-rolltemplate-custom-activate .inlinerollresult,
-.sheet-rolltemplate-custom-show .inlinerollresult {
-	display: inline-block;
-	min-width: 1.5em;
-	text-align: center;
-	border: 2px solid palegoldenrod;
-	background: #fff990;
-}
-
-.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult,
-.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult {
-	background-color: #fff990;
-	border: 2px solid palegoldenrod;
-}
-
-.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullcrit,
-.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullcrit {
-	border: 2px solid #228833;
-}
-
-.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullfail,
-.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullfail {
-	border: 2px solid #AA3377;
-}
-
-/* --------------------------------------------------- */
-/* Power block expanding/collapse functionality        */
-/* --------------------------------------------------- */
-
-/* Nominal state for expanded areas */
-.sheet-power-expand-01,
-.sheet-power-expand-02,
-.sheet-power-expand-03,
-.sheet-power-expand-04,
-.sheet-power-expand-05,
-.sheet-power-expand-06,
-.sheet-power-expand-07,
-.sheet-power-expand-08,
-.sheet-power-expand-09,
-.sheet-power-expand-10,
-.sheet-power-expand-11,
-.sheet-power-expand-12,
-.sheet-power-expand-13,
-.sheet-power-expand-14,
-.sheet-power-expand-15,
-.sheet-power-expand-16,
-.sheet-power-expand-17 {
-	display: none;
-}
-
-/* Expand the selected left power block. */
-.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .sheet-power-expand-01,
-.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .sheet-power-expand-02,
-.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .sheet-power-expand-03,
-.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .sheet-power-expand-04,
-.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .sheet-power-expand-05,
-.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .sheet-power-expand-06,
-.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .sheet-power-expand-07,
-.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .sheet-power-expand-08,
-.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .sheet-power-expand-09 {
-	display: block;
-}
-
-/* Expand the selected right power block. */
-.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .sheet-power-expand-10,
-.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .sheet-power-expand-11,
-.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .sheet-power-expand-12,
-.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .sheet-power-expand-13,
-.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .sheet-power-expand-14,
-.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .sheet-power-expand-15,
-.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .sheet-power-expand-16,
-.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .sheet-power-expand-17 {
-	display: block;
-}
-
-/* Turn down the opacity on the left point values to help visibility overall. */
-.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-opacity-power01,
-.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-opacity-power02,
-.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-opacity-power03,
-.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-opacity-power04,
-.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-opacity-power05,
-.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-opacity-power06,
-.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-opacity-power07,
-.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-opacity-power08,
-.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-opacity-power09 {
-	opacity: 0.4;
-}
-
-/* Turn down the opacity on the right point values to help visibility overall. */
-.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-opacity-power10,
-.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-opacity-power11,
-.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-opacity-power12,
-.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-opacity-power13,
-.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-opacity-power14,
-.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-opacity-power15,
-.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-opacity-power16,
-.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-opacity-power17 {
-	opacity: 0.4;
-}
-
-/* Hide the base and active costs for a tidier look. */
-.subitem-visibility-power01,
-.subitem-visibility-power02,
-.subitem-visibility-power03,
-.subitem-visibility-power04,
-.subitem-visibility-power05,
-.subitem-visibility-power06,
-.subitem-visibility-power07,
-.subitem-visibility-power08,
-.subitem-visibility-power09,
-.subitem-visibility-power10,
-.subitem-visibility-power11,
-.subitem-visibility-power12,
-.subitem-visibility-power13,
-.subitem-visibility-power14,
-.subitem-visibility-power15,
-.subitem-visibility-power16,
-.subitem-visibility-power17 {
-	visibility: hidden;
-}
-
-.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power01,
-.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power02,
-.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power03,
-.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power04,
-.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power05,
-.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power06,
-.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power07,
-.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power08,
-.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power09 {
-	visibility: visible;
-}
-
-.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power10,
-.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power11,
-.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power12,
-.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power13,
-.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power14,
-.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power15,
-.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power16,
-.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power17 {
-	visibility: visible;
-}
-
-/* --------------------------------------------------- */
-/* Maneuver block expanding/collapse functionality     */
-/* --------------------------------------------------- */
-
-/* Nominal state for expanded areas */
-.sheet-maneuver-expand-01,
-.sheet-maneuver-expand-02,
-.sheet-maneuver-expand-03,
-.sheet-maneuver-expand-04,
-.sheet-maneuver-expand-05,
-.sheet-maneuver-expand-06,
-.sheet-maneuver-expand-07,
-.sheet-maneuver-expand-08,
-.sheet-maneuver-expand-09  {
-	display: none;
-}
-
-/* Expand the selected maneuver block. */
-.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .sheet-maneuver-expand-01,
-.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .sheet-maneuver-expand-02,
-.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .sheet-maneuver-expand-03,
-.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .sheet-maneuver-expand-04,
-.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .sheet-maneuver-expand-05,
-.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .sheet-maneuver-expand-06,
-.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .sheet-maneuver-expand-07,
-.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08,
-.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .sheet-maneuver-expand-09 {
-	display: block;
-}
-
-/* ---------------------------------------------------------------- */
-/* Custom button for power expand                                   */
-/* ---------------------------------------------------------------- */
-
-.custom-expand-button-container {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	margin-right: 1px;
-}
-
-.custom-expand-button-container button.buttonExpand {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	height: 24px;
-	width: 10px;
-	align-items: center;
-	padding: 0px;
-	margin-right: 2px;
-	margin-left: 0px;
-	border-color: transparent;
-	background: transparent;
-}
-
-.custom-expand-button-container button.buttonExpand span {
-	display: inline-block;
-	text-align: center;
-}
-
-/* Rotate when expanded */
-.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01,
-.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02,
-.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03,
-.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04,
-.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05,
-.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06,
-.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07,
-.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08,
-.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09,
-.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10,
-.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11,
-.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12,
-.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13,
-.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14,
-.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15,
-.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16,
-.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17,
-.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01,
-.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02,
-.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03,
-.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04,
-.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05,
-.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06,
-.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07,
-.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08,
-.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09
- {
-	transform: rotate(90deg);
-}
-
-/* Rotate when not expanded, but hover */
-.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01:hover,
-.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02:hover,
-.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03:hover,
-.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04:hover,
-.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05:hover,
-.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06:hover,
-.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07:hover,
-.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08:hover,
-.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09:hover,
-.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10:hover,
-.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11:hover,
-.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12:hover,
-.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13:hover,
-.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14:hover,
-.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15:hover,
-.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16:hover,
-.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand01"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand02"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand03"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand04"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand05"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand06"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand07"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover,
-.sheet-maneuver-toggle:not([value="maneuverExpand09"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09:hover
-{
-	transition: 0.25s;
-	transform: rotate(90deg);
-}
-
-.custom-button-triangle,
-.custom-button-triangle-alt {
-	position: relative; 
-	border-top: 8px solid transparent;
-	border-bottom: 8px solid transparent;
-	border-right: 8px solid transparent;
-	top: 0px;
-	left: 5px;
-}
-
-.custom-button-triangle {
-	border-left: 12px solid silver;
-}
-
-.custom-button-triangle-alt {
-	border-left: 12px solid silver;
-}
-
-.custom-button-triangle:before,
-.custom-button-triangle-alt:before {
-	content: "";
-	width: 0;
-	height: 0;
-	position: absolute;
-	border-top: 6px solid transparent;
-	border-bottom: 6px solid transparent;
-	top: -6px;
-	left: -11px; 
-}
-
-.custom-button-triangle:before {
-	border-left: 10px solid #FFF9CF;
-}
-
-.custom-button-triangle-alt:before {
-	border-left: 10px solid white;
-}
-
-.subitem-flex-container-martial-row .custom-expand-button-container button.buttonExpand {
-	height: 18px;
-}
-
-.custom-button-triangle:hover,
-.custom-button-triangle:after,
-.custom-button-triangle-alt:hover,
-.custom-button-triangle-alt:after  {
-	position: relative; 
-	border-top: 8px solid transparent;
-	border-bottom: 8px solid transparent;
-	border-right: 8px solid transparent;
-	top: 0px;
-	left: 5px;
-}
-
-.custom-button-triangle:hover,
-.custom-button-triangle:after {
-	border-left: 12px solid silver;
-}
-
-.custom-button-triangle-alt:hover,
-.custom-button-triangle-alt:after {
-	border-left: 10px solid silver;
-}
+	.grid-container-skills-tab .custom-select,
+	.grid-container-skills-tab .custom-select-skill,
+	.grid-container-skills-tab .custom-select-alternate,
+	.grid-container-skills-tab .custom-select-alternate-skill {
+		font-size: 13px;
+		max-width: 110px;
+		margin-left: 3px;
+		padding-left: 3px;
+	}
+	
+	/* Item: Skill Containers for Skill Groups 01, 02, and 03 */
+	.item-skillsTab-flex-container-skills-group01,
+	.item-skillsTab-flex-container-skills-group02,
+	.item-skillsTab-flex-container-skills-group03 {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-evenly;
+		max-width: 358px;
+		margin-left: 5px;
+		background-color: #f7f1a0; 
+		border: solid 2px goldenrod;
+		border-radius: 3px;
+		line-height: 1.10;
+		padding-left: 1px;
+		padding-right: 4px;
+	}
+	
+	.item-skillsTab-flex-container-skills-group01 {
+		grid-area: theSkills1;
+		padding-bottom: 2px;
+	}
+	
+	.item-skillsTab-flex-container-skills-group02 {
+		grid-area: theSkills2;
+		padding-top: 3px;
+		padding-bottom: 2px;
+	}
+	
+	.item-skillsTab-flex-container-skills-group03 {
+		grid-area: theSkills3;
+		padding-top: 3px;
+		padding-bottom: 2px;
+		margin-bottom: 4px;
+	}
+	
+	.item-skillsTab-flex-container-skills-group01 input[type=number],
+	.item-skillsTab-flex-container-skills-group02 input[type=number],
+	.item-skillsTab-flex-container-skills-group03 input[type=number] {
+		text-align: right;
+		padding-right: 0px;
+		margin-top: 0px;
+		margin-bottom: 0px;
+		border: solid 1px palegoldenrod;
+		max-height: 22px;
+	}
+	
+	.item-skillsTab-flex-container-skills-group01 input[readonly],
+	.item-skillsTab-flex-container-skills-group02 input[readonly],
+	.item-skillsTab-flex-container-skills-group03 input[readonly] {
+		text-align: center;
+		background-color: #fff990; 
+		border: transparent;
+		max-width: 24px;
+	}
+	
+	.item-skillsTab-flex-container-skills-group01 input[type=text]:nth-child(1),
+	.item-skillsTab-flex-container-skills-group02 input[type=text]:nth-child(1),
+	.item-skillsTab-flex-container-skills-group03 input[type=text]:nth-child(1) {
+		max-width: 140px;
+		margin-top: 1px;
+		margin-bottom: 1px;
+		font-size: 13px;
+		text-align: left;
+		margin-left: 4px;
+		margin-right: 1px;
+		padding-left: 1px;
+		padding-right: 1px;
+		border: solid 1px palegoldenrod;
+	}
+	
+	/* Sub-Item: Flex containers for rows */
+	.subitem-skillsTab-grid-container-skills-heading-left {
+		grid-template-areas: "skillName skillType rollChance . skillCost";
+		grid-template-columns: 164px 70px 26px 38px 46px;
+		display: grid;
+	}
+	
+	.subitem-skillsTab-grid-container-skills-heading-left-name {
+		grid-area: skillName;
+		padding-left: 5px;
+	}
+	
+	.subitem-skillsTab-grid-container-skills-heading-left-name h2 {
+		text-align: left;
+	}
+	
+	.subitem-skillsTab-grid-container-skills-heading-left-type {
+		grid-area: skillType;
+		text-align: center;
+	}
+	
+	.subitem-skillsTab-grid-container-skills-heading-left-roll {
+		grid-area: rollChance;
+		text-align: center;
+	}
+	
+	.subitem-skillsTab-grid-container-skills-heading-left-cost {
+		grid-area: skillCost;
+		text-align: center;
+	}
+	
+	.subitem-skillsTab-flex-container-skill {
+		text-align: left;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-height: 24px;
+	}
+	
+	.subitem-skillsTab-flex-container {
+		text-align: right;
+	}
+	
+	/* Buttons for skill movers. */
+	.skill-mover-plus-minus-enclosure {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	
+	.skill-mover-plus-minus-button {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		height: 24px;
+		width: 10px;
+		align-items: center;
+		padding: 0px;
+		margin-right: 2px;
+		margin-left: 2px;
+	}
+	
+	.skill-mover-plus-minus-button button.buttonPlus,
+	.skill-mover-plus-minus-button button.buttonMinus {
+		background-color: lemonchiffon;
+		border: solid 1px silver;
+		color: slategray;
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		display: inline-block;
+		font-size: 10px;
+		margin: 0px 0px;
+		line-height: 1.25ch;
+		border-radius: 0px;
+		max-width: 10px;
+	}
+	
+	.skill-mover-plus-minus-button button.buttonPlus span,
+	.skill-mover-plus-minus-button button.buttonMinus span {
+		display: inline-block;
+		transform: rotate(-90deg);
+		text-align: center;
+	}
+	
+	.skill-mover-plus-minus-button button.buttonPlus:hover,
+	.skill-mover-plus-minus-button button.buttonMinus:hover {
+		background-color: gray;
+		color: white;
+		transition: 0.05s;
+	} 
+	
+	/* Item: Skill Container for combat skill flex "columns" */
+	.item-skillsTab-grid-container-combat-skills {
+		grid-area: theCombatSkills;
+		display: grid;
+		grid-template-areas: 
+		"skillNames skillLevels skillTypes skillCosts"
+		"skillLevelNames skillLevels . skillCosts";
+		grid-template-columns: 150px 50px 61px 38px;
+		grid-template-rows: 199px 76px;
+		max-width: 292px;
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-bottom: 3px;
+		padding-top: 0px;
+		background-color: #f7f1a0; 
+		border: solid 2px goldenrod;
+		border-radius: 3px;
+		line-height: 1.10;
+	}
+	
+	/* Subitem: flex container for combat skill name "column" */
+	.subitem-skillsTab-flex-container-combat-skills-names {
+		grid-area: skillNames;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-bottom: 3px;
+		padding-top: 0px;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-names input[type=text] {
+		max-width: 140px;
+		margin-top: 0px;
+		margin-bottom: 3px;
+		font-size: 13px;
+		text-align: left;
+		margin-left: 4px;
+		padding-left: 1px;
+		padding-right: 1px;
+		border: solid 1px palegoldenrod;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-names h1 {
+		text-align: left;
+		padding-top: 3px;
+		padding-bottom: 3px;
+		max-height: 18px;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-level-names {
+		grid-area: skillLevelNames;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-bottom: 8px;
+		padding-top: 0px;
+	} 
+	
+	.subitem-skillsTab-flex-container-combat-skills-level-names h1 {
+		text-align: left;
+		padding-top: 3px;
+		padding-bottom: 3px;
+		max-height: 18px;
+		font-weight: bold;
+	}
+	
+	/* Subitem: flex container for combat skill levels "column" */
+	.subitem-skillsTab-flex-container-combat-skills-levels {
+		grid-area: skillLevels;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-top: 7px;
+		margin-bottom: 6px;
+		max-height: 264px;
+		margin-top: 3px;
+		padding-bottom: 2px;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-levels input[type=number] {
+		text-align: center;
+		padding-left: 3px;
+		padding-right: 1px; /* Fix for shifting spinners on focus */
+		max-width: 45px;
+		margin-right: 5px;
+		padding-bottom: 1px;
+		max-height: 22px;
+		border: solid 1px palegoldenrod;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-levels h1 {
+		text-align: left;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		max-height: 18px;
+		margin-left: 0px;
+	}
+	
+	/* Subitem: flex container for combat skill type "column" */
+	.subitem-skillsTab-flex-container-combat-skills-types {
+		grid-area: skillTypes;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-top: 3px;
+		margin-bottom: 5px;
+		margin-left: 0px;
+		height: 189px;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-types h1 {
+		text-align: center;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		max-height: 18px;
+		margin-left: 0px;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-types .custom-select {
+		max-width: 55px;
+		text-align: center;
+		height: 19px;
+		padding-left: 3px;
+	}
+	
+	/* Subitem: flex container for combat skill costs "column" */
+	.subitem-skillsTab-flex-container-combat-skills-costs {
+		grid-area: skillCosts;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-bottom: 7px;
+		margin-top: 3px;
+		padding-bottom: 2px;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-costs h1 {
+		text-align: center;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		padding-right: 0px;
+		max-height: 18px;
+		max-width: 40px;
+	}
+	
+	.subitem-skillsTab-flex-container-combat-skills-costs input[readonly] {
+		text-align: center;
+		background-color: #fff990;
+		max-width: 30px;
+		margin-left: 5px;
+	}
+	
+	/* Item: Skill Container for Language Skill "rows" */
+	.item-skillsTab-flex-container-languages {
+		grid-area: theLanguageSkills;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		max-width: 292px;
+		background-color: #f7f1a0; 
+		border: solid 2px goldenrod;
+		border-radius: 3px;
+		line-height: 1.10;
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-bottom: 3px;
+	}
+	
+	/* Sub-Item: Flex containers for columns */
+	.subitem-skillsTab-flex-container-languages-heading {
+		grid-template-areas: "skillName skillFluency literacy skillCost";
+		grid-template-columns: 148px 83px 31px 36px;
+		display: grid;
+		margin-left: 0px;
+	}
+	
+	.subitem-skillsTab-flex-container-languages-heading-name {
+		grid-area: skillName;
+		text-align: left;
+	}
+	
+	.subitem-skillsTab-flex-container-languages-heading-fluency {
+		grid-area: skillFluency;
+		text-align: center;
+	}
+	
+	.subitem-skillsTab-flex-container-languages-heading-literacy {
+		grid-area: literacy;
+		text-align: center;
+	}
+	
+	.subitem-skillsTab-flex-container-languages-heading-cost {
+		grid-area: skillCost;
+		text-align: center;
+	}
+	
+	.subitem-skillsTab-flex-container-language {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-width: 285px;
+		margin-left: 0px;
+		padding: 0px;
+		margin-left: 4px;
+	}
+	
+	.subitem-skillsTab-flex-container-language input[type=text]:nth-child(1) {
+		text-align: left;
+		padding-left: 2px;
+		min-width: 140px;
+		margin-right: 0px;
+		border: solid 1px palegoldenrod;	
+	}
+	
+	.subitem-skillsTab-flex-container-language input[readonly] {
+		text-align: center;
+		background-color: #f7f1a0;
+		max-width: 22px;
+		margin-right: 0px;
+		margin-left: 3px;
+		border: transparent;
+	}
+	
+	.subitem-skillsTab-flex-container-language .container-checkbox-small {
+		margin-top: 3px;
+		margin-left: 10px;
+	}
+	
+	.subitem-skillsTab-flex-container-language .custom-select {
+		min-width: 70px;
+		margin-left: 8px;
+		max-height: 19px;
+		padding-left: 3px;
+	}
+	
+	
+	/* Item: Skill Container for Skill Enhancers */
+	.item-skillsTab-grid-container-skill-enhancers {
+		grid-area: theEnhancers;
+		display: grid;
+		grid-template-areas: 
+		". skillEnhancersHeading skillEnhancersHeading skillEnhancersHeading"
+		"checkboxes skillNames . skillCosts"
+		". skillNames skillLevels skillCosts";
+		grid-template-columns: 25px 175px 65px 38px;
+		grid-template-rows: 20px 112px 112px;
+		max-width: 295px;
+		padding-left: 5px;
+		grid-gap:0px;
+		background-color: #f7f1a0; 
+		border: solid 2px goldenrod;
+		border-radius: 3px;
+		max-height: 251px;
+	}
+	
+	.item-skillsTab-grid-container-skill-enhancers input[readonly]{
+		background-color: #fff990;
+		text-align: center;
+		height: 18px;
+		max-width: 30px;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-checkboxes {
+		grid-area: checkboxes;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		line-height: 1.2;
+		padding-bottom: 5px;
+		padding-top: 5px;
+		height: 113px;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-heading {
+		grid-area: skillEnhancersHeading;
+		text-align: left;
+		display: flex;
+		flex-direction: row;
+		padding-top: 4px;
+		justify-content: space-between;
+		line-height: 1.15;
+		width: 264px;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-heading h1:nth-child(2) {
+		padding-right: 0px;
+		line-height: 1.15;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-names {
+		grid-area: skillNames;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-evenly;
+		height: 229px;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-names h1 {
+		text-align: left;
+		line-height: 1.15;
+		font-weight: bold;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-levels {
+		grid-area: skillLevels;
+		text-align: left;
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		line-height: 1.15;
+		margin-top: 11px;
+		height: 107px;
+		margin-bottom: 4px;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-levels input[type=number]{
+		border: solid 1px palegoldenrod;
+		height: 19px;
+		margin-bottom: 2px;
+	}
+	
+	.subitem-skillsTab-flex-container-skill-enhancers-costs {
+		grid-area: skillCosts;
+		text-align: center;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-evenly;
+		line-height: 1.15;
+		height: 229px;
+	}
+	
+	/* ----------------------------------------------------- */
+	/* Gear: armor, weapons, and equipment                   */
+	/* Organized into a 3x4 grid of containers               */
+	/* ----------------------------------------------------- */
+	
+	.grid-container-tab-gear {
+		display: grid;
+		grid-template-areas:
+		"theEncumbrance theEncumbrance gearHealth"
+		"theArmor theArmor gearHealth"
+		"theWeapons theWeapons theWeapons"
+		"theEquipment theSlides theSlides";
+		grid-gap: 8px;
+		grid-template-columns: 250px 336px 84px;
+		grid-template-rows: 63px 174px 155px 322px;
+		max-width: 692px;
+		padding: 0px;
+		padding-left: 2px;
+		font-size: 16px;
+		background-color: royalblue;
+		border: 3px solid #fff990;
+		border-radius: 5px;
+		justify-content: middle;
+		min-height: 801px;
+	}
+	
+	.grid-container-tab-gear h1 {
+		display:inline-block;
+		margin-left: 0px;
+		padding-left: 2px;
+		padding-right: 0px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		margin: 0px;
+		margin-top: 1px;
+		font-size: 13px;
+		font-style: normal;
+		line-height: 1.10;
+		text-align: center;
+	}
+	
+	.grid-container-tab-gear .custom-select {
+		font-size: 13px;
+		max-width: 110px;
+		max-height: 19px;
+	}
+	
+	/* Health status styling grouped with item-health-characteristics */
+	
+	/* Encumbrance */
+	.item-tab-gear-flex-container-encumbrance {
+		grid-area: theEncumbrance;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		margin-left: 4px;
+		margin-top: 6px;
+		padding: 0px;
+		max-width: 594px;
+		max-height: 56px;
+		padding-left: 20px;
+		padding-right: 20px;
+		text-align: left;
+		vertical-align: middle;
+		background-color: royalblue;
+		border: none;
+	}
+	
+	.item-tab-gear-flex-container-encumbrance h1 {
+		text-align: center;
+		color: white;
+		font-size: 13px;
+	}
+	
+	.item-tab-gear-flex-container-encumbrance input[type=number]{
+		text-align: center;
+		max-width: 70px;
+		background-color: #F0E442;
+		border: solid 1px #ebb232;
+		font-size: 16px;
+		margin-left: 0px;
+		padding-right: 0px;
+		min-height: 22px;
+	}
+	
+	.subitem-tab-gear-flex-container-encumbrance,
+	.subitem-tab-gear-flex-container-encumbrance-bonus {
+		display:flex;
+		flex-direction: column;
+		justify-content: space-between;
+		max-width: 80px;
+		align-items: center;
+	}
+	
+	.subitem-tab-gear-flex-container-encumbrance-bonus {
+		margin-left: 0px;
+	}
+	
+	.subitem-tab-gear-plus-minus-enclosure {
+		display: flex;
+		flex-direction: row;
+		background-color: #F0E442;
+		justify-content: space-between;
+		width: 50px;
+		max-height: 20px;
+		border: solid 1px #ebb232;
+		border-radius: 3px;
+	}
+	
+	.subitem-tab-gear-plus-minus-enclosure input[type=text] {
+		max-width: 40px;
+		height: 20px;
+		font-size: 16px;
+		background-color: transparent;
+		text-align: center;
+		vertical-align: center;
+	}
+	
+	.subitem-tab-gear-plus-minus-enclosure input[type=text]:focus{
+		outline: transparent;
+	}
+	
+	.subitem-tab-gear-flex-container-stat {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		height: 20px;
+		width: 10px;
+		align-items: center;
+		padding: 0px;
+	}
+	
+	.subitem-tab-gear-flex-container-stat button.buttonPlus,
+	.subitem-tab-gear-flex-container-stat button.buttonMinus {
+		background-color: LemonChiffon;
+		border: solid 1px slategray;
+		color: slategray;
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		display: inline-block;
+		font-size: 10px;
+		margin: 0px 0px;
+		line-height: 1.4ch;
+		border-radius: 0px;
+		max-width: 10px;
+	}
+	
+	.subitem-tab-gear-flex-container-stat button.buttonPlus span,
+	.subitem-tab-gear-flex-container-stat button.buttonMinus span {
+		display: inline-block;
+		transform: rotate(-90deg);
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-stat button.buttonPlus:hover,
+	.subitem-tab-gear-flex-container-stat button.buttonMinus:hover {
+		background-color: gray;
+		color: white;
+		transition: 0.05s;
+	} 
+	
+	/* ------------- */
+	/* Item: Armor   */
+	/* ------------- */
+	.item-tab-gear-grid-container-armor {
+		grid-area: theArmor;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-around;
+		max-width: 594px;
+		padding-left: 5px;
+		margin-left: 4px;
+		padding-top: 0px;
+		grid-gap: 3px;
+		background-color: #f6ee8d; 
+		border: solid 2px #ebb232;
+		border-radius: 3px;
+		min-height: 179px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: center;
+		max-width: 575px;
+		margin-bottom: 1px;
+		height: 24px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(1) {
+		min-width: 118px;
+		text-align: left;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(2),
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(3),
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(4),
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(5) {
+		min-width: 34px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(6),
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(7) {
+		min-width: 44px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(8) {
+		min-width: 36px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(9) {
+		min-width: 98px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row h1:nth-child(10) {
+		min-width: 46px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row input {
+		max-height: 22px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row input[type=number] {
+		text-align: right;
+		padding-left: 2px;
+		max-width: 36px;
+		min-width: 34px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1),
+	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
+		padding-left: 1px;
+		padding-right: 1px;
+		margin-right: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(1) {
+		text-align: left;
+		max-width: 120px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row input[type=text]:nth-child(9) {
+		text-align: center;
+		max-width: 100px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row input[type=number]:nth-child(10) {
+		text-align: right;
+		min-width: 48px;
+	}
+	
+	.subitem-tab-gear-flex-container-armor-row select {
+		text-align-last: center; /* For Chrome */
+		text-align: center; /* Firefox */
+	}
+	
+	/* Shield */
+	
+	.subitem-tab-gear-flex-container-shield {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-right: 5px;
+		margin-top: 5px;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1 {
+		margin-bottom: 3px;
+		padding: 0px;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row input {
+		max-height: 21px;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row label {
+		max-width: 5px;
+		margin-left: 2px;
+		margin-top: 3px;
+		padding-right: 0px;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row .container-checkbox-small {
+		padding-left: 10px;
+		margin-right: 3px;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(1) {
+		min-width: 120px;
+		text-align: left;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(3) {
+		min-width: 67px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(4) {
+		min-width: 24px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(6) {
+		min-width: 38px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(7) {
+		min-width: 48px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(5),
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(8),
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(9) {
+		min-width: 32px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(2),
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(10),
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(11) {
+		min-width: 40px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row h1:nth-child(12) {
+		min-width: 42px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1),
+	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
+		padding-left: 1px;
+		padding-right: 1px;
+		margin-right: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(1) {
+		max-width: 120px;
+		text-align: left;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row input[type=text]:nth-child(3) {
+		max-width: 65px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row  input[readonly]:nth-child(9){
+		background-color: inherit;
+		text-align: center;
+		padding-left: 0px;
+		max-width: 24px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 0px;
+		margin-top: 3px;
+		margin-bottom: 2px;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row input[type=number] {
+		text-align: right;
+		padding-left: 3px;
+		max-width: 38px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row input[type=number]:nth-child(12) {
+		text-align: right;
+		padding-left: 3px;
+		min-width: 42px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-shield-row{
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-width: 576px;
+	}
+	
+	/* ------------- */
+	/* Item: Weapons */
+	/* ------------- */
+	.item-tab-gear-flex-container-weapons {
+		grid-area: theWeapons;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-around;
+		margin-left: 4px;
+		padding: 0px;
+		padding-left: 5px;
+		margin-top: 8px;
+		max-height: 145px;
+		max-width: 655px;
+		background-color: #f6ee8d; 
+		border: solid 2px #ebb232;
+		border-radius: 3px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-width: 650px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row input {
+		max-height: 21px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1 {
+		min-width: 39px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row label {
+		max-width: 5px;
+		margin-left: 2px;
+		margin-top: 3px;
+		padding-right: 0px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(1) {
+		min-width: 120px;
+		text-align: left;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(2) {
+		min-width: 65px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(3) {
+		min-width: 26px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(4) {
+		min-width: 32px;
+		text-align: left;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(5) {
+		min-width: 36px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(6) {
+		min-width: 40x;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(7) {
+		min-width: 44px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(8) {
+		min-width: 42px;
+		text-align: center;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(9) {
+		min-width: 32px;
+		text-align: right;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(10) {
+		min-width: 34px;
+		text-align: right;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(11) {
+		min-width: 45px;
+		text-align: center;
+		padding-left: 0px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(12) {
+		min-width: 32px;
+		text-align: center;
+		padding: 0px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row h1:nth-child(13) {
+		min-width: 32px;
+		text-align: right;
+		margin-right: 6px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(1) {
+		text-align: left;
+		padding-left: 1px;
+		padding-right: 1px;
+		max-width: 120px;
+		margin-right: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row input[type=text]:nth-child(2) {
+		text-align: center;
+		padding-left: 1px;
+		padding-right: 1px;
+		max-width: 68px;
+		margin-right: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row .container-checkbox-small {
+		padding-left: 10px;
+		margin-right: 3px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row button:nth-child(4) {
+		margin-left: 0px;
+		margin-right: 0px;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(5),
+	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(6),
+	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(7),
+	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(9) {
+		text-align: right;
+		padding-left: 3px;
+		max-width: 38px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(8),
+	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(11),
+	.subitem-tab-gear-flex-container-weapon-row input[type=number]:nth-child(13) {
+		text-align: right;
+		padding-left: 3px;
+		max-width: 46px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 0px;
+		border: solid 1px #F0E442;
+	}
+	
+	.subitem-tab-gear-flex-container-weapon-row input[readonly]:nth-child(10){
+		background-color: inherit;
+		text-align: center;
+		padding-left: 0px;
+		max-width: 24px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 0px;
+		margin-top: 3px;
+		margin-bottom: 2px;
+	}
+	
+	/* --------------- */
+	/* Item: Equipment */
+	/* --------------- */
+	.item-tab-gear-flex-container-equipment {
+		grid-area: theEquipment;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		max-width: 248px;
+		margin-left: 4px;
+		padding: 4px;
+		padding-top: 3px;
+		background-color: #cce8f8;
+		border: solid 2px #c4c4c4;
+		border-radius: 3px;
+		height: 367px;
+	}
+	
+	.subitem-tab-gear-flex-container-equipment {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	
+	.subitem-tab-gear-flex-container-equipment h1 {
+		margin-right: 8px;
+		margin-bottom: 2px;
+	}
+	
+	.subitem-tab-gear-flex-container-equipment input[type=text] {
+		text-align: left;
+		padding-left: 1px;
+		padding-right: 1px;
+		max-width: 162px;
+		max-height: 21px;
+		margin-right: 0px;
+		border: solid 1px #bbe1f6;
+	}
+	
+	
+	/* Close spacing of equipment items means the focus border is clipped unless we move the z position to relative. */
+	.subitem-tab-gear-flex-container-equipment input[type=text]:focus {
+		position: relative;
+	}
+	
+	.subitem-tab-gear-flex-container-equipment input[type=number] {
+		text-align: right;
+		padding-left: 3px;
+		max-width: 120px;
+		min-width: 50px;
+		max-height: 21px;
+		padding-right: 0px;
+		margin-right: 0px;
+		margin-left: 2px;
+		border: solid 1px #bbe1f6;
+	}
+	
+	/* Buttons for equipment movers. */
+	
+	.gear-mover-plus-minus-enclosure {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	
+	.gear-mover-plus-minus-button {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		height: 22px;
+		width: 10px;
+		align-items: center;
+		padding: 0px;
+		margin-right: 2px;
+	}
+	
+	.gear-mover-plus-minus-button button.buttonPlus,
+	.gear-mover-plus-minus-button button.buttonMinus {
+		background-color: white;
+		border: solid 1px #99d2f1;
+		color: #99d2f1;
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		display: inline-block;
+		font-size: 8px;
+		margin: 0px 0px;
+		line-height: 1.25ch;
+		border-radius: 0px;
+		max-width: 10px;
+	}
+	
+	.gear-mover-plus-minus-button button.buttonPlus span,
+	.gear-mover-plus-minus-button button.buttonMinus span {
+		display: inline-block;
+		transform: rotate(-90deg);
+		text-align: center;
+	}
+	
+	.gear-mover-plus-minus-button button.buttonPlus:hover,
+	.gear-mover-plus-minus-button button.buttonMinus:hover {
+		background-color: #b8b8b8;
+		transition: 0.05s;
+		color: white;
+	} 
+	
+	/* ----------------------------------------------------------- */
+	/* Item: Attacks and Maneuvers or treasures text box slideshow */
+	/* ----------------------------------------------------------- */
+	
+	.item-tab-gear-slide-container {
+		grid-area: theSlides;
+		position: relative;
+	}
+	
+	.item-tab-gear-slide-container h1 {
+		text-align: left;
+		line-height: 1.2;
+		font-size: 12px;
+		margin: 0px;
+	}
+	
+	.item-tab-gear-slide-container h2 {
+		font-size: 12px;
+		text-align: center;
+		font-weight: 400;
+		line-height: 1.2;
+	}
+	
+	.item-tab-gear-slide-container .button-left-arrow {
+		position: absolute;
+		top: 4.5%;
+		left: 88%;
+		transform: translate(-50%, -50%);
+		color: white;
+		background-color: #8A8A8A;
+		font-size: 12px;
+		padding: 1px 5px;
+		border: none;
+		cursor: pointer;
+		border-radius: 3px;
+		text-align: center;
+	}
+	
+	.item-tab-gear-slide-container .button-right-arrow {
+		position: absolute;
+		top: 4.5%;
+		left: 92.5%;
+		transform: translate(-50%, -50%);
+		color: white;
+		background-color: #8A8A8A;
+		font-size: 12px;
+		padding: 1px 5px;
+		border: none;
+		cursor: pointer;
+		border-radius: 3px;
+		text-align: center;
+	}
+	
+	.item-tab-gear-slide-container .button-right-arrow:hover,
+	.item-tab-gear-slide-container .button-left-arrow:hover {
+		background-color: #F0E442;
+		color: black;
+	}
+	
+	.item-tab-gear-slide-flex-container-maneuvers,
+	.item-tab-gear-slide-flex-container-martial-maneuvers {
+		width: 406px;
+		height: 374px;
+		padding: 0px;
+		margin-left: 0px;
+		margin-bottom: 0px;
+		background-color: #cce8f8;
+		border: solid 2px #c4c4c4;
+		border-radius: 3px;
+	}
+	
+	.item-tab-gear-slide-flex-container-martial-maneuvers-block {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		margin-top: 6px;
+		max-height: 310px;
+		min-height: 270px;
+	}
+	
+	.item-tab-gear-slide-flex-container-martial-maneuvers input[type=text] {
+		border: solid 1px #bbe1f6;
+		height: 22px;
+		width: 30px;
+	}
+	
+	.subitem-flex-container-martial-row input {
+		text-align: center;
+		height: 22px;
+		border: solid 1px #bbe1f6;
+		margin: 0px;
+		padding: 0px;
+	}
+	
+	.subitem-flex-container-martial-row input[type=number] {
+		text-align: right;
+		height: 22px;
+		border: solid 1px #bbe1f6;
+		max-width: 35px;
+	}
+	
+	.subitem-flex-container-martial-row input[type=text]:nth-child(2) {
+		width: 220px;
+		margin: 0px;
+		height: 22px;
+		text-align: left;
+		padding-left: 1px;
+		border: solid 1px #bbe1f6;
+	}
+	
+	.subitem-flex-container-martial-cv-row input[type=text] {
+		width: 30px;
+		border: 1px solid #bbe1f6;
+		text-align: center;
+		padding-left: 2px;
+		height: 18px;
+		margin-left: 3px;
+	}
+	
+	.item-tab-gear-slide-flex-container-martial-maneuvers textarea {
+		width: 244px;
+		border: 1px solid #bbe1f6;
+		max-height: 37px;
+		padding: 0px 3px; 
+		font-size: 12px;
+		margin: 0px;
+	}
+	
+	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(1),
+	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(1) {
+		width: 108px;
+	}
+	
+	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(2),
+	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(2),
+	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(3),
+	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(3),
+	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(4),
+	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(4) {
+		width: 40px;
+		padding: 0px;
+		margin: 0px;
+		text-align: center;
+	}
+	
+	.item-tab-gear-slide-flex-container-maneuvers h1:nth-child(5),
+	.item-tab-gear-slide-flex-container-maneuvers h2:nth-child(5) {
+		text-align: left;
+		padding-left: 0px;
+		margin-left: 0px;
+	}
+	
+	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(1) {
+		padding-left: 2px;
+		width: 261px;
+	}
+	
+	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(2),
+	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading h1:nth-child(3) {
+		text-align: center;
+		width: 39px;
+	}
+	
+	.subitem-tab-gear-slide-flex-container-maneuvers-heading,
+	.subitem-tab-gear-slide-flex-container-martial-maneuvers-heading {
+		flex-direction: row;
+		display: flex;
+		justify-content: flex-start;
+		width: 402px;
+		height: 19px;
+		padding: 0px;
+		margin-left: 0px;
+		padding-top: 5px;
+		padding-left: 4px;
+		margin-bottom: 0px;
+	}
+	
+	.subitem-tab-gear-slide-flex-container-maneuvers-light-row,
+	.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
+		flex-direction: row;
+		display: flex;
+		justify-content: flex-start;
+		width: 402px;
+		height: 19px;
+		padding: 0px;
+		margin-left: 0px;
+		padding-top: 4px;
+		padding-left: 4px;
+		margin-top: 0px;
+		margin-bottom: 0px;
+	}
+	
+	.subitem-tab-gear-slide-flex-container-maneuvers-light-row {
+		background-color: white;
+	}
+	
+	.subitem-tab-gear-slide-flex-container-maneuvers-dark-row {
+		background-color: #cce8f8;
+	}
+	
+	.subitem-tab-gear-slide-flex-container-martial-maneuvers-row {
+		flex-direction: row;
+		display: flex;
+		justify-content: space-between;
+		width: 397px;
+		height: 40px;
+		padding: 0px;
+		margin-left: 0px;
+		padding-top: 0px;
+		padding-left: 4px;
+		margin-top: 0px;
+		margin-bottom: 0px;
+	}
+	
+	/* Buttons for maneuver movers. */
+	.maneuver-mover-plus-minus-enclosure {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+	
+	.maneuver-mover-plus-minus-button {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		height: 24px;
+		width: 10px;
+		align-items: center;
+		padding: 0px;
+		margin-right: 2px;
+		margin-left: 2px;
+	}
+	
+	.maneuver-mover-plus-minus-button button.buttonPlus,
+	.maneuver-mover-plus-minus-button button.buttonMinus {
+		background-color: white;
+		border: solid 1px #99d2f1;
+		color: #99d2f1;
+		padding-left: 4px;
+		padding-right: 4px;
+		padding-top: 1px;
+		padding-bottom: 1px;
+		display: inline-block;
+		font-size: 10px;
+		margin: 0px 0px;
+		line-height: 1.25ch;
+		border-radius: 0px;
+		max-width: 10px;
+	}
+	
+	.maneuver-mover-plus-minus-button button.buttonPlus span,
+	.maneuver-mover-plus-minus-button button.buttonMinus span {
+		display: inline-block;
+		transform: rotate(-90deg);
+		text-align: center;
+	}
+	
+	.maneuver-mover-plus-minus-button button.buttonPlus:hover,
+	.maneuver-mover-plus-minus-button button.buttonMinus:hover {
+		background-color: #8A8A8A;
+		color: white;
+		transition: 0.05s;
+	} 
+	
+	.item-flex-maneuver {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		width: 399px;
+		padding-left: 4px;
+		margin-top: 1px;
+		padding-bottom: 3px;
+	}
+	
+	.subitem-flex-container-martial-row {
+		text-align: left;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-height: 24px;
+	}
+	
+	/* Update when custom maneuver attack roll made */
+	.subitem-flex-container-martial-row .buttonRollAttack {
+		margin-top: 1px;
+		margin-left: 3px;
+	}
+	
+	.subitem-flex-container-martial-ocv-dcv {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		max-height: 40px;
+		max-width: 134px;
+		padding: 0px 0px;
+	}
+	
+	/* Martial Maneuver Details */
+	
+	.subitem-flex-container-martial-details-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: top;
+		max-width: 397px;
+		height: 48px;
+		margin-top: 3px;
+		margin-bottom: 3px;
+		padding: 0px;
+		padding-left: 24px;
+	}
+	
+	.subitem-flex-container-martial-details-row .buttonRollShow {
+		margin-top: 3px;
+	}
+	
+	.subitem-flex-container-martial-details-column {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 48px;
+	}
+	
+	.subitem-flex-container-martial-buttons-column {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 45px;
+		padding-top: 2px;
+		padding-bottom: 1px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		max-height: 21px;
+		align-items: center;
+		padding-right: 1px;
+		margin: 0px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row h1 {
+		padding-right: 1px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row h1:not(:first-child) {
+		padding-left: 2px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row input[type=number] {
+		height: 21px;
+		max-width: 35px;
+		border: solid 1px #bbe1f6;
+		text-align: right;
+		padding-right: 1px;
+	}
+	
+	.subitem-flex-container-martial-cv-damage-row input[type=text] {
+		text-align: center;
+		height: 21px;
+		width: 68px;
+		padding-left: 2px;
+		padding-right: 4px;
+		border: solid 1px #bbe1f6;
+	}
+	
+	.subitem-martial-description-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		align-items: bottom;
+		max-height: 22px;
+		min-width: 320px;
+		padding: 0px;
+		margin: 0px;
+	}
+	
+	.subitem-martial-description-row input[type=text] {
+		width: 220px;
+		height: 22px;
+		text-align: left;
+		padding-left: 2px;
+		margin-right: 0px;
+		border: solid 1px #bbe1f6;
+	}
+	
+	.subitem-martial-description-row h1 {
+		padding-top: 5px;
+	}
+	
+	.subitem-martial-description-row input[type=number] {
+		height: 22px;
+		max-width: 35px;
+		border: solid 1px #bbe1f6;
+		text-align: right;
+		margin-right: 0px;
+	}
+	
+			
+	/* Range Modifier Table */
+	.subitem-tab-gear-slide-flex-container-range-modifiers {
+		flex-direction: row;
+		display: flex;
+		justify-content: space-between;
+		width: 391px;
+		height: 28px;
+		padding: 3px;
+		margin-top: 1px;
+		margin-bottom: 7px;
+		margin-right: 0px;
+		margin-left: 4px;
+		background-color: white;
+		border-radius: 3px;
+		border: solid 1px #bbe1f6;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		height: 33px;
+		align-items: top;
+		padding: 0px;
+		margin: 0px;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container:nth-child(1) {
+		width: 60px;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container:nth-child(2) {
+		width: 37px;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container:nth-child(3) {
+		width: 43px;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container:nth-child(4) {
+		width: 49px;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container:nth-child(5) {
+		width: 50px;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container:nth-child(6) {
+		width: 57px;
+	}
+	
+	.subitem-range-modifier-container-column h2:nth-child(1) {
+		font-weight: bold;
+	}
+	
+	.subitem-range-modifier-container-column {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		height: 30px;
+		padding-top: 0px;
+	}
+	
+	.subitem-range-modifier-button-container {
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-start;
+		height: 30px;
+		padding-top: 1px;
+	}
+	
+	.subitem-tab-gear-slide-range-modifier-container:nth-child(1) .subitem-range-modifier-container-column {
+		margin-bottom: 3px;
+		height: 30px;
+	}
+	
+	/* Item: Hit Locations */
+	.item-tab-gear-slide-flex-container-hit-locations {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		width: 403px;
+		height: 375px;
+		padding: 0px;
+		padding-left: 3px;
+		background-color: #cce8f8;
+		margin-left: 0px;
+		margin-bottom: 0px;
+		border: solid 2px #c4c4c4;
+		border-radius: 3px;
+	}
+	
+	.item-gear-slide-container-hit-locations-flex-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		border-radius: 3px;
+		width: 400px;
+	}
+	
+	/* Special Hit Locations */
+	.item-gear-slide-flex-container-hit-locations-special {
+		width: 260px;
+		height: 145px;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+	}
+	
+	.item-gear-slide-flex-container-hit-locations-special label {
+		display: inline-block;
+		margin-left: 14px;
+		margin-right: 4px;
+		margin-top: 2px; /* A fix to get a uniform look with the hit location table */
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-heading {
+		height: 20px;
+		margin-bottom: 3px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(1){
+		width: 42px;
+		text-align: left;
+		margin-left: 2px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(2){
+		width: 40px;
+		text-align: center;
+		margin-left: 3px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(3){
+		width: 52px;
+		text-align: center;
+		margin-left: 30px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-heading h1:nth-child(4){
+		width: 44px;
+		text-align: right;
+		margin-left: 15px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-top-row,
+	.subitem-gear-slide-flex-container-hit-locations-special-middle-row,
+	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		background-color: white;
+		border-left: solid 1px #bbe1f6;
+		border-right: solid 1px #bbe1f6;
+		width: 260px;
+		height: 20px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-top-row {
+		border-top: solid 1px #bbe1f6;
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
+		padding-top: 5px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row {
+		border-bottom: solid 1px #bbe1f6;
+		border-bottom-left-radius: 3px;
+		border-bottom-right-radius: 3px;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-top-row h1,
+	.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1,
+	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1 {
+		width: 65px;
+		text-align: center;
+	}
+	
+	.subitem-gear-slide-flex-container-hit-locations-special-top-row h1:nth-child(4),
+	.subitem-gear-slide-flex-container-hit-locations-special-middle-row h1:nth-child(4),
+	.subitem-gear-slide-flex-container-hit-locations-special-bottom-row h1:nth-child(4) {
+		width: 35px;
+		text-align: right;
+		padding-right: 19px;
+	}
+	
+	/* Targeting Options */
+	.item-gear-slide-container-hit-locations-options {
+		width: 130px;
+		height: 100px;
+		margin-top: 50px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-options-top,
+	.subitem-gear-slide-container-hit-locations-options-bottom {
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
+		width: 115px;
+		margin: 3px;
+		margin-bottom: 15px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-options-top {
+		margin-left: 10px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-options-top h1,
+	.subitem-gear-slide-container-hit-locations-options-bottom h1 {
+		padding-top: 4px;
+		margin: 0px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-options-top label {
+		max-width: 0px;
+		margin-left: 2px;
+		margin-right: 0px;
+		margin-top: 3px;
+		padding-right: 0px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-options-bottom input {
+		margin-left: 5px;
+		border: solid 1px #bbe1f6;
+	}
+	
+	/* Hit Location Table */
+	.item-gear-slide-container-hit-locations-table {
+		width: 399px;
+		height: 215px;
+	}
+	
+	.item-gear-slide-container-hit-locations-table h1 {
+		width: 51px;
+		text-align: center;
+	}
+	
+	.item-gear-slide-container-hit-locations-table label {
+		display: inline-block;
+		margin-left: 14px;
+		margin-right: 3px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-heading {
+		height: 20px;
+		margin-bottom: 3px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-heading h1 {
+		text-align: center;
+		margin-left: 2px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(1){
+		width: 42px;
+		text-align: left;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-heading h1:nth-child(2){
+		width: 34px;
+		text-align: center;
+		margin-right: 9px;
+		margin-left: 3px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-top-row,
+	.subitem-gear-slide-container-hit-locations-table-middle-row,
+	.subitem-gear-slide-container-hit-locations-table-bottom-row {
+		height: 19px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
+	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
+	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
+		width: 40x;
+		text-align: center;
+		margin-right: 11px;
+	}
+
+	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(2),
+	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(2),
+	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(2){
+		width: 34px;
+		text-align: center;
+		margin-left: 21px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(6),
+	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(6),
+	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(6){
+		width: 45px;
+		text-align: center;
+		margin-left: 6px;
+		margin-right: 0px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-top-row h1:nth-child(7),
+	.subitem-gear-slide-container-hit-locations-table-middle-row h1:nth-child(7),
+	.subitem-gear-slide-container-hit-locations-table-bottom-row h1:nth-child(7){
+		width: 34px;
+		text-align: right;
+		margin-left: 4px;
+		margin-right: 17px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-top-row {
+		background-color: white;
+		border: solid 1px #bbe1f6;
+		border-bottom: none;
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-middle-row {
+		background-color: white;
+		border-left: solid 1px #bbe1f6;
+		border-right: solid 1px #bbe1f6;
+	}
+	
+	.subitem-gear-slide-container-hit-locations-table-bottom-row {
+		background-color: white;
+		border: solid 1px #bbe1f6;
+		border-top: none;
+		border-bottom-left-radius: 3px;
+		border-bottom-right-radius: 3px;
+		padding-bottom: 5px;
+	}
+	
+	/* Item: Slide of treasure and notes box  */
+	.item-tab-gear-slide-treasure-text {
+		width: 402px;
+		height: 367px;
+		padding: 0px;
+		margin-left: 0px;
+		margin-bottom: 0px;
+	}
+	
+	.item-tab-gear-slide-treasure-text textarea {
+		width: 398px;
+		height: 367px;
+		margin: 0px;
+		border: solid 2px lightgray;
+		border-radius: 3px;
+	}
+	
+	/* hide all gear tab slides by default */
+	
+	.item-tab-gear-slide-flex-container-maneuvers,
+	.item-tab-gear-slide-flex-container-martial-maneuvers,
+	.item-tab-gear-slide-flex-container-hit-locations,
+	.item-tab-gear-slide-treasure-text {
+		display: none;
+	}
+	
+	/* show the selected gear slide */
+	.item-gear-slideshow[value="1"] ~ div.item-tab-gear-slide-flex-container-maneuvers,
+	.item-gear-slideshow[value="2"] ~ div.item-tab-gear-slide-flex-container-martial-maneuvers,
+	.item-gear-slideshow[value="3"] ~ div.item-tab-gear-slide-flex-container-hit-locations,
+	.item-gear-slideshow[value="4"] ~ div.item-tab-gear-slide-treasure-text {
+		display: block;
+		position: relative;
+	}
+	
+	/* ---------------------------------------------------------------- */
+	/* Custom radio button from w3 schools.                             */
+	/* https://www.w3schools.com/howto/howto_css_custom_checkbox.asp    */
+	/* ---------------------------------------------------------------- */
+	
+	/* Customize the label (the container) */
+	.custom-radio-button-container {
+		display: block;
+		position: relative;
+		padding: 0px;
+		margin: 0px;
+		cursor: pointer;
+		font-size: 12px;
+		max-width: 0px;
+		max-height: 0px;
+		-webkit-user-select: none;
+		-moz-user-select: none;
+		-ms-user-select: none;
+		user-select: none;
+		/* background-color: #E69F00; */
+	}
+	
+	/* Hide the browser's default radio button */
+	.custom-radio-button-container input {
+		position: absolute;
+		opacity: 0;
+		cursor: pointer;
+		height: 0;
+		width: 0;
+	}
+	
+	/* Create a custom radio button */
+	.custom-radio-button {
+		position: absolute;
+		top: -2px; /* A fix to get a uniform look with the hit location table */
+		left: 0px;
+		height: 11px;
+		width: 11px;
+		background-color: white;
+		border: solid 2px lightsteelblue;
+		border-radius: 50%;
+		margin-bottom: 0px;
+		padding: 0px;
+	}
+	
+	/* On mouse-over, add a grey background color */
+	.custom-radio-button-container:hover input ~ .custom-radio-button {
+		background-color: lightsteelblue;
+	}
+	
+	/* When the radio button is checked, add a blue background */
+	.custom-radio-button-container input:checked ~ .custom-radio-button {
+		background-color: #D55E00;
+		border: solid 2px #D55E00;
+	}
+	
+	/* Create the indicator (the dot/circle - hidden when not checked) */
+	.custom-radio-button:after {
+		content: "";
+		position: absolute;
+		display: none;
+	}
+	
+	/* Show the indicator (dot/circle) when checked */
+	.custom-radio-button-container input:checked ~ .custom-radio-button:after {
+		display: block;
+	}
+	
+	/* Style the indicator (dot/circle) */
+	.custom-radio-button-container .custom-radio-button:after {
+		top: 0px;
+		left: 0px;
+		width: 7px;
+		height: 7px;
+		border-radius: 50%;
+		border: solid 2px white;
+		background: #D55E00;
+		margin: 0px;
+		padding: 0px;
+	}
+	
+	/* ---------------------------------------------------------------- */
+	/* Jackob's Roll Template                                           */
+	/* https://wiki.roll20.net/Building_Character_Sheets/Roll_Templates */
+	/* ---------------------------------------------------------------- */
+	
+	/* Three different Templates for attacks, armor activation, and skills ability checks. */
+	.sheet-rolltemplate-custom,
+	.sheet-rolltemplate-custom-success-roll,
+	.sheet-rolltemplate-custom-defense,
+	.sheet-rolltemplate-custom-attack,
+	.sheet-rolltemplate-custom-normal-attack,
+	.sheet-rolltemplate-custom-power-attack,
+	.sheet-rolltemplate-custom-activate,
+	.sheet-rolltemplate-custom-show {
+		margin-left: -37px;
+		color: #181818;
+	}
+	
+	.withoutavatars .sheet-rolltemplate-custom,
+	.withoutavatars .sheet-rolltemplate-custom-success-roll,
+	.withoutavatars .sheet-rolltemplate-custom-defense,
+	.withoutavatars .sheet-rolltemplate-custom-attack,
+	.withoutavatars .sheet-rolltemplate-custom-normal-attack,
+	.withoutavatars .sheet-rolltemplate-custom-power-attack,
+	.withoutavatars .sheet-rolltemplate-custom-activate,
+	.withoutavatars .sheet-rolltemplate-custom-show {
+		margin-left: -7px;
+		color: #181818;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-container,
+	.sheet-rolltemplate-custom-success-roll .sheet-container,
+	.sheet-rolltemplate-custom-defense .sheet-container,
+	.sheet-rolltemplate-custom-attack .sheet-container,
+	.sheet-rolltemplate-custom-normal-attack .sheet-container,
+	.sheet-rolltemplate-custom-power-attack .sheet-container,
+	.sheet-rolltemplate-custom-activate .sheet-container,
+	.sheet-rolltemplate-custom-show .sheet-container {
+		border: 1px solid;
+		/* by default, the border is the same color as the header. You can change this here, e.g. to black */
+		border-color: var(--header-bg-color);
+	}
+	
+	/* Header formatting - title and subtitle */
+	.sheet-rolltemplate-custom .sheet-header,
+	.sheet-rolltemplate-custom-success-roll .sheet-header {
+		background-color: #E69F00;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-defense .sheet-header {
+		background-color: #56B4E9;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-attack .sheet-header {
+		background-color: #D55E00;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-normal-attack .sheet-header {
+		background-color: #009E73;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-power-attack .sheet-header {
+		background-color: #CC79A7;
+		/* background-color: #56B4E9; */
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-activate .sheet-header {
+		background-color: #0072B2;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-show .sheet-header {
+		background-color: #8A8A8A;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-title,
+	.sheet-rolltemplate-custom-success-roll .sheet-title,
+	.sheet-rolltemplate-custom-defense .sheet-title,
+	.sheet-rolltemplate-custom-attack .sheet-title,
+	.sheet-rolltemplate-custom-normal-attack .sheet-title,
+	.sheet-rolltemplate-custom-power-attack .sheet-title,
+	.sheet-rolltemplate-custom-activate .sheet-title,
+	.sheet-rolltemplate-custom-show .sheet-title {
+		font-size:1.2em;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-subtitle,
+	.sheet-rolltemplate-custom-success-roll .sheet-subtitle,
+	.sheet-rolltemplate-custom-defense .sheet-subtitle,
+	.sheet-rolltemplate-custom-attack .sheet-subtitle,
+	.sheet-rolltemplate-custom-normal-attack .sheet-subtitle,
+	.sheet-rolltemplate-custom-power-attack .sheet-subtitle,
+	.sheet-rolltemplate-custom-activate .sheet-subtitle,
+	.sheet-rolltemplate-custom-show .sheet-subtitle {
+		font-size:1.0em;
+		padding-top: 0.1em;
+	}
+	
+	/* example colors */
+	.sheet-rolltemplate-custom .sheet-container,
+	.sheet-rolltemplate-custom-success-roll .sheet-container,
+	.sheet-rolltemplate-custom-defense .sheet-container,
+	.sheet-rolltemplate-custom-attack .sheet-container,
+	.sheet-rolltemplate-custom-normal-attack .sheet-container,
+	.sheet-rolltemplate-custom-power-attack .sheet-container,
+	.sheet-rolltemplate-custom-activate .sheet-container,
+	.sheet-rolltemplate-custom-show .sheet-container  {
+		/* this is the default color */
+		--header-bg-color: black;
+		--header-text-color: #FFF;
+	}
+	
+	/* Allprops part */
+	.sheet-rolltemplate-custom .sheet-content,
+	.sheet-rolltemplate-custom-success-roll .sheet-content,
+	.sheet-rolltemplate-custom-defense .sheet-content,
+	.sheet-rolltemplate-custom-attack .sheet-content,
+	.sheet-rolltemplate-custom-normal-attack .sheet-content,
+	.sheet-rolltemplate-custom-power-attack .sheet-content,
+	.sheet-rolltemplate-custom-activate .sheet-content,
+	.sheet-rolltemplate-custom-show .sheet-content {
+		display: grid;
+		background: #FFF;
+		/* Header formatting - modify the column layout below */
+		grid-template-columns: auto auto;
+		/* Line height to match default roll template */
+		line-height:1.4em;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-content > div,
+	.sheet-rolltemplate-custom-success-roll .sheet-content > div,
+	.sheet-rolltemplate-custom-defense .sheet-content > div,
+	.sheet-rolltemplate-custom-attack .sheet-content > div,
+	.sheet-rolltemplate-custom-normal-attack .sheet-content > div,
+	.sheet-rolltemplate-custom-power-attack .sheet-content > div,
+	.sheet-rolltemplate-custom-activate .sheet-content > div,
+	.sheet-rolltemplate-custom-show .sheet-content > div {
+		padding: 5px;
+	}
+	
+	/* Left column */
+	.sheet-rolltemplate-custom .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-success-roll .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-defense .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-attack .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-normal-attack .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-power-attack .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-activate .sheet-content .sheet-key,
+	.sheet-rolltemplate-custom-show .sheet-content .sheet-key {
+		font-weight: bold;
+		padding-right: 10px;
+		text-align: right;
+		color: #222222; /* To fix dark mode in Chrome. */
+	}
+	
+	/* Right column. Color to fix dark mode in Chrome. */
+	.sheet-rolltemplate-custom .sheet-value,
+	.sheet-rolltemplate-custom-success-roll .sheet-value,
+	.sheet-rolltemplate-custom-defense .sheet-value,
+	.sheet-rolltemplate-custom-attack .sheet-value,
+	.sheet-rolltemplate-custom-normal-attack .sheet-value,
+	.sheet-rolltemplate-custom-power-attack .sheet-value,
+	.sheet-rolltemplate-custom-activate .sheet-value,
+	.sheet-rolltemplate-custom-show .sheet-value {
+		color: #222222;
+	}
+	
+	/* Make even-numbered rows grey */
+	.sheet-rolltemplate-custom .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-success-roll .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-defense .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-attack .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-normal-attack .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-power-attack .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-activate .sheet-content :nth-child(4n),
+	.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n+3),
+	.sheet-rolltemplate-custom-show .sheet-content :nth-child(4n) {
+		background:#EEE;
+	}
+	
+	/* Description field */
+	.sheet-rolltemplate-custom .sheet-desc,
+	.sheet-rolltemplate-custom-success-roll .sheet-desc,
+	.sheet-rolltemplate-custom-defense .sheet-desc,
+	.sheet-rolltemplate-custom-attack .sheet-desc,
+	.sheet-rolltemplate-custom-normal-attack .sheet-desc,
+	.sheet-rolltemplate-custom-power-attack .sheet-desc,
+	.sheet-rolltemplate-custom-activate .sheet-desc,
+	.sheet-rolltemplate-custom-show .sheet-desc {
+		grid-column: span 2;
+		padding-right: 10px;
+		text-align: left;
+		color: #222222; /* To fix dark mode in Chrome. */
+	}
+	
+	/* Dice roll face colors. Needed to prevent problems with dark mode. */
+	.sheet-rolltemplate-custom .inlinerollresult,
+	.sheet-rolltemplate-custom-success-roll .inlinerollresult,
+	.sheet-rolltemplate-custom-defense .inlinerollresult,
+	.sheet-rolltemplate-custom-attack .inlinerollresult,
+	.sheet-rolltemplate-custom-normal-attack .inlinerollresult,
+	.sheet-rolltemplate-custom-power-attack .inlinerollresult,
+	.sheet-rolltemplate-custom-activate .inlinerollresult,
+	.sheet-rolltemplate-custom-show .inlinerollresult {
+		display: inline-block;
+		min-width: 1.5em;
+		text-align: center;
+		border: 2px solid palegoldenrod;
+		background: #fff990;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult,
+	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult {
+		background-color: #fff990;
+		border: 2px solid palegoldenrod;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullcrit,
+	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullcrit {
+		border: 2px solid #228833;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-success-roll .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-defense .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-normal-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-power-attack .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullfail,
+	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullfail {
+		border: 2px solid #AA3377;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Power block expanding/collapse functionality        */
+	/* --------------------------------------------------- */
+	
+	/* Nominal state for expanded areas */
+	.sheet-power-expand-01,
+	.sheet-power-expand-02,
+	.sheet-power-expand-03,
+	.sheet-power-expand-04,
+	.sheet-power-expand-05,
+	.sheet-power-expand-06,
+	.sheet-power-expand-07,
+	.sheet-power-expand-08,
+	.sheet-power-expand-09,
+	.sheet-power-expand-10,
+	.sheet-power-expand-11,
+	.sheet-power-expand-12,
+	.sheet-power-expand-13,
+	.sheet-power-expand-14,
+	.sheet-power-expand-15,
+	.sheet-power-expand-16,
+	.sheet-power-expand-17 {
+		display: none;
+	}
+	
+	/* Expand the selected left power block. */
+	.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .sheet-power-expand-01,
+	.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .sheet-power-expand-02,
+	.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .sheet-power-expand-03,
+	.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .sheet-power-expand-04,
+	.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .sheet-power-expand-05,
+	.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .sheet-power-expand-06,
+	.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .sheet-power-expand-07,
+	.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .sheet-power-expand-08,
+	.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .sheet-power-expand-09 {
+		display: block;
+	}
+	
+	/* Expand the selected right power block. */
+	.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .sheet-power-expand-10,
+	.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .sheet-power-expand-11,
+	.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .sheet-power-expand-12,
+	.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .sheet-power-expand-13,
+	.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .sheet-power-expand-14,
+	.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .sheet-power-expand-15,
+	.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .sheet-power-expand-16,
+	.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .sheet-power-expand-17 {
+		display: block;
+	}
+	
+	/* Turn down the opacity on the left point values to help visibility overall. */
+	.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-opacity-power01,
+	.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-opacity-power02,
+	.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-opacity-power03,
+	.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-opacity-power04,
+	.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-opacity-power05,
+	.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-opacity-power06,
+	.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-opacity-power07,
+	.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-opacity-power08,
+	.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-opacity-power09 {
+		opacity: 0.4;
+	}
+	
+	/* Turn down the opacity on the right point values to help visibility overall. */
+	.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-opacity-power10,
+	.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-opacity-power11,
+	.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-opacity-power12,
+	.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-opacity-power13,
+	.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-opacity-power14,
+	.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-opacity-power15,
+	.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-opacity-power16,
+	.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-opacity-power17 {
+		opacity: 0.4;
+	}
+	
+	/* Hide the base and active costs for a tidier look. */
+	.subitem-visibility-power01,
+	.subitem-visibility-power02,
+	.subitem-visibility-power03,
+	.subitem-visibility-power04,
+	.subitem-visibility-power05,
+	.subitem-visibility-power06,
+	.subitem-visibility-power07,
+	.subitem-visibility-power08,
+	.subitem-visibility-power09,
+	.subitem-visibility-power10,
+	.subitem-visibility-power11,
+	.subitem-visibility-power12,
+	.subitem-visibility-power13,
+	.subitem-visibility-power14,
+	.subitem-visibility-power15,
+	.subitem-visibility-power16,
+	.subitem-visibility-power17 {
+		visibility: hidden;
+	}
+	
+	.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power01,
+	.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power02,
+	.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power03,
+	.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power04,
+	.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power05,
+	.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power06,
+	.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power07,
+	.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power08,
+	.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-points-block-left .subitem-visibility-power09 {
+		visibility: visible;
+	}
+	
+	.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power10,
+	.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power11,
+	.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power12,
+	.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power13,
+	.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power14,
+	.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power15,
+	.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power16,
+	.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-points-block-right .subitem-visibility-power17 {
+		visibility: visible;
+	}
+	
+	/* --------------------------------------------------- */
+	/* Maneuver block expanding/collapse functionality     */
+	/* --------------------------------------------------- */
+	
+	/* Nominal state for expanded areas */
+	.sheet-maneuver-expand-01,
+	.sheet-maneuver-expand-02,
+	.sheet-maneuver-expand-03,
+	.sheet-maneuver-expand-04,
+	.sheet-maneuver-expand-05,
+	.sheet-maneuver-expand-06,
+	.sheet-maneuver-expand-07,
+	.sheet-maneuver-expand-08,
+	.sheet-maneuver-expand-09  {
+		display: none;
+	}
+	
+	/* Expand the selected maneuver block. */
+	.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .sheet-maneuver-expand-01,
+	.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .sheet-maneuver-expand-02,
+	.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .sheet-maneuver-expand-03,
+	.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .sheet-maneuver-expand-04,
+	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .sheet-maneuver-expand-05,
+	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .sheet-maneuver-expand-06,
+	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .sheet-maneuver-expand-07,
+	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .sheet-maneuver-expand-08,
+	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .sheet-maneuver-expand-09 {
+		display: block;
+	}
+	
+	/* ---------------------------------------------------------------- */
+	/* Custom button for power expand                                   */
+	/* ---------------------------------------------------------------- */
+	
+	.custom-expand-button-container {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		margin-right: 1px;
+	}
+	
+	.custom-expand-button-container button.buttonExpand {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		height: 24px;
+		width: 10px;
+		align-items: center;
+		padding: 0px;
+		margin-right: 2px;
+		margin-left: 0px;
+		border-color: transparent;
+		background: transparent;
+	}
+	
+	.custom-expand-button-container button.buttonExpand span {
+		display: inline-block;
+		text-align: center;
+	}
+	
+	/* Rotate when expanded */
+	.sheet-left-power-toggle[value="powerExpand01"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01,
+	.sheet-left-power-toggle[value="powerExpand02"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02,
+	.sheet-left-power-toggle[value="powerExpand03"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03,
+	.sheet-left-power-toggle[value="powerExpand04"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04,
+	.sheet-left-power-toggle[value="powerExpand05"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05,
+	.sheet-left-power-toggle[value="powerExpand06"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06,
+	.sheet-left-power-toggle[value="powerExpand07"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07,
+	.sheet-left-power-toggle[value="powerExpand08"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08,
+	.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09,
+	.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10,
+	.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11,
+	.sheet-right-power-toggle[value="powerExpand12"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12,
+	.sheet-right-power-toggle[value="powerExpand13"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13,
+	.sheet-right-power-toggle[value="powerExpand14"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14,
+	.sheet-right-power-toggle[value="powerExpand15"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15,
+	.sheet-right-power-toggle[value="powerExpand16"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16,
+	.sheet-right-power-toggle[value="powerExpand17"] ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17,
+	.sheet-maneuver-toggle[value="maneuverExpand01"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01,
+	.sheet-maneuver-toggle[value="maneuverExpand02"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02,
+	.sheet-maneuver-toggle[value="maneuverExpand03"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03,
+	.sheet-maneuver-toggle[value="maneuverExpand04"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04,
+	.sheet-maneuver-toggle[value="maneuverExpand05"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05,
+	.sheet-maneuver-toggle[value="maneuverExpand06"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06,
+	.sheet-maneuver-toggle[value="maneuverExpand07"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07,
+	.sheet-maneuver-toggle[value="maneuverExpand08"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08,
+	.sheet-maneuver-toggle[value="maneuverExpand09"] ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09
+ 	{
+		transform: rotate(90deg);
+	}
+	
+	/* Rotate when not expanded, but hover */
+	.sheet-left-power-toggle:not([value="powerExpand01"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-01:hover,
+	.sheet-left-power-toggle:not([value="powerExpand02"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-02:hover,
+	.sheet-left-power-toggle:not([value="powerExpand03"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-03:hover,
+	.sheet-left-power-toggle:not([value="powerExpand04"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-04:hover,
+	.sheet-left-power-toggle:not([value="powerExpand05"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-05:hover,
+	.sheet-left-power-toggle:not([value="powerExpand06"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-06:hover,
+	.sheet-left-power-toggle:not([value="powerExpand07"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-07:hover,
+	.sheet-left-power-toggle:not([value="powerExpand08"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-08:hover,
+	.sheet-left-power-toggle:not([value="powerExpand09"]) ~ div.item-flex-power .subitem-flex-power-effect-left .custom-expand-button-container .custom-expand-button-container-09:hover,
+	.sheet-right-power-toggle:not([value="powerExpand10"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-10:hover,
+	.sheet-right-power-toggle:not([value="powerExpand11"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-11:hover,
+	.sheet-right-power-toggle:not([value="powerExpand12"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-12:hover,
+	.sheet-right-power-toggle:not([value="powerExpand13"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-13:hover,
+	.sheet-right-power-toggle:not([value="powerExpand14"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-14:hover,
+	.sheet-right-power-toggle:not([value="powerExpand15"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-15:hover,
+	.sheet-right-power-toggle:not([value="powerExpand16"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-16:hover,
+	.sheet-right-power-toggle:not([value="powerExpand17"]) ~ div.item-flex-power .subitem-flex-power-effect-right .custom-expand-button-container .custom-expand-button-container-17:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand01"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-01:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand02"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-02:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand03"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-03:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand04"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-04:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand05"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-05:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand06"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-06:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand07"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-07:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand08"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-08:hover,
+	.sheet-maneuver-toggle:not([value="maneuverExpand09"]) ~ div.item-flex-maneuver .subitem-flex-container-martial-row .custom-expand-button-container .custom-expand-button-container-09:hover
+	{
+		transition: 0.25s;
+		transform: rotate(90deg);
+	}
+	
+	.custom-button-triangle,
+	.custom-button-triangle-alt,
+	.custom-button-triangle:hover,
+	.custom-button-triangle:after,
+	.custom-button-triangle-alt:hover,
+	.custom-button-triangle-alt:after  {
+		position: relative; 
+		border-top: 8px solid transparent;
+		border-bottom: 8px solid transparent;
+		border-right: 8px solid transparent;
+		top: 0px;
+		left: 4px;
+	}
+	
+	.custom-button-triangle:before,
+	.custom-button-triangle-alt:before {
+		content: "";
+		width: 0;
+		height: 0;
+		position: absolute;
+		border-top: 6px solid transparent;
+		border-bottom: 6px solid transparent;
+		top: -6px;
+		left: -11px;
+	}
+	
+	.custom-button-triangle:before {
+		/* border-left: 10px solid #FFF9CF; /* Color Triangle */
+		border-left: 9px solid #FFF9CF; /* Color Triangle */
+	}
+	
+	.custom-button-triangle-alt:before {
+		border-left: 9px solid white; /* Color Triangle Alt */
+	}
+	
+	.custom-button-triangle,
+	.custom-button-triangle:hover,
+	.custom-button-triangle:after {
+		border-left: 12px solid #b8b8b8; /* Color Triangle Border */
+	}
+	
+	.custom-button-triangle-alt,
+	.custom-button-triangle-alt:hover,
+	.custom-button-triangle-alt:after {
+		border-left: 12px solid #8A8A8A; /* Color Triangle Alt Border */
+	}
+	
+	.subitem-flex-container-martial-row .custom-expand-button-container button.buttonExpand {
+		height: 18px;
+	}

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -4064,7 +4064,7 @@ select:focus + .focus {
 }
 
 .item-tab-gear-slide-flex-container-martial-maneuvers input[type=text] {
-	border: 1px solid lightgray;
+	border: solid 1px #eaeaea;
 	height: 22px;
 	width: 30px;
 }
@@ -4072,7 +4072,7 @@ select:focus + .focus {
 .subitem-flex-container-martial-row input {
 	text-align: center;
 	height: 22px;
-	border: solid 1px lightgray;
+	border: solid 1px #eaeaea;
 	margin: 0px;
 	padding: 0px;
 }
@@ -4080,7 +4080,7 @@ select:focus + .focus {
 .subitem-flex-container-martial-row input[type=number] {
 	text-align: right;
 	height: 22px;
-	border: solid 1px lightgray;
+	border: solid 1px #eaeaea;
 	max-width: 35px;
 }
 
@@ -4089,7 +4089,8 @@ select:focus + .focus {
 	margin: 0px;
 	height: 22px;
 	text-align: left;
-	padding-left: 1px;	
+	padding-left: 1px;
+	border: solid 1px #eaeaea;
 }
 
 .subitem-flex-container-martial-cv-row input[type=text] {
@@ -4293,8 +4294,6 @@ select:focus + .focus {
 	margin-bottom: 3px;
 	padding: 0px;
 	padding-left: 24px;
-	background-color: white;
-	border-radius: 3px;
 }
 
 .subitem-flex-container-martial-details-row .buttonRollShow {
@@ -4338,7 +4337,7 @@ select:focus + .focus {
 .subitem-flex-container-martial-cv-damage-row input[type=number] {
 	height: 21px;
 	max-width: 35px;
-	border: solid 1px lightgray;
+	border: solid 1px #eaeaea;
 	text-align: right;
 	padding-right: 1px;
 }
@@ -4349,6 +4348,7 @@ select:focus + .focus {
 	width: 68px;
 	padding-left: 2px;
 	padding-right: 4px;
+	border: solid 1px #eaeaea;
 }
 
 .subitem-martial-description-row {
@@ -4363,11 +4363,12 @@ select:focus + .focus {
 }
 
 .subitem-martial-description-row input[type=text] {
-	width: 220px; /* 220 */
+	width: 220px;
 	height: 22px;
 	text-align: left;
-	padding-left: 1px;
+	padding-left: 2px;
 	margin-right: 0px;
+	border: solid 1px #eaeaea;
 }
 
 .subitem-martial-description-row h1 {
@@ -4377,47 +4378,27 @@ select:focus + .focus {
 .subitem-martial-description-row input[type=number] {
 	height: 22px;
 	max-width: 35px;
-	border: solid 1px lightgray;
+	border: solid 1px #eaeaea;
 	text-align: right;
 	margin-right: 0px;
 }
 
-/* Basic Attack */
-/* .subitem-tab-gear-slide-flex-container-standard-attack {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	margin-left: 23px;
-	margin-bottom: 1px;
-	padding-right: 0px;
-	min-width: 376px;
-	align-items: center;
-}
-
-.subitem-tab-gear-slide-flex-container-standard-attack h1 {
-	text-align: left;
-}
-
-.subitem-tab-gear-slide-flex-container-standard-attack input[type=text] {
-	text-align: left;
-	margin-left: 96px;
-	margin-right: 41px;
-	text-align: center;
-} */
-
+		
 /* Range Modifier Table */
 .subitem-tab-gear-slide-flex-container-range-modifiers {
 	flex-direction: row;
 	display: flex;
 	justify-content: space-between;
-	width: 395px;
-	height: 30px;
-	padding: 0px;
-	padding-left: 5px;
-	margin-left: 0px;
-	margin-top: 5px;
+	width: 391px;
+	height: 28px;
+	padding: 3px;
+	margin-top: 1px;
 	margin-bottom: 7px;
-	margin-right: 2px;
+	margin-right: 0px;
+	margin-left: 4px;
+	background-color: white;
+	border-radius: 3px;
+	border: solid 1px #eaeaea;
 }
 
 .subitem-tab-gear-slide-range-modifier-container {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1571,7 +1571,7 @@ select:focus + .focus {
 	background-color: #009E73;
 }
 
-/* Change maneuver attack button color to indicate non-damaging defensive function. */
+/* Change maneuver attack button color to indicate a non-damaging defensive action. */
 .maneuver-block01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
 .maneuver-block02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
 .maneuver-block03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
@@ -1582,7 +1582,7 @@ select:focus + .focus {
 .maneuver-block08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover),
 .maneuver-block09[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack09"]:not(:hover)
 {
-	background-color: #56B4E9;;
+	background-color: #56B4E9;
 }
 
 .buttonRollActivate {
@@ -1617,7 +1617,7 @@ select:focus + .focus {
 }
 
 .buttonRollShieldAttack  {
-	background-color: #D55E00;
+	background-color: #56B4E9;
 	border-radius: 2.5px;
 }
 

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -4251,7 +4251,7 @@
 	.subitem-flex-container-martial-cv-damage-row input[type=text] {
 		text-align: center;
 		height: 21px;
-		width: 60px;
+		width: 68px;
 		padding-left: 2px;
 		padding-right: 4px;
 	}

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1539,6 +1539,7 @@
 	}
 	
 	.item-flex-maneuver .buttonRollAttack {
+		background-color: #009E73;
 		margin-right: 3px;
 		margin-left: 61px;
 		border-radius: 3px;

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -4396,39 +4396,73 @@ select:focus + .focus {
 	flex-direction: row;
 	display: flex;
 	justify-content: space-between;
-	width: 397px;
+	width: 395px;
 	height: 30px;
 	padding: 0px;
 	padding-left: 5px;
 	margin-left: 0px;
 	margin-top: 11px;
 	margin-bottom: 2px;
+	margin-right: 2px;
 }
 
-.subitem-tab-gear-slide-range-modifier-container-first,
 .subitem-tab-gear-slide-range-modifier-container {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	height: 33px;
+	align-items: top;
+	padding: 0px;
+	margin: 0px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container:nth-child(1) {
+	width: 60px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container:nth-child(2) {
+	width: 37px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container:nth-child(3) {
+	width: 43px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container:nth-child(4) {
+	width: 49px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container:nth-child(5) {
+	width: 50px;
+}
+
+.subitem-tab-gear-slide-range-modifier-container:nth-child(6) {
+	width: 57px;
+}
+
+.subitem-range-modifier-container-column h2:nth-child(1) {
+	font-weight: bold;
+}
+
+.subitem-range-modifier-container-column {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	height: 30px;
+	padding-top: 0px;
 }
 
-.subitem-tab-gear-slide-range-modifier-container-first {
-	min-width: 83px;
-	align-items: flex-start;
+.subitem-range-modifier-button-container {
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	height: 30px;
+	padding-top: 1px;
 }
 
-.subitem-tab-gear-slide-range-modifier-container {
-	min-width: 50px;
-	align-items: center;
-}
-
-.subitem-tab-gear-slide-range-modifier-container h2:nth-child(1) {
-	font-weight: bold;
-}
-
-.subitem-tab-gear-slide-range-modifier-container-first h2 {
-	font-weight: bold;
+.subitem-tab-gear-slide-range-modifier-container:nth-child(1) .subitem-range-modifier-container-column {
+	margin-bottom: 3px;
+	height: 30px;
 }
 
 /* Item: Hit Locations */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -68,9 +68,21 @@
 		
 	}
 	
-	/* --------------------------------------------------- */
-	/* General Styling                                     */
-	/* --------------------------------------------------- */
+	/* ----------------------------------------------------	*/
+	/* General Styling 										*/
+	/* ----------------------------------------------------	*/
+	
+	/* Okabe and Ito colorblind-safe palette:				*/
+	/* Green: 			#009E73								*/
+	/* Blue: 			#0072B2 							*/
+	/* Light blue: 		#56B4E9 							*/
+	/* Yellow: 			#F0E442								*/
+	/* Orange: 			#E69F00								*/
+	/* Orange-red: 		#D55E00								*/
+	/* Violet: 			#CC79A7								*/
+	/* 														*/
+	/* Plus:												*/
+	/* A mid-tone gray:	#8A8A8A								*/
 	
 	textarea {
 		font-size: 14px;
@@ -198,7 +210,7 @@
 		width: 12px;
 		height: 8px;
 		-webkit-clip-path: polygon(100% 0%, 0 0%, 50% 100%);
-		  	clip-path: polygon(100% 0%, 0 0%, 50% 100%);
+		clip-path: polygon(100% 0%, 0 0%, 50% 100%);
 	}
 	
 	.custom-select::after,
@@ -265,25 +277,25 @@
 	
 	/* Style the buttons inside the tab */
 	.tab button {
-  	background-color: #CCCCFF;
-  	float: left;
-  	outline: none;
-  	cursor: pointer;
-  	padding: 10px 10px;
-  	margin-right: 0px;
-  	transition: 0.3s;
-  	font-size: 18px;
-  	border: 0px;
+		background-color: #CCCCFF;
+		float: left;
+		outline: none;
+		cursor: pointer;
+		padding: 10px 10px;
+		margin-right: 0px;
+		transition: 0.3s;
+		font-size: 18px;
+		border: 0px;
 	}
 	
 	/* Change background color of buttons on hover */
 	.tab button:hover {
-  	background-color: yellow;
+		background-color: yellow;
 	}
 	
 	/* Create an active/current tab class */
 	.tab button.active {
-  	background-color: yellow;
+		background-color: yellow;
 	}
 	
 	/* --------------------------------------------------- */
@@ -1517,13 +1529,21 @@
 	.buttonRoll {
 		margin-right: 3px;
 		margin-left: 3px;
-		background-color: orange;
+		background-color: #E69F00;
 		border-radius: 3px;
 	}
 	
 	.buttonRollAttack {
-		background-color: indianred;
+		background-color: #D55E00;
 		border-radius: 2.5px;
+	}
+	
+	.item-flex-maneuver .buttonRollAttack {
+		margin-right: 3px;
+		margin-left: 61px;
+		border-radius: 3px;
+		min-width: 36px;
+		max-width: 38px;
 	}
 
 	.weapon-normal-damage01[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon01"]:not(:hover),
@@ -1532,13 +1552,25 @@
 	.weapon-normal-damage04[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon04"]:not(:hover),
 	.weapon-normal-damage05[value="on"] ~ .subitem-tab-gear-flex-container-weapon-row .buttonRollAttack[name="act_attackWeapon05"]:not(:hover)
 	{
-		background-color: olivedrab;
-	}	
+		background-color: #009E73;
+	}
+	
+	.maneuver-normal-damage01[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack01"]:not(:hover),
+	.maneuver-normal-damage02[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack02"]:not(:hover),
+	.maneuver-normal-damage03[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack03"]:not(:hover),
+	.maneuver-normal-damage04[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack04"]:not(:hover),
+	.maneuver-normal-damage05[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack05"]:not(:hover),
+	.maneuver-normal-damage06[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack06"]:not(:hover),
+	.maneuver-normal-damage07[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack07"]:not(:hover),
+	.maneuver-normal-damage08[value="on"] ~ .item-flex-maneuver .buttonRollAttack[name="act_maneuverAttack08"]:not(:hover)
+	{
+		background-color: #009E73;
+	}
 
 	.buttonRollActivate {
 		margin-right: 3px;
 		margin-left: 3px;
-		background-color: steelblue;
+		background-color: #0072B2;
 		border-radius: 3px;
 	}
 	
@@ -1546,13 +1578,13 @@
 		margin-right: 3px;
 		margin-left: 61px;
 		border-radius: 3px;
-		background-color: olivedrab;
+		background-color: #D55E00;
 		min-width: 36px;
 		max-width: 38px;
 	}
 	
 	.buttonRollShieldAttack  {
-		background-color: DarkGoldenrod;
+		background-color: #D55E00;
 		border-radius: 2.5px;
 	}
 	
@@ -1560,7 +1592,7 @@
 		margin-right: 3px;
 		margin-left: 3px;
 		border-radius: 3px;
-		background-color: lightslategray;
+		background-color: #8A8A8A;
 		min-width: 36px;
 		max-width: 38px;
 	}
@@ -2870,7 +2902,7 @@
 	
 	.skill-mover-plus-minus-button button.buttonPlus,
 	.skill-mover-plus-minus-button button.buttonMinus {
-		background-color: LemonChiffon;
+		background-color: lemonchiffon;
 		border: solid 1px silver;
 		color: slategray;
 		padding-left: 4px;
@@ -4187,7 +4219,8 @@
 		max-height: 24px;
 	}
 	
-	.subitem-flex-container-martial-row .buttonRollNormalAttack {
+	/* Update when custom maneuver attack roll made */
+	.subitem-flex-container-martial-row .buttonRollAttack {
 		margin-top: 1px;
 		margin-left: 3px;
 	}
@@ -4643,6 +4676,7 @@
 		-ms-user-select: none;
 		user-select: none;
 		background-color: orange;
+		/* background-color: orange; */
 	}
 	
 	/* Hide the browser's default radio button */
@@ -4745,33 +4779,9 @@
 	}
 	
 	/* Header formatting - title and subtitle */
-	.sheet-rolltemplate-custom .sheet-header,
-	.sheet-rolltemplate-custom-success-roll .sheet-header {
-		background-color: orange;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-		
-	.sheet-rolltemplate-custom-attack .sheet-header {
-		background-color: indianred;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
 	
 	.sheet-rolltemplate-custom-normal-attack .sheet-header {
-		background-color: olivedrab;
-		/* change text-align to center to center the header text */
-		text-align: left;
-		color: var(--header-text-color);
-		padding: 5px;
-	}
-		
-	.sheet-rolltemplate-custom-power-attack .sheet-header {
-		background-color: #9184E2; /* lighter than mediumslateblue; */
+		background-color: #009E73;
 		/* change text-align to center to center the header text */
 		text-align: left;
 		color: var(--header-text-color);
@@ -4779,15 +4789,40 @@
 	}
 	
 	.sheet-rolltemplate-custom-activate .sheet-header {
-		background-color: steelblue;
+		background-color: #0072B2;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom-power-attack .sheet-header {
+		background-color: #56B4E9; /* lighter than mediumslateblue; */
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
+	.sheet-rolltemplate-custom .sheet-header,
+	.sheet-rolltemplate-custom-success-roll .sheet-header {
+		background-color: #E69F00;
 		/* change text-align to center to center the header text */
 		text-align: left;
 		color: var(--header-text-color);
 		padding: 5px;
 	}
 		
+	.sheet-rolltemplate-custom-attack .sheet-header {
+		background-color: #D55E00;
+		/* change text-align to center to center the header text */
+		text-align: left;
+		color: var(--header-text-color);
+		padding: 5px;
+	}
+	
 	.sheet-rolltemplate-custom-show .sheet-header {
-		background-color: lightslategray;
+		background-color: #8A8A8A;
 		/* change text-align to center to center the header text */
 		text-align: left;
 		color: var(--header-text-color);
@@ -4944,7 +4979,7 @@
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullcrit,
 	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullcrit {
-		border: 2px solid #3FB315;
+		border: 2px solid #228833;
 	}
 	
 	.sheet-rolltemplate-custom .sheet-template-wrapper .inlinerollresult.fullfail,
@@ -4954,7 +4989,7 @@
 	.sheet-rolltemplate-custom-attack .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-activate .sheet-template-wrapper .inlinerollresult.fullfail,
 	.sheet-rolltemplate-custom-show .sheet-template-wrapper .inlinerollresult.fullfail {
-		border: 2px solid #B31515;
+		border: 2px solid #AA3377;
 	}
 	
 	/* --------------------------------------------------- */
@@ -4994,7 +5029,7 @@
 	.sheet-left-power-toggle[value="powerExpand09"] ~ div.item-flex-power .sheet-power-expand-09 {
 		display: block;
 	}
-	
+
 	/* Expand the selected right power block. */
 	.sheet-right-power-toggle[value="powerExpand10"] ~ div.item-flex-power .sheet-power-expand-10,
 	.sheet-right-power-toggle[value="powerExpand11"] ~ div.item-flex-power .sheet-power-expand-11,

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1,4 +1,4 @@
-			/* --------------------------------------------------- */
+/* --------------------------------------------------- */
 /* Roll20-specific styling                             */
 /* --------------------------------------------------- */
 
@@ -223,12 +223,14 @@ select {
 
 .custom-select::after,
 .custom-select-skill::after {
-	background-color: olive;
+	/* background-color: olive; */
+	background-color: #8A8A8A;
 }
 
 .custom-select-alternate::after,
 .custom-select-alternate-skill::after {
-	background-color: salmon;
+	/* background-color: salmon; */
+	background-color: #CC79A7;
 }
 
 .custom-select-option::after  {
@@ -1468,14 +1470,16 @@ select:focus + .focus {
 }
 
 .button-Power-END-left {
-	background-color: olive;
+	/* background-color: olive; */
+	background-color: #8A8A8A;
 	margin-right: 0px;
 	min-width: 34px;
 	max-width: 35px;
 }
 
 .button-Power-END-right {
-	background-color: salmon;
+	/* background-color: salmon; */
+	background-color: #8A8A8A;
 	margin-right: 0px;
 	min-width: 34px;
 	max-width: 35px;
@@ -1637,7 +1641,8 @@ select:focus + .focus {
 }
 
 .buttonRollPower {
-	background-color: #9184E2; /* lighter than mediumslateblue */
+	/* background-color: #9184E2; lighter than mediumslateblue */
+	background-color: #CC79A7;
 	border-radius: 2.5px;
 }
 
@@ -4219,9 +4224,9 @@ select:focus + .focus {
 
 .maneuver-mover-plus-minus-button button.buttonPlus,
 .maneuver-mover-plus-minus-button button.buttonMinus {
-	background-color: LemonChiffon;
-	border: solid 1px silver;
-	color: slategray;
+	background-color: white;
+	border: solid 1px lightgray;
+	color: lightskyblue;
 	padding-left: 4px;
 	padding-right: 4px;
 	padding-top: 1px;
@@ -5353,30 +5358,42 @@ select:focus + .focus {
 	transform: rotate(90deg);
 }
 
-.custom-button-triangle {
+.custom-button-triangle,
+.custom-button-triangle-alt {
 	position: relative; 
 	border-top: 8px solid transparent;
 	border-bottom: 8px solid transparent;
-	border-left: 12px solid silver;
 	border-right: 8px solid transparent;
 	top: 0px;
 	left: 5px;
 }
 
-.subitem-tab-gear-slide-flex-container-standard-attack .custom-button-triangle {
-	left: 3px
+.custom-button-triangle {
+	border-left: 12px solid silver;
 }
 
-.custom-button-triangle:before {
+.custom-button-triangle-alt {
+	border-left: 12px solid silver;
+}
+
+.custom-button-triangle:before,
+.custom-button-triangle-alt:before {
 	content: "";
 	width: 0;
 	height: 0;
 	position: absolute;
 	border-top: 6px solid transparent;
 	border-bottom: 6px solid transparent;
-	border-left: 10px solid #FFF9CF;
 	top: -6px;
 	left: -11px; 
+}
+
+.custom-button-triangle:before {
+	border-left: 10px solid #FFF9CF;
+}
+
+.custom-button-triangle-alt:before {
+	border-left: 10px solid white;
 }
 
 .subitem-flex-container-martial-row .custom-expand-button-container button.buttonExpand {
@@ -5384,12 +5401,23 @@ select:focus + .focus {
 }
 
 .custom-button-triangle:hover,
-.custom-button-triangle:after {
+.custom-button-triangle:after,
+.custom-button-triangle-alt:hover,
+.custom-button-triangle-alt:after  {
 	position: relative; 
 	border-top: 8px solid transparent;
 	border-bottom: 8px solid transparent;
-	border-left: 12px solid #666666;
 	border-right: 8px solid transparent;
 	top: 0px;
 	left: 5px;
+}
+
+.custom-button-triangle:hover,
+.custom-button-triangle:after {
+	border-left: 12px solid silver;
+}
+
+.custom-button-triangle-alt:hover,
+.custom-button-triangle-alt:after {
+	border-left: 10px solid silver;
 }

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -1,4 +1,4 @@
-		/* --------------------------------------------------- */
+			/* --------------------------------------------------- */
 /* Roll20-specific styling                             */
 /* --------------------------------------------------- */
 
@@ -4081,7 +4081,7 @@ select:focus + .focus {
 	text-align: right;
 	height: 22px;
 	border: solid 1px lightgray;
-	max-width: 38px;
+	max-width: 35px;
 }
 
 .subitem-flex-container-martial-row input[type=text]:nth-child(2) {
@@ -4253,8 +4253,8 @@ select:focus + .focus {
 	justify-content: space-between;
 	width: 399px;
 	padding-left: 4px;
-	margin-top: 2px;
-	padding-bottom: 2px;
+	margin-top: 1px;
+	padding-bottom: 3px;
 }
 
 .subitem-flex-container-martial-row {
@@ -4289,9 +4289,12 @@ select:focus + .focus {
 	align-items: top;
 	max-width: 397px;
 	height: 48px;
-	padding-left: 23px;
-	padding-top: 0px;
-	padding-bottom: 0px;
+	margin-top: 3px;
+	margin-bottom: 3px;
+	padding: 0px;
+	padding-left: 24px;
+	background-color: white;
+	border-radius: 3px;
 }
 
 .subitem-flex-container-martial-details-row .buttonRollShow {
@@ -4321,6 +4324,7 @@ select:focus + .focus {
 	max-height: 21px;
 	align-items: center;
 	padding-right: 1px;
+	margin: 0px;
 }
 
 .subitem-flex-container-martial-cv-damage-row h1 {
@@ -4328,12 +4332,12 @@ select:focus + .focus {
 }
 
 .subitem-flex-container-martial-cv-damage-row h1:not(:first-child) {
-	padding-left: 7px;
+	padding-left: 2px;
 }
 
 .subitem-flex-container-martial-cv-damage-row input[type=number] {
 	height: 21px;
-	max-width: 38px;
+	max-width: 35px;
 	border: solid 1px lightgray;
 	text-align: right;
 	padding-right: 1px;
@@ -4348,28 +4352,38 @@ select:focus + .focus {
 }
 
 .subitem-martial-description-row {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: bottom;
 	max-height: 22px;
-	min-width: 321px;
+	min-width: 320px;
+	padding: 0px;
+	margin: 0px;
 }
 
 .subitem-martial-description-row input[type=text] {
-	width: 277px;
-	height: 21px;
+	width: 220px; /* 220 */
+	height: 22px;
 	text-align: left;
-	padding-left: 2px;
-	margin-right: 2px;
+	padding-left: 1px;
+	margin-right: 0px;
+}
+
+.subitem-martial-description-row h1 {
+	padding-top: 5px;
 }
 
 .subitem-martial-description-row input[type=number] {
-	height: 21px;
-	max-width: 38px;
+	height: 22px;
+	max-width: 35px;
 	border: solid 1px lightgray;
 	text-align: right;
 	margin-right: 0px;
 }
 
 /* Basic Attack */
-.subitem-tab-gear-slide-flex-container-standard-attack {
+/* .subitem-tab-gear-slide-flex-container-standard-attack {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -4389,7 +4403,7 @@ select:focus + .focus {
 	margin-left: 96px;
 	margin-right: 41px;
 	text-align: center;
-}
+} */
 
 /* Range Modifier Table */
 .subitem-tab-gear-slide-flex-container-range-modifiers {
@@ -4401,8 +4415,8 @@ select:focus + .focus {
 	padding: 0px;
 	padding-left: 5px;
 	margin-left: 0px;
-	margin-top: 11px;
-	margin-bottom: 2px;
+	margin-top: 5px;
+	margin-bottom: 7px;
 	margin-right: 2px;
 }
 
@@ -4776,7 +4790,6 @@ select:focus + .focus {
 	-ms-user-select: none;
 	user-select: none;
 	background-color: orange;
-	/* background-color: orange; */
 }
 
 /* Hide the browser's default radio button */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.css
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.css
@@ -3884,9 +3884,9 @@ select:focus + .focus {
 	flex-direction: column;
 	justify-content: space-between;
 	max-width: 248px;
-	padding-left: 5px;
 	margin-left: 4px;
 	padding: 4px;
+	padding-top: 3px;
 	background-color: lightcyan;
 	border: solid 2px lightgray;
 	border-radius: 3px;
@@ -3901,6 +3901,7 @@ select:focus + .focus {
 
 .subitem-tab-gear-flex-container-equipment h1 {
 	margin-right: 8px;
+	margin-bottom: 2px;
 }
 
 .subitem-tab-gear-flex-container-equipment input[type=text] {
@@ -3911,6 +3912,14 @@ select:focus + .focus {
 	max-height: 21px;
 	margin-right: 0px;
 	border: solid 1px #eaeaea;
+}
+
+/* .subitem-tab-gear-flex-container-equipment input[type=text]:hover {
+	position: relative;
+} */
+
+.subitem-tab-gear-flex-container-equipment input[type=text]:focus {
+	position: relative;
 }
 
 .subitem-tab-gear-flex-container-equipment input[type=number] {
@@ -4328,6 +4337,8 @@ select:focus + .focus {
 	height: 21px;
 	max-width: 38px;
 	border: solid 1px lightgray;
+	text-align: right;
+	padding-right: 1px;
 }
 
 .subitem-flex-container-martial-cv-damage-row input[type=text] {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -7889,14 +7889,14 @@
 		var enhancerBonus=0;
 		var languageCP=0;
 		let literacyCP=0;
-				
+		
 		if (skillLiteracy!=0) {
 			literacyCP=literacyCost;
 		}
 			
 		if (enhancerLinguist!=0) {
 			enhancerBonus=1;
-				}
+		}
 	
 		switch (skillFluency) {
 			case "native": languageCP = literacyCP;
@@ -7912,16 +7912,16 @@
 			break;
 			
 			case "accent": languageCP = 3+literacyCP-enhancerBonus;
-									break;
+			break;
 			
 			case "idiomatic": languageCP = 4+literacyCP-enhancerBonus;
 			break;
 			
 			case "imitate": languageCP = 5+literacyCP-enhancerBonus;
-									break;
-				}
-		return languageCP;
+			break;
 			}
+		return languageCP;
+	}
 			
 	function standardSkillChance(theBaseSkillRoll,skillCP,additionalLevels) {
 		var skillCost=3;
@@ -8023,11 +8023,11 @@
 			
 			case "pre":
 			theSkillRollChance=standardSkillChance( presenceChance,skillCP,interactionSkillLevels+bonusLevels);
-									break;
+			break;
 			
 			case "ps":
 			theSkillRollChance=knowledgeSkillChance( enhancerJack,skillCP,bonusLevels);
-									break;
+			break;
 			
 			case "intPS":
 			theSkillRollChance=knowledgeIntSkillChance( intelligenceChance, enhancerJack,skillCP,bonusLevels);
@@ -8067,8 +8067,8 @@
 			
 			case "group":
 			theSkillRollChance=0;
-						break;
-						
+			break;
+			
 			default:
 			theSkillRollChance=0;
 		}
@@ -8126,7 +8126,6 @@
 					}
 					theRoll += "{{Roll=[[3d6cf6cs1]]}}";
 				}
-	
 				startRoll(theRoll, (results) => {
 					finishRoll(results.rollId,{});
 				});	
@@ -8156,11 +8155,9 @@
 					}
 					theRoll += "+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}}"
 				}
-
 				startRoll(theRoll, (results) => {
 					finishRoll(results.rollId,{});
 				});
-
 			});
 		});
 	});
@@ -8178,7 +8175,6 @@
 					theRoll += "&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
 						+ "{{Base Chance = [[@{skillRollChance"+skillId+"}[Skill Chance]+?{Modifiers|0}[Modifiers]]] }} {{Roll=[[3d6cf6cs1]]}}"
 				}
-	
 				startRoll(theRoll, (results) => {
 					finishRoll(results.rollId,{});
 				});	
@@ -8203,57 +8199,57 @@
 			// Skill 01
 			let bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
 			let skillRollChance01=calculateSkillChance(values.skillType01, (parseInt(values.skillCP01)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-							
+			
 			// Skill 02
 			// Bonus Levels for Skills 02, 03, and 04 may include group levels if Skill 01 is of type "group".
 			if (values.skillType01==="group") {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0)+Math.floor((parseInt(values.skillCP01))/3);
 			} else {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
-						}
-						
+			}
+			
 			let skillRollChance02=calculateSkillChance(values.skillType02, (parseInt(values.skillCP02)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 03 
 			let skillRollChance03=calculateSkillChance(values.skillType03, (parseInt(values.skillCP03)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-					
+			
 			// Skill 04 
 			let skillRollChance04=calculateSkillChance(values.skillType04, (parseInt(values.skillCP04)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-					
+			
 			// Skill 05
 			bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
 			let skillRollChance05=calculateSkillChance(values.skillType05, (parseInt(values.skillCP05)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-					
+			
 			// Skill 06
 			// Bonus Levels for Skills 06, 07, and 08 may include group levels if Skill 05 is of type "group".
 			if (values.skillType05=="group") {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0)+Math.floor((parseInt(values.skillCP05))/3);
 			} else {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
-					}
-							
+			}
+			
 			let skillRollChance06=calculateSkillChance(values.skillType06, (parseInt(values.skillCP06)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 07 
 			let skillRollChance07=calculateSkillChance(values.skillType07, (parseInt(values.skillCP07)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-											 
+			
 			// Skill 08 
 			let skillRollChance08=calculateSkillChance(values.skillType08, (parseInt(values.skillCP08)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-							
-						
+			
+			
 			// Skill 09
 			// Skills 09 and 10 aren't available for group levels.
 			bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
 			let skillRollChance09=calculateSkillChance(values.skillType09, (parseInt(values.skillCP09)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 10
 			let skillRollChance10=calculateSkillChance(values.skillType10, (parseInt(values.skillCP10)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill Set 1 total character point cost
 			let setSkillsCost=(parseInt(values.skillCP01)||0)+(parseInt(values.skillCP02)||0)+(parseInt(values.skillCP03)||0)+(parseInt(values.skillCP04)||0)+(parseInt(values.skillCP05)||0)+(parseInt(values.skillCP06)||0)+(parseInt(values.skillCP07)||0)+(parseInt(values.skillCP08)||0)+(parseInt(values.skillCP09)||0)+(parseInt(values.skillCP10)||0);
-						
+			
 			// Assign calculated skill rolls.
-						setAttrs({
+			setAttrs({
 				"skillRollChance01":skillRollChance01,
 				"skillRollChance02":skillRollChance02,
 				"skillRollChance03":skillRollChance03,
@@ -8265,7 +8261,7 @@
 				"skillRollChance09":skillRollChance09,
 				"skillRollChance10":skillRollChance10,
 				"hiddenSet1SkillsCost":setSkillsCost
-				});
+			});
 		});
 	});
 	
@@ -8288,9 +8284,9 @@
 			// Bonus Levels for Skills 12, 13, and 14 may include group levels if Skill 11 is of type "group".
 			if (values.skillType11==="group") {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0)+Math.floor((parseInt(values.skillCP11))/3);
-								  } else {
+			} else {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
-					}
+			}
 					
 			let skillRollChance12=calculateSkillChance(values.skillType12, (parseInt(values.skillCP12)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
 							
@@ -8310,8 +8306,8 @@
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0)+Math.floor((parseInt(values.skillCP15))/3);
 			} else {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
-					}
-							
+			}
+			
 			let skillRollChance16=calculateSkillChance(values.skillType16, (parseInt(values.skillCP16)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
 						
 			// Skill 17 
@@ -8333,7 +8329,7 @@
 			let setSkillsCost=(parseInt(values.skillCP11)||0)+(parseInt(values.skillCP12)||0)+(parseInt(values.skillCP13)||0)+(parseInt(values.skillCP14)||0)+(parseInt(values.skillCP15)||0)+(parseInt(values.skillCP16)||0)+(parseInt(values.skillCP17)||0)+(parseInt(values.skillCP18)||0)+(parseInt(values.skillCP19)||0)+(parseInt(values.skillCP20)||0); 
 						
 			// Assign calculated skill rolls.
-						setAttrs({
+			setAttrs({
 				"skillRollChance11":skillRollChance11,
 				"skillRollChance12":skillRollChance12,
 				"skillRollChance13":skillRollChance13,
@@ -8345,7 +8341,7 @@
 				"skillRollChance19":skillRollChance19,
 				"skillRollChance20":skillRollChance20,
 				"hiddenSet2SkillsCost":setSkillsCost 
-				});
+			});
 		});
 	});
 	
@@ -8368,9 +8364,9 @@
 			// Bonus Levels for Skills 22, 23, and 24 may include group levels if Skill 21 is of type "group".
 			if (values.skillType21==="group") {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0)+Math.floor((parseInt(values.skillCP21))/3);
-								  } else {
+			} else {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
-							}
+			}
 			 
 			let skillRollChance22=calculateSkillChance(values.skillType22, (parseInt(values.skillCP22)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
 			
@@ -8427,7 +8423,7 @@
 				"hiddenSet3SkillsCost":setSkillsCost 
 			}); 
 		});
-					});
+	});
 					
 	/* Combat Skills */
 	on("change:skillLevels31 change:skillType31 change:skillLevels32 change:skillType32 change:skillLevels33 change:skillType33 change:skillLevels34 change:skillType34 change:skillLevels35 change:skillType35 change:skillLevels36 change:skillType36 change:skillLevels37 change:skillType37 change:skillLevels38 change:skillLevels39 change:skillLevels40", function () {
@@ -8461,7 +8457,7 @@
 						
 			let combatSkillsCost = skill31Cost+skill32Cost+skill33Cost+skill34Cost+skill35Cost+skill36Cost+skill37Cost+skill38Cost+skill39Cost+skill40Cost;
 						
-						setAttrs({
+			setAttrs({
 				"hiddenCombatSkillsCost":combatSkillsCost,
 				"skillCP31":skill31Cost,
 				"skillCP32":skill32Cost,
@@ -8473,7 +8469,7 @@
 				"skillCP38":skill38Cost,
 				"skillCP39":skill39Cost,
 				"skillCP40":skill40Cost
-				});
+			});
 		});
 	});
 	
@@ -8481,7 +8477,7 @@
 		// Used to calculate costs of general combat skill and familiarities.
 		let skillBaseCost=0;
 		let skillLevelCost=0;
-					
+			
 		switch (skillType) {
 			case "none": skillLevelCost=0;
 			skillBaseCost = 0;
@@ -8526,10 +8522,9 @@
 			default: skillLevelCost=0;
 			skillBaseCost = 0;
 			break;
-							}
-					
+		}	
 		return skillBaseCost+numberOfLevels*skillLevelCost;
-					}
+	}
 							
 						
 	/* Language Skills */
@@ -8557,7 +8552,7 @@
 						
 			let totalLanguageCosts = skill41Cost+skill42Cost+skill43Cost+skill44Cost+skill45Cost+skill46Cost+skill47Cost+skill48Cost+skill49Cost;
 						
-						setAttrs({
+			setAttrs({
 				"hiddenLanguageSkillsCost":totalLanguageCosts,
 				"skillCP41":skill41Cost,
 				"skillCP42":skill42Cost,
@@ -8568,7 +8563,7 @@
 				"skillCP47":skill47Cost,
 				"skillCP48":skill48Cost,
 				"skillCP49":skill49Cost
-				});
+			});
 		});
 	});
 	
@@ -8650,9 +8645,9 @@
 				"hiddenEnhancerSkillsCost":skillEnhancersCost+skillLevelsCost,
 			});
 			
-			//addSkillPoints();
-					});
-				});
+		//addSkillPoints();
+		});
+	});
 					
 	/* ----------------------------------------------------- */
 	/* Martial Skills, which are entered in the Gear Section */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1247,7 +1247,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="Strike" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="170"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="170"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp01">
@@ -1268,8 +1268,8 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="Damage by STR or weapon." maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="173"/>
-										<input type="number" value="0" name="attr_maneuverEND01" title="@{maneuverEND01}" tabindex="174"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="173"/>
+										<input type="number" value="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1280,7 +1280,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="176"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="2d6" name="attr_maneuverDamage01" title="@{maneuverDamage01}" maxlength="12" tabindex="177"/>
+										<input type="text" value="" name="attr_maneuverDamage01" title="@{maneuverDamage01}" maxlength="12" tabindex="177"/>
 										
 										<h1>N:</h1>
 										
@@ -1317,7 +1317,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="Block" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="180"/>
+							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="180"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp02">
@@ -1338,8 +1338,8 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="Block/Abort" maxlength="100" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" tabindex="183"/>
-										<input type="number" value="0" name="attr_maneuverEND02" title="@{maneuverEND02}" tabindex="184"/>
+										<input type="text" value=" " maxlength="100" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" tabindex="183"/>
+										<input type="number" value="0" name="attr_maneuverEndurance02" title="@{maneuverEndurance02}" tabindex="184"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1350,7 +1350,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" tabindex="186"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="2d6" name="attr_maneuverDamage02" title="@{maneuverDamage02}" maxlength="12" tabindex="187"/>
+										<input type="text" value="0" name="attr_maneuverDamage02" title="@{maneuverDamage02}" maxlength="12" tabindex="187"/>
 										
 										<h1>N:</h1>
 										
@@ -1408,8 +1408,8 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" tabindex="193"/>
-										<input type="number" value="0" name="attr_maneuverEND03" title="@{maneuverEND03}" tabindex="194"/>
+										<input type="text" value=" " maxlength="100" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" tabindex="193"/>
+										<input type="number" value="0" name="attr_maneuverEndurance03" title="@{maneuverEndurance03}" tabindex="194"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1420,7 +1420,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" tabindex="196"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage03" title="@{maneuverDamage03}" maxlength="12" tabindex="197"/>
+										<input type="text" value="0" name="attr_maneuverDamage03" title="@{maneuverDamage03}" maxlength="12" tabindex="197"/>
 										
 										<h1>N:</h1>
 										
@@ -1457,7 +1457,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="200"/>
+							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="200"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp04">
@@ -1479,7 +1479,7 @@
 									
 									<div class="subitem-martial-description-row">
 										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" tabindex="203"/>
-										<input type="number" value="0" name="attr_maneuverEND04" title="@{maneuverEND04}" tabindex="204"/>
+										<input type="number" value="0" name="attr_maneuverEndurance04" title="@{maneuverEndurance04}" tabindex="204"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1490,7 +1490,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" tabindex="206"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage04" title="@{maneuverDamage04}" maxlength="12" tabindex="207"/>
+										<input type="text" value="0" name="attr_maneuverDamage04" title="@{maneuverDamage04}" maxlength="12" tabindex="207"/>
 										
 										<h1>N:</h1>
 										
@@ -1527,7 +1527,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="210"/>
+							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="210"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp05">
@@ -1549,7 +1549,7 @@
 									
 									<div class="subitem-martial-description-row">
 										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" tabindex="213"/>
-										<input type="number" value="0" name="attr_maneuverEND05" title="@{maneuverEND05}" tabindex="214"/>
+										<input type="number" value="0" name="attr_maneuverEndurance05" title="@{maneuverEndurance05}" tabindex="214"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1560,7 +1560,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" tabindex="216"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage05" title="@{maneuverDamage05}" maxlength="12" tabindex="217"/>
+										<input type="text" value="0" name="attr_maneuverDamage05" title="@{maneuverDamage05}" maxlength="12" tabindex="217"/>
 										
 										<h1>N:</h1>
 										
@@ -1597,7 +1597,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="220"/>
+							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="220"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp06">
@@ -1619,7 +1619,7 @@
 									
 									<div class="subitem-martial-description-row">
 										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" tabindex="223"/>
-										<input type="number" value="0" name="attr_maneuverEND06" title="@{maneuverEND06}" tabindex="224"/>
+										<input type="number" value="0" name="attr_maneuverEndurance06" title="@{maneuverEndurance06}" tabindex="224"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1630,7 +1630,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" tabindex="226"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage06" title="@{maneuverDamage06}" maxlength="12" tabindex="227"/>
+										<input type="text" value="0" name="attr_maneuverDamage06" title="@{maneuverDamage06}" maxlength="12" tabindex="227"/>
 										
 										<h1>N:</h1>
 										
@@ -1667,13 +1667,13 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="230"/>
+							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="230"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp07">
 										<span>&#10095;</span>
 									</button>
-									<button type="action" class="button buttonMinus" tabindex="-1" name="act_martialManeuverDown076">
+									<button type="action" class="button buttonMinus" tabindex="-1" name="act_martialManeuverDown07">
 										<span>&#10094;</span>
 									</button>
 								</div>
@@ -1689,7 +1689,7 @@
 									
 									<div class="subitem-martial-description-row">
 										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" tabindex="233"/>
-										<input type="number" value="0" name="attr_maneuverEND07" title="@{maneuverEND07}" tabindex="234"/>
+										<input type="number" value="0" name="attr_maneuverEndurance07" title="@{maneuverEndurance07}" tabindex="234"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1700,7 +1700,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" tabindex="236"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage07" title="@{maneuverDamage07}" maxlength="12" tabindex="237"/>
+										<input type="text" value="0" name="attr_maneuverDamage07" title="@{maneuverDamage07}" maxlength="12" tabindex="237"/>
 										
 										<h1>N:</h1>
 										
@@ -1737,7 +1737,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="240"/>
+							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="240"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp08">
@@ -1759,7 +1759,7 @@
 									
 									<div class="subitem-martial-description-row">
 										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" tabindex="243"/>
-										<input type="number" value="0" name="attr_maneuverEND08" title="@{maneuverEND08}" tabindex="244"/>
+										<input type="number" value="0" name="attr_maneuverEndurance08" title="@{maneuverEndurance08}" tabindex="244"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1770,7 +1770,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" tabindex="246"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage08" title="@{maneuverDamage08}" maxlength="12" tabindex="247"/>
+										<input type="text" value="0" name="attr_maneuverDamage08" title="@{maneuverDamage08}" maxlength="12" tabindex="247"/>
 										
 										<h1>N:</h1>
 										
@@ -1807,7 +1807,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName09" title="@{martialManeuverName09}" tabindex="250"/>
+							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName09" title="@{martialManeuverName09}" tabindex="250"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp09">
@@ -1829,7 +1829,7 @@
 									
 									<div class="subitem-martial-description-row">
 										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" tabindex="253"/>
-										<input type="number" value="0" name="attr_maneuverEND09" title="@{maneuverEND09}" tabindex="254"/>
+										<input type="number" value="0" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" tabindex="254"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1840,7 +1840,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" tabindex="256"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage09" title="@{maneuverDamage09}" maxlength="12" tabindex="257"/>
+										<input type="text" value="0" name="attr_maneuverDamage09" title="@{maneuverDamage09}" maxlength="12" tabindex="257"/>
 										
 										<h1>N:</h1>
 										
@@ -2131,7 +2131,7 @@
 			
 			<!-- Slide for text -->
 			<div class="item-tab-gear-slide-treasure-text">
-				<textarea name="attr_treasures" title="@{treasures}" maxlength="4096" tabindex="201"></textarea>
+				<textarea name="attr_treasures" title="@{treasures}" maxlength="4096" tabindex="260"></textarea>
 			</div>
 			
 			<button type="action" name="act_left-gear-arrow-button" tabindex="-1" class="button button-left-arrow">&#10094;</button>
@@ -6123,15 +6123,16 @@
 <input type="hidden" name="attr_hiddenWeaponDamage03"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage04"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage05"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage01"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage02"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage03"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage04"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage05"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage06"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage07"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage08"  value="2d6"/>
-<input type="hidden" name="attr_hiddenManeuverDamage09"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage01"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage02"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage03"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage04"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage05"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage06"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage07"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage08"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage09"  value="0"/>
+<input type="hidden" name="attr_hiddenBasicDamage"  value="0"/>
 <input type="hidden" name="attr_hiddenBasicEndurance" value="2"/>
 
 <!-- Hidden variables for clean power dice strings -->
@@ -6234,19 +6235,20 @@
 				<div class="sheet-value">{{value}}</div>
 				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
 				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+				
 				<!-- Stun, Body, and Hit Location go at the end -->
-					{{#STUN}}
-					<div class="sheet-key">STUN</div>
-					<div class="sheet-value">{{computed::STUN}}</div>
-					{{/STUN}}
-					{{#BODY}}
-					<div class="sheet-key">BODY</div>
-					<div class="sheet-value">{{computed::BODY}}</div>
-					{{/BODY}}
-					{{#HITLOC}}
-					<div class="sheet-key">Hit Location</div>
-					<div class="sheet-value">{{computed::HITLOC}}</div>
-					{{/HITLOC}}
+				{{#STUN}}
+				<div class="sheet-key">STUN</div>
+				<div class="sheet-value">{{computed::STUN}}</div>
+				{{/STUN}}
+				{{#BODY}}
+				<div class="sheet-key">BODY</div>
+				<div class="sheet-value">{{computed::BODY}}</div>
+				{{/BODY}}
+				{{#HITLOC}}
+				<div class="sheet-key">Hit Location</div>
+				<div class="sheet-value">{{computed::HITLOC}}</div>
+				{{/HITLOC}}
 			</div>
 		</div>
 	</div>
@@ -6266,6 +6268,7 @@
 				<div class="sheet-value">{{value}}</div>
 				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
 				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+				
 				<!-- Stun, Body, and Hit Location go at the end -->
 				{{#STUN}}
 				<div class="sheet-key">STUN</div>
@@ -6285,7 +6288,7 @@
 </rolltemplate>
 
 <!-- Jackob's Roll Template for killing damage maneuvers -->
-<rolltemplate class="sheet-rolltemplate-custom-maneuver">
+<!-- <rolltemplate class="sheet-rolltemplate-custom-maneuver">
 	<div class="sheet-template-wrapper">
 		<div class="sheet-container sheet-color-{{color}}">
 			<div class="sheet-header">
@@ -6297,9 +6300,10 @@
 				<div class="sheet-key">{{key}}</div>
 				<div class="sheet-value">{{value}}</div>
 				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
-				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}} -->
+				
 				<!-- Stun, Body, and Hit Location go at the end -->
-				{{#STUN}}
+				<!-- {{#STUN}}
 				<div class="sheet-key">STUN</div>
 				<div class="sheet-value">{{computed::STUN}}</div>
 				{{/STUN}}
@@ -6314,10 +6318,10 @@
 			</div>
 		</div>
 	</div>
-</rolltemplate>
+</rolltemplate> -->
 
 <!-- Jackob's Roll Template for normal damage maneuvers -->
-<rolltemplate class="sheet-rolltemplate-custom-normal-maneuver">
+<!-- <rolltemplate class="sheet-rolltemplate-custom-normal-maneuver">
 	<div class="sheet-template-wrapper">
 		<div class="sheet-container sheet-color-{{color}}">
 			<div class="sheet-header">
@@ -6329,24 +6333,25 @@
 				<div class="sheet-key">{{key}}</div>
 				<div class="sheet-value">{{value}}</div>
 				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
-				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}} -->
+				
 				<!-- Stun, Body, and Hit Location go at the end -->
-					{{#STUN}}
-					<div class="sheet-key">STUN</div>
-					<div class="sheet-value">{{computed::STUN}}</div>
-					{{/STUN}}
-					{{#BODY}}
-					<div class="sheet-key">BODY</div>
-					<div class="sheet-value">{{computed::BODY}}</div>
-					{{/BODY}}
-					{{#HITLOC}}
-					<div class="sheet-key">Hit Location</div>
-					<div class="sheet-value">{{computed::HITLOC}}</div>
-					{{/HITLOC}}
+				<!-- {{#STUN}}
+				<div class="sheet-key">STUN</div>
+				<div class="sheet-value">{{computed::STUN}}</div>
+				{{/STUN}}
+				{{#BODY}}
+				<div class="sheet-key">BODY</div>
+				<div class="sheet-value">{{computed::BODY}}</div>
+				{{/BODY}}
+				{{#HITLOC}}
+				<div class="sheet-key">Hit Location</div>
+				<div class="sheet-value">{{computed::HITLOC}}</div>
+				{{/HITLOC}}
 			</div>
 		</div>
 	</div>
-</rolltemplate>
+</rolltemplate> -->
 
 <!-- Jackob's Roll Template for armor activation-->
 <rolltemplate class="sheet-rolltemplate-custom-activate">
@@ -7261,7 +7266,6 @@
 			});
 			
 			sumCharacteristicPoints();
-			
 		});
 	});
 	
@@ -8709,9 +8713,7 @@
 		var highId = String(num == maxManeuverNum ? 1 : num + 1).padStart(2,'0');
 		on("clicked:martialManeuverDown"+lowId+" clicked:martialManeuverUp"+highId, function() {
 			getAttrs(["martialManeuverName"+lowId, "martialManeuverPhase"+lowId, "martialManeuverCP"+lowId,
-					"martialManeuverOCV"+lowId, "martialManeuverDCV"+lowId, "martialManeuverEffect"+lowId,
-					"martialManeuverName"+highId, "martialManeuverPhase"+highId, "martialManeuverCP"+highId,
-					"martialManeuverOCV"+highId, "martialManeuverDCV"+highId, "martialManeuverEffect"+highId], function(values)
+					"martialManeuverOCV"+lowId, "martialManeuverDCV"+lowId, "martialManeuverEffect"+lowId, "maneuverDamage"+lowId, "maneuverNormalDamage"+lowId, "maneuverBlock"+lowId, "maneuverEndurance"+lowId, "martialManeuverName"+highId, "martialManeuverPhase"+highId, "martialManeuverCP"+highId, "martialManeuverOCV"+highId, "martialManeuverDCV"+highId, "martialManeuverEffect"+highId, "maneuverDamage"+highId, "maneuverNormalDamage"+highId, "maneuverBlock"+highId, "maneuverEndurance"+highId], function(values)
 			{
 				var attributes = new Object();
 
@@ -8727,6 +8729,14 @@
 				attributes["martialManeuverDCV"+highId] = values["martialManeuverDCV"+lowId];
 				attributes["martialManeuverEffect"+lowId] = values["martialManeuverEffect"+highId];
 				attributes["martialManeuverEffect"+highId] = values["martialManeuverEffect"+lowId];
+				attributes["maneuverDamage"+lowId] = values["maneuverDamage"+highId];
+				attributes["maneuverDamage"+highId] = values["maneuverDamage"+lowId];
+				attributes["maneuverNormalDamage"+lowId] = values["maneuverNormalDamage"+highId];
+				attributes["maneuverNormalDamage"+highId] = values["maneuverNormalDamage"+lowId];
+				attributes["maneuverBlock"+lowId] = values["maneuverBlock"+highId];
+				attributes["maneuverBlock"+highId] = values["maneuverBlock"+lowId];
+				attributes["maneuverEndurance"+lowId] = values["maneuverEndurance"+highId];
+				attributes["maneuverEndurance"+highId] = values["maneuverEndurance"+lowId];
 
 				setAttrs(attributes);
 			});
@@ -8845,16 +8855,16 @@
 				dexPenalty=-5;
 				enduranceCost=4+armorENDcost;
 				movePenalty=-16;
-						}
+			}
 						
-						setAttrs({
+			setAttrs({
 				"carriedWeight":carriedWeight,
 				"weightEndPenalty":enduranceCost,
 				"weightDexDCVPenalty":dexPenalty,
 				"weightMovePenalty":movePenalty
-						});
-					});
-				});
+			});
+		});
+	});
 					
 	// Open with first tab (thanks to GiGs)
 	on("sheet:opened", function() {
@@ -8931,90 +8941,104 @@
 		});
 	});
 	
+	
 	// /* Activate Maneuver XX */
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');
 		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "hiddenBasicEndurance", "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
+			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "treasures", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
 				let isBlocking = values["maneuverBlock"+maneuverId] != 0;
 				
 				// Martial maneuvers by default cost no endurance. Come back to this.
-				let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
+				let subtractENDAmt =  parseInt(values["maneuverEndurance"+maneuverId])||0;
 				
 				let dmgType = isNormalDamage ? "STUN" : "BODY";
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 				
 				if (isBlocking) {
 					// Use the Blocking template.
-					theRoll += "&{template:custom-defense} {{title=@{character_name} - @{character_title}}} "
-						+ "{{subtitle=Blocks with @{martialManeuverName"+maneuverId+"}}} ";
+					theRoll += "&{template:custom-defense} {{title=@{character_name} - @{character_title}}} " + "{{subtitle=Blocks with @{martialManeuverName"+maneuverId+"}}} ";
 					if (values.displayDegreeOfSuccess != 0) {
-						theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]+?{Modifiers|0}[Modifier]]]}} ";
+						theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll] + @{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} ";
 					} else {
-						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]+?{Modifiers|0}[Modifier]]]}} " + "{{Result=[[3d6cf6cs1]]}} ";
+						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} " + "{{Result=[[3d6cf6cs1]]}} ";
 					}
+					if (subtractENDAmt != 0) {
+						theRoll	+= "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
+					}
+					
 				} else {
-					// If isNormalDamage is TRUE, use the Normal Damage template.
-					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-maneuver} {{title=@{character_name} - @{character_title}}} "
-						+ "{{subtitle= Uses @{martialManeuverName"+maneuverId+"} to make a " + (isNormalDamage ? "normal" : "killing") + " attack.}} ";
+					// If isNormalDamage is TRUE, use the Normal Damage template. Else use the killing template.
+					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "") + "-attack} {{title=@{character_name} - @{character_title}}} " + "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{martialManeuverName"+maneuverId+"}}} ";
 					if (values.displayDegreeOfSuccess != 0) {
-						theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
+						theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifiers|0}[Modifier]]]}} ";
 					} else {
-						theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
-						+ "{{Result=[[3d6cf6cs1]]}}";
+						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifiers|0}[Modifier] ]]}} " + "{{Result=[[3d6cf6cs1]]}}";
 					}
-					theRoll	+= (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
-						+ "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}} "
+					theRoll	+= (subtractENDAmt ? "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}} " : "") 
+						+ "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}} " 
 						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 					if (useHitLocations)
 						theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
 				}
 				
-				startRoll(theRoll, (results) => {
-					if (!isBlocking) {
+				let debug = values.treasures||"";
+				// debug += " damage = " + values["hiddenManeuverDamage"+maneuverId];
+				debug += " roll = " + otherDmgType;
+				setAttrs({
+					"treasures":debug
+				});
+				
+				if (!isBlocking) {
+					startRoll(theRoll, (results) => {
 						let computed = parseInt(results.results[dmgType].result)||0;
 						let theSTUNMultiplier = Math.floor(Math.random()*3+1);
-					}
-					
-					// Get hit location message if system used.
-					if (useHitLocations && !isBlocking) {
-						var theHitLocation = hitLocationDetails(results.results.HITLOC.result);
-						theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
-						theSTUNMultiplier = theHitLocation.STUNx;
-					}
-					
-					if (!isBlocking) {
+						
+						// Get hit location message if system used.
+						if (useHitLocations) {
+							let theHitLocation = hitLocationDetails(results.results.HITLOC.result);
+							theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
+							theSTUNMultiplier = theHitLocation.STUNx;
+						}
+						
 						if (isNormalDamage)
 							// Convert dice roll to equivalent BODY damage.
 							computed = convertStunToBody(results.results.STUN.rolls);
 						else {
-							// theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
-							theSTUNMultiplier = Math.max(1,theSTUNMultiplier);
 							computed *= theSTUNMultiplier;
-							
+											
 							computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
 						}
-					}
-					
-					let theResult = new Object();
-					
-					if (!isBlocking) {
+						
+						let theResult = new Object();
+						
 						theResult[otherDmgType] = computed;
 						theResult.HITLOC = theMessage;
-					}
-						
-					// Subtract END cost if option checked.
-					if (values.optionAutoSubtractEND != 0) {
-						subtractEndurance(subtractENDAmt);
-					}
-						
-					finishRoll(results.rollId, theResult);
-				});
+							
+						// Subtract END cost if option checked.
+						if (values.optionAutoSubtractEND != 0) {
+							subtractEndurance(subtractENDAmt);
+						}
+							
+						finishRoll(results.rollId, theResult);
+					});
+				} else {
+					startRoll(theRoll, (results) => {
+						let theResult = new Object();
+							
+						// Subtract END cost if option checked.
+						if (values.optionAutoSubtractEND != 0) {
+							subtractEndurance(subtractENDAmt);
+						}
+							
+						finishRoll(results.rollId, theResult);
+					});
+				}
 			});
 		});
 	});
@@ -9024,9 +9048,8 @@
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');
 		on("clicked:buttonManeuverEND"+maneuverId, function() {
-			getAttrs(["maneuverEND"+maneuverId], function(values) {
-				// subtractEndurance(parseInt(values["maneuverEND"+maneuverId]));
-				subtractEndurance(parseInt(values["maneuverEND"+maneuverId]));
+			getAttrs(["maneuverEndurance"+maneuverId], function(values) {
+				subtractEndurance(parseInt(values["maneuverEndurance"+maneuverId]));
 			});
 		});
 	});
@@ -9347,7 +9370,7 @@
 				hiddenWeaponDamage03:theWeaponDamage03,
 				hiddenWeaponDamage04:theWeaponDamage04,
 				hiddenWeaponDamage05:theWeaponDamage05,
-				hiddenManeuverDamage01:theStrengthDamage
+				hiddenBasicDamage:theStrengthDamage
 			});
 		});
 	});
@@ -9371,12 +9394,18 @@
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 				
 				// If isNormalDamage is TRUE, use the Normal Damage template.
-				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
-						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{weaponName"+weaponId+"}}} ";
+				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")
+					+ "-attack} {{title=@{character_name} - @{character_title}}} "
+					+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") 
+					+ " attack with @{weaponName"+weaponId+"}}} ";
 				if (values.displayDegreeOfSuccess != 0) {
-					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["+ (areaOfEffect ? 0 : 1) +"*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} ";
+					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["
+						+ (areaOfEffect ? 0 : 1) 	
+						+ "*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} ";
 				} else {
-					theRoll += "{{OCV=[[@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["+ (areaOfEffect ? 0 : 1) +"*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} "
+					theRoll += "{{OCV=[[@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["
+						+ (areaOfEffect ? 0 : 1) 
+						+ "*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} "
 						+ "{{Result=[[3d6cf6cs1]]}}"
 				}
 				theRoll	+= (subtractENDAmt ? "{{END=[[@{weaponEndurance"+weaponId+"}]] (@{currentEND})}} " : "")
@@ -9515,51 +9544,50 @@
 		});
 	});
 	
-	on('clicked:standardAttackRoll', (info) => {
-		// Roll attack and damage dice for standardAttack
-
-		getAttrs(["hiddenBasicEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
-			var theRoll = values.whisperToGM||"";
-			let useHitLocations = values.optionHitLocationSystem != 0;
-
-			let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
-
-			theRoll += "&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} "
-				+ "{{subtitle= Makes a normal attack with Strength @{strength}}} ";
-			if (values.displayDegreeOfSuccess != 0) {
-				theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
-			} else {
-				theRoll += "{{OCV=[[@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
-					+ "{{Result=[[3d6cf6cs1]]}}";
-			}
-			theRoll += (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
-				+ "{{STUN=[[@{hiddenManeuverDamage01}]]}} "
-				+ "{{BODY=[[0[See STUN]]]}}";
-			if (useHitLocations)
-				theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
-
-			startRoll(theRoll, (results) => {
-				let theMessage = " ";
-				let computed = convertStunToBody(results.results.STUN.rolls);
-
-				// Get hit location message if system used.
-				if (useHitLocations) {
-					theMessage = hitLocationDetails(results.results.HITLOC.result).normalMessage;
-				}
-
-				let theResult = new Object();
-				theResult.BODY = computed;
-				theResult.HITLOC = theMessage;
-					
-				// Subtract END cost if option checked.
-				if (values.optionAutoSubtractEND != 0) {
-					subtractEndurance(subtractENDAmt);
-				}
-
-				finishRoll(results.rollId, theResult);
-			});					
-		});
-	});
+// 	on('clicked:standardAttackRoll', (info) => {
+// 		// Roll attack and damage dice for standardAttack
+// 
+// 		getAttrs(["hiddenBasicEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
+// 			var theRoll = values.whisperToGM||"";
+// 			let useHitLocations = values.optionHitLocationSystem != 0;
+// 
+// 			let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
+// 
+// 			theRoll += "&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} "
+// 				+ "{{subtitle= Makes a normal attack with Strength @{strength}}} ";
+// 			if (values.displayDegreeOfSuccess != 0) {
+// 				theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll] + @{ocv}[OCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifier|0}[Modifier]]]}} ";
+// 			} else {
+// 				theRoll += "{{OCV=[[@{ocv}[OCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifier|0}[Modifier]]]}} " + "{{Result=[[3d6cf6cs1]]}}";
+// 			}
+// 			theRoll += (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
+// 				+ "{{STUN=[[@{hiddenManeuverDamage01}]]}} "
+// 				+ "{{BODY=[[0[See STUN]]]}}";
+// 			if (useHitLocations)
+// 				theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
+// 
+// 			startRoll(theRoll, (results) => {
+// 				let theMessage = " ";
+// 				let computed = convertStunToBody(results.results.STUN.rolls);
+// 
+// 				// Get hit location message if system used.
+// 				if (useHitLocations) {
+// 					theMessage = hitLocationDetails(results.results.HITLOC.result).normalMessage;
+// 				}
+// 
+// 				let theResult = new Object();
+// 				theResult.BODY = computed;
+// 				theResult.HITLOC = theMessage;
+// 					
+// 				// Subtract END cost if option checked.
+// 				if (values.optionAutoSubtractEND != 0) {
+// 					subtractEndurance(subtractENDAmt);
+// 				}
+// 
+// 				finishRoll(results.rollId, theResult);
+// 			});					
+// 		});
+// 	});
 	
 						
 	/* ---------------- */
@@ -9624,7 +9652,7 @@
 	/* ---------------------- */
 	/* Complication Functions */
 	/* ---------------------- */
-						
+		
 	arrayOf(maxComplicationNum).forEach(num => {
 		var lowId = String(num).padStart(2,'0');
 		var highId = String(num == maxComplicationNum ? 1 : num + 1).padStart(2,'0');

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -6785,23 +6785,28 @@
 	}
 	
 	// Reset endurance and stun in item-characteristics-health when the reset action button is clicked.
+	// Also resets targeting choices if that option is checked.
 	on("clicked:resetHealth", function () {
-		getAttrs(["endurance", "stun", "optionResetTargeting", "rangeSelection"], function(values) {
+		getAttrs(["endurance", "stun", "optionResetTargeting", "targetSelection", "rangeSelection"], function(values) {
 			const maxEND = parseInt(values.endurance);
 			const maxSTUN = parseInt(values.stun);
 			
-			let theRangeSelection = parseInt(values.rangeSelection)||0;
+			let theRangeSelection;
+			let theTargetSelection;
 			
-			let resetOption = values.optionResetTargeting||0;
-			
-			if (resetOption) {
+			if (values.optionResetTargeting != 0) {
 				theRangeSelection = 0;
+				theTargetSelection = 1;
+			} else {
+				theRangeSelection = parseInt(values.rangeSelection)||0;
+				theTargetSelection = parseInt(values.targetSelection)||1;
 			}
 			
 			setAttrs({
 				"currentSTUN":maxSTUN,
 				"currentEND":maxEND,
-				"rangeSelection":theRangeSelection
+				"rangeSelection":theRangeSelection,
+				"targetSelection":theTargetSelection
 			});
 		});
 	});
@@ -9031,6 +9036,7 @@
 				if (!isBlocking) {
 					// If isNormalDamage is TRUE, use the Normal Damage template. Else use the killing template.
 					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "") + "-attack} {{title=@{character_name} - @{character_title}}} " + "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{martialManeuverName"+maneuverId+"}}} ";
+					theRoll += "{{DCV=[[@{currentDCV}[CurrentDCV]+@{martialManeuverDCV"+maneuverId+"}[ManeuverDCV]]]}}";
 					if (values.displayDegreeOfSuccess != 0) {
 						theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]-@{rangeOCVPenalty}[RangeOCV]+?{Modifiers|0}[Modifier]]]}}";
 					} else {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -8679,6 +8679,7 @@
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["martialNormalDamage"+maneuverId] != 0;
+				// let stunMod = parseInt(values["weaponStunMod"+weaponId])||0;
 			
 				let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
 			
@@ -8689,12 +8690,9 @@
 				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
 						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{martialManeuverName"+maneuverId+"}}} ";
 				if (values.displayDegreeOfSuccess != 0) {
-					// theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
-					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
+					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
 				} else {
-					// theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
-					// + "{{Result=[[3d6cf6cs1]]}}";
-					theRoll += "{{OCV=[[@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
+					theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
 					+ "{{Result=[[3d6cf6cs1]]}}";
 				}
 				theRoll	+= (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
@@ -8707,31 +8705,32 @@
 					let computed = parseInt(results.results[dmgType].result)||0;
 					let theSTUNMultiplier = Math.floor(Math.random()*3+1);
 			
-			// 		// Get hit location message if system used.
-			// 		if (useHitLocations) {
-			// 			let theHitLocation = hitLocationDetails(results.results.HITLOC.result);
-			// 			theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
-			// 			theSTUNMultiplier = theHitLocation.STUNx;
-			// 		}
-			// 
-			// 		if (isNormalDamage) {
-			// 			// Convert dice roll to equivalent BODY damage.
-			// 			computed = convertStunToBody(results.results.STUN.rolls);
-			// 		} else {
-			// 			theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
-			// 			computed *= theSTUNMultiplier;
-			// 
-			// 			computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
-			// 		}
-			// 
-			// 		let theResult = new Object();
-			// 		theResult[otherDmgType] = computed;
-			// 		theResult.HITLOC = theMessage;
-			// 			
-			// 		// Subtract END cost if option checked.
-			// 		if (values.optionAutoSubtractEND != 0) {
-			// 			subtractEndurance(subtractENDAmt);
-			// 		}
+					// Get hit location message if system used.
+					if (useHitLocations) {
+						let theHitLocation = hitLocationDetails(results.results.HITLOC.result);
+						theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
+						theSTUNMultiplier = theHitLocation.STUNx;
+					}
+			
+					if (isNormalDamage) {
+						// Convert dice roll to equivalent BODY damage.
+						computed = convertStunToBody(results.results.STUN.rolls);
+					} else {
+						// theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
+						theSTUNMultiplier = Math.max(1,theSTUNMultiplier);
+						computed *= theSTUNMultiplier;
+			
+						computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
+					}
+			
+					let theResult = new Object();
+					theResult[otherDmgType] = computed;
+					theResult.HITLOC = theMessage;
+						
+					// Subtract END cost if option checked.
+					if (values.optionAutoSubtractEND != 0) {
+						subtractEndurance(subtractENDAmt);
+					}
 			
 					finishRoll(results.rollId, theResult);
 				});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -225,7 +225,7 @@
 			
 				<!-- Avatar Portrait Image -->
 				<div class="item-portrait-01">
-					<img alt="Character Avatar" name="attr_theSheetAvatar" style="width:250px;height:250px;">
+					<img alt="Sheet Avatar" name="attr_theSheetAvatar" title="Sheet Avatar" style="width:250px;height:250px;">
 				</div>
 				
 				<!-- Sticky Note -->
@@ -1894,8 +1894,8 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-						  		<input type="radio" name="attr_rangeSelection" value="0" checked>
-						  		<span class="custom-radio-button"></span>
+								<input type="radio" name="attr_rangeSelection" value="0" checked>
+								<span class="custom-radio-button"></span>
 							</label>
 						</div>
 						
@@ -1908,8 +1908,8 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="9">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_rangeSelection" value="9">
+								<span class="custom-radio-button"></span>
 							</label>
 						</div>
 						
@@ -1922,8 +1922,8 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="17">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_rangeSelection" value="17">
+								<span class="custom-radio-button"></span>
 							</label>
 						</div>
 						
@@ -1936,8 +1936,8 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="33">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_rangeSelection" value="33">
+								<span class="custom-radio-button"></span>
 							</label>
 						</div>
 						
@@ -1950,8 +1950,8 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="65">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_rangeSelection" value="65">
+								<span class="custom-radio-button"></span>
 							</label>
 						</div>
 						
@@ -1975,8 +1975,8 @@
 						</div>
 						<div class="subitem-gear-slide-flex-container-hit-locations-special-top-row">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_targetSelection" value="1" checked>
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_targetSelection" value="1" checked>
+								<span class="custom-radio-button"></span>
 							</label>
 							<h1>3d6</h1>
 							<h1>Any</h1>
@@ -1984,8 +1984,8 @@
 						</div>
 						<div class="subitem-gear-slide-flex-container-hit-locations-special-middle-row">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_targetSelection" value="12">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_targetSelection" value="12">
+								<span class="custom-radio-button"></span>
 							</label>
 							<h1>1d6+3</h1>
 							<h1>Head Shot</h1>
@@ -1993,8 +1993,8 @@
 						</div>
 						<div class="subitem-gear-slide-flex-container-hit-locations-special-middle-row">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_targetSelection" value="13">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_targetSelection" value="13">
+								<span class="custom-radio-button"></span>
 							</label>
 							<h1>2d6+1</h1>
 							<h1>High Shot</h1>
@@ -2002,8 +2002,8 @@
 						</div>
 						<div class="subitem-gear-slide-flex-container-hit-locations-special-middle-row">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_targetSelection" value="14">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_targetSelection" value="14">
+								<span class="custom-radio-button"></span>
 							</label>
 							<h1>2d6+4</h1>
 							<h1>Body Shot</h1>
@@ -2011,8 +2011,8 @@
 						</div>
 						<div class="subitem-gear-slide-flex-container-hit-locations-special-middle-row">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_targetSelection" value="15">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_targetSelection" value="15">
+								<span class="custom-radio-button"></span>
 							</label>
 							<h1>2d6+7</h1>
 							<h1>Low Shot</h1>
@@ -2020,8 +2020,8 @@
 						</div>
 						<div class="subitem-gear-slide-flex-container-hit-locations-special-bottom-row">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_targetSelection" value="16">
-								  <span class="custom-radio-button"></span>
+								<input type="radio" name="attr_targetSelection" value="16">
+								<span class="custom-radio-button"></span>
 							</label>
 							<h1>1d6+12</h1>
 							<h1>Leg Shot</h1>
@@ -2062,8 +2062,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-top-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="2">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="2">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>3-5</h1>
 						<h1>Head</h1>
@@ -2075,8 +2075,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="3">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="3">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>6</h1>
 						<h1>Hands</h1>
@@ -2088,8 +2088,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="4">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="4">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>7-8</h1>
 						<h1>Arms</h1>
@@ -2101,8 +2101,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="5">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="5">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>9</h1>
 						<h1>Shoulders</h1>
@@ -2114,8 +2114,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="6">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="6">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>10-11</h1>
 						<h1>Chest</h1>
@@ -2127,8 +2127,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="7">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="7">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>12</h1>
 						<h1>Stomach</h1>
@@ -2140,8 +2140,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="8">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="8">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>13</h1>
 						<h1>Vitals</h1>
@@ -2153,8 +2153,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="9">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="9">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>14</h1>
 						<h1>Thighs</h1>
@@ -2166,8 +2166,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-middle-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="10">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="10">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>15-16</h1>
 						<h1>Legs</h1>
@@ -2179,8 +2179,8 @@
 					
 					<div class="subitem-gear-slide-container-hit-locations-table-bottom-row">
 						<label class="custom-radio-button-container">
-							  <input type="radio" name="attr_targetSelection" value="11">
-							  <span class="custom-radio-button"></span>
+							<input type="radio" name="attr_targetSelection" value="11">
+							<span class="custom-radio-button"></span>
 						</label>
 						<h1>17-18</h1>
 						<h1>Feet</h1>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1267,7 +1267,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="" maxlength="100" tabindex="183"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx01" title="@{martialManeuverSTUNx01}" value="0" min="0" max="9" step="1" tabindex="184"/>
+										<input type="number" name="attr_martialManeuverStunMod01" title="@{martialManeuverStunMod01}" value="0" min="0" max="9" step="1" tabindex="184"/>
 										<input type="number" value="" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="185"/>
 									</div>
 										
@@ -1339,7 +1339,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" value="" maxlength="100" tabindex="193"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx02" title="@{martialManeuverSTUNx02}" value="0" min="0" max="9" step="1" tabindex="194"/>
+										<input type="number" name="attr_martialManeuverStunMod02" title="@{martialManeuverStunMod02}" value="0" min="0" max="9" step="1" tabindex="194"/>
 										<input type="number" name="attr_maneuverEndurance02" title="@{maneuverEndurance02}" value="0" step="1" min="0" tabindex="195"/>
 									</div>
 										
@@ -1411,7 +1411,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" value="" maxlength="100" tabindex="203"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx03" title="@{martialManeuverSTUNx03}" value="0" min="0" max="9" step="1" tabindex="204"/>
+										<input type="number" name="attr_martialManeuverStunMod03" title="@{martialManeuverStunMod03}" value="0" min="0" max="9" step="1" tabindex="204"/>
 										<input type="number" name="attr_maneuverEndurance03" title="@{maneuverEndurance03}" value="0" step="1" min="0" tabindex="205"/>
 									</div>
 										
@@ -1483,7 +1483,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" value="" maxlength="100" tabindex="213"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx04" title="@{martialManeuverSTUNx04}" value="0" min="0" max="9" step="1" tabindex="214"/>
+										<input type="number" name="attr_martialManeuverStunMod04" title="@{martialManeuverStunMod04}" value="0" min="0" max="9" step="1" tabindex="214"/>
 										<input type="number" name="attr_maneuverEndurance04" title="@{maneuverEndurance04}" value="0" step="1" min="0" tabindex="215"/>
 									</div>
 										
@@ -1555,7 +1555,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" value="" maxlength="100" tabindex="223"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx05" title="@{martialManeuverSTUNx05}" value="0" min="0" max="9" step="1" tabindex="224"/>
+										<input type="number" name="attr_martialManeuverStunMod05" title="@{martialManeuverStunMod05}" value="0" min="0" max="9" step="1" tabindex="224"/>
 										<input type="number" name="attr_maneuverEndurance05" title="@{maneuverEndurance05}" value="0" step="1" min="0" tabindex="225"/>
 									</div>
 										
@@ -1627,7 +1627,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" value="" maxlength="100" tabindex="233"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx06" title="@{martialManeuverSTUNx06}" value="0" min="0" max="9" step="1" tabindex="234"/>
+										<input type="number" name="attr_martialManeuverStunMod06" title="@{martialManeuverStunMod06}" value="0" min="0" max="9" step="1" tabindex="234"/>
 										<input type="number" name="attr_maneuverEndurance06" title="@{maneuverEndurance06}" value="0" step="1" min="0" tabindex="235"/>
 									</div>
 										
@@ -1699,7 +1699,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" value="" maxlength="100" tabindex="243"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx07" title="@{martialManeuverSTUNx07}" value="0" min="0" max="9" step="1" tabindex="244"/>
+										<input type="number" name="attr_martialManeuverStunMod07" title="@{martialManeuverStunMod07}" value="0" min="0" max="9" step="1" tabindex="244"/>
 										<input type="number" name="attr_maneuverEndurance07" title="@{maneuverEndurance07}" value="0" step="1" min="0" tabindex="245"/>
 									</div>
 										
@@ -1771,7 +1771,7 @@
 									<div class="subitem-martial-description-row">
 										<input type="text" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" value="" maxlength="100" tabindex="253"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx08" title="@{martialManeuverSTUNx08}" value="0" min="0" max="9" step="1" tabindex="254"/>
+										<input type="number" name="attr_martialManeuverStunMod08" title="@{martialManeuverStunMod08}" value="0" min="0" max="9" step="1" tabindex="254"/>
 										<input type="number" name="attr_maneuverEndurance08" title="@{maneuverEndurance08}" value="0" step="1" min="0" tabindex="255"/>
 									</div>
 										
@@ -1820,7 +1820,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName09" title="@{martialManeuverName09}" value="Basic HTH Strike" maxlength="34" tabindex="260"/>
+							<input type="text" name="attr_martialManeuverName09" title="@{martialManeuverName09}" value="Strike" maxlength="34" tabindex="260"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp09">
@@ -1841,9 +1841,9 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="Damage by STR" maxlength="100" tabindex="263"/>
+										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="Damage by STR or by weapon" maxlength="100" tabindex="263"/>
 										<h1>Sx:</h1>
-										<input type="number" name="attr_martialManeuverSTUNx09" title="@{martialManeuverSTUNx09}" value="0" min="0" max="9" step="1" tabindex="264"/>
+										<input type="number" name="attr_martialManeuverStunMod09" title="@{martialManeuverStunMod09}" value="0" min="0" max="9" step="1" tabindex="264"/>
 										<input type="number" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" value="2" step="1" min="0" tabindex="265"/>
 									</div>
 										
@@ -8975,23 +8975,25 @@
 	/* Update Basic HTH Strike */
 	arrayOf(maxManeuverNum).forEach(num => {
 		// If strength changes enough so that hiddenBasicDamage and hiddenBasicEndurance change,
-		// look at each maneuver to see if it is a "Basic HTH Strike." If so, update its damage and endurance values.
+		// look at each maneuver effect to see if it includes the keyword phrase "Damage by STR." If so, update its damage and endurance values.
 		// A basic strike does normal damage, so hold off if the maneuver's normal damage option is unchecked.
 		
 		var maneuverId = String(num).padStart(2,'0');
 		
 		on(`change:hiddenBasicDamage change:hiddenBasicEndurance change:maneuverNormalDamage${maneuverId}`, function() {
-			getAttrs(["hiddenBasicEndurance", "hiddenBasicDamage", "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverDamage"+maneuverId, "hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId], function(values) {
+			getAttrs(["hiddenBasicEndurance", "hiddenBasicDamage", "martialManeuverEffect"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverDamage"+maneuverId, "hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId], function(values) {
 				var attributes = new Object();
 				
-				let defaultName = "Basic HTH Strike";
-				let currentName = values["martialManeuverName"+maneuverId]||"";
+				let keywordPhrase = "Damage by STR";
+				let currentEffect = values["martialManeuverEffect"+maneuverId]||"";
 				let theEndurance = parseInt(values["maneuverEndurance"+maneuverId])||0;
 				let theDamage = values["maneuverDamage"+maneuverId]||0;
 				let theHiddenDamage = values["hiddenManeuverDamage"+maneuverId]||0;
+				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
 				
-				if ( (currentName.localeCompare(defaultName) === 0) && (values["maneuverNormalDamage"+maneuverId] === "on")) {
-					// The name is the keyword defaultName and the maneuver is still a normal damage attack.
+				if (currentEffect.includes(keywordPhrase) && isNormalDamage) {
+					// The effect includes the keyword phrase and the maneuver is still a normal damage attack.
+					attributes["treasures"] = "invoked";
 					theEndurance = parseInt(values.hiddenBasicEndurance)||0;
 					theDamage = values.hiddenBasicDamage;
 					theHiddenDamage = values.hiddenBasicDamage;
@@ -9010,17 +9012,23 @@
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');	
 		on(`clicked:showMartialRoll${maneuverId}`, (info) => {
-			getAttrs(["whisperToGM", "maneuverNormalDamage"+maneuverId], function(values) {
+			getAttrs(["whisperToGM", "maneuverNormalDamage"+maneuverId, "martialManeuverStunMod"+maneuverId], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
+				let theStunMod = parseInt(values["martialManeuverStunMod"+maneuverId])||0;
 				
 				theRoll += "&{template:custom-show} {{title=@{character_name} - @{character_title}}} "
 					+ "{{subtitle= Maneuver - @{martialManeuverName"+maneuverId+"}}} "
 					+ "{{Phases=@{martialManeuverPhase"+maneuverId+"}}} "
 					+ "{{END = @{maneuverEndurance"+maneuverId+"}}} "
 					+ "{{OCV = @{martialManeuverOCV"+maneuverId+"}}} "
-					+ "{{DCV = @{martialManeuverDCV"+maneuverId+"}}} "
-					+ "{{Damage = @{maneuverDamage"+maneuverId+"}" + (isNormalDamage ? " N" : " K") + "}} "
+					+ "{{DCV = @{martialManeuverDCV"+maneuverId+"}}} ";
+					
+				if (!isNormalDamage && (theStunMod > 0) ) {
+					theRoll += "{{STUNx = @{martialManeuverStunMod"+maneuverId+"}}} ";
+				}
+					
+					theRoll += "{{Damage = @{maneuverDamage"+maneuverId+"}" + (isNormalDamage ? " N" : " K") + "}} "
 					+ "{{desc=@{martialManeuverEffect"+maneuverId+"}}}";
 				
 				startRoll(theRoll, (results) => {
@@ -9037,12 +9045,11 @@
 		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess", "rangeSelection"], function(values) {
+			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverStunMod"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess", "rangeSelection"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
-				// let stunMod = parseInt(values["weaponStunMod"+weaponId])||0;
-				let stunMod = 0; // Reserved for later use.
+				let stunMod = parseInt(values["martialManeuverStunMod"+maneuverId])||0;
 				let isBlocking = values["maneuverBlock"+maneuverId] != 0;
 				
 				// Martial maneuvers by default cost no endurance. Endurance costs used for flexibility.

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -6090,7 +6090,7 @@
 				</label>
 				<h1>Takes No STUN</h1>
 			</div>
-
+			
 			<div class="item-options-row">
 				<label class="container-checkbox">
 					<input type="checkbox" checked="checked" name="attr_displayDegreeOfSuccess">
@@ -6098,7 +6098,15 @@
 				</label>
 				<h1>Display Degree of Success</h1>
 			</div>
-
+			
+			<div class="item-options-row">
+				<label class="container-checkbox">
+					<input type="checkbox" checked="checked" name="attr_optionResetTargeting">
+					<span class="checkmark" title="@{optionResetTargeting}"></span>
+				</label>
+				<h1>Health reset buttons also reset target and range</h1>
+			</div>
+			
 			<div class="item-options-row">
 				<div class="custom-select-option">
 					<select name="attr_whisperToGM">
@@ -6109,7 +6117,7 @@
 				</div>
 				<h1>Whisper Rolls to GM</h1>
 			</div>
-
+			
 			<div class="item-version-row">
 				<div class="item-version-label">
 					<h2>Version:</h2>
@@ -6778,13 +6786,22 @@
 	
 	// Reset endurance and stun in item-characteristics-health when the reset action button is clicked.
 	on("clicked:resetHealth", function () {
-		getAttrs(["endurance","stun"], function(values) {
+		getAttrs(["endurance", "stun", "optionResetTargeting", "rangeSelection"], function(values) {
 			const maxEND = parseInt(values.endurance);
 			const maxSTUN = parseInt(values.stun);
+			
+			let theRangeSelection = parseInt(values.rangeSelection)||0;
+			
+			let resetOption = values.optionResetTargeting||0;
+			
+			if (resetOption) {
+				theRangeSelection = 0;
+			}
 			
 			setAttrs({
 				"currentSTUN":maxSTUN,
 				"currentEND":maxEND,
+				"rangeSelection":theRangeSelection
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -972,7 +972,7 @@
 						</button>
 					</div>
 				</div>
-				<input type="number" name="attr_equipMass13" title="@{equipMass13}" min="0" step="0.1"/ tabindex="157"/>
+				<input type="number" name="attr_equipMass13" title="@{equipMass13}" min="0" step="0.1" tabindex="157"/>
 			</div>
 			
 			<div class="subitem-tab-gear-flex-container-equipment">
@@ -1869,33 +1869,81 @@
 				
 				<!-- Range Modifier Table -->
 				<div class="subitem-tab-gear-slide-flex-container-range-modifiers">
-					<div class="subitem-tab-gear-slide-range-modifier-container-first">
-						<h2>Range (m)</h2>
-						<h2>OCV Mod:</h2>
-					</div>
 					<div class="subitem-tab-gear-slide-range-modifier-container">
-						<h2>0-8</h2>
-						<h2>0</h2>
+						<div class="subitem-range-modifier-container-column">
+							<h2>Range (m)</h2>
+							<h2>OCV Mod:</h2>
+						</div>
 					</div>
+					
 					<div class="subitem-tab-gear-slide-range-modifier-container">
-						<h2>9-16</h2>
-						<h2>-2</h2>
+						<div class="subitem-range-modifier-button-container">
+							<label class="custom-radio-button-container">
+						  		<input type="radio" name="attr_rangeSelection" value="0" checked>
+						  		<span class="custom-radio-button"></span>
+							</label>
+						</div>
+						
+						<div class="subitem-range-modifier-container-column">
+							<h2>0-8</h2>
+							<h2>0</h2>
+						</div>
 					</div>
+					
 					<div class="subitem-tab-gear-slide-range-modifier-container">
-						<h2>17-32</h2>
-						<h2>-4</h2>
+						<div class="subitem-range-modifier-button-container">
+							<label class="custom-radio-button-container">
+								  <input type="radio" name="attr_rangeSelection" value="-2">
+								  <span class="custom-radio-button"></span>
+							</label>
+						</div>
+						
+						<div class="subitem-range-modifier-container-column">
+							<h2>9-16</h2>
+							<h2>-2</h2>
+						</div>
 					</div>
+					
 					<div class="subitem-tab-gear-slide-range-modifier-container">
-						<h2>33-64</h2>
-						<h2>-6</h2>
+						<div class="subitem-range-modifier-button-container">
+							<label class="custom-radio-button-container">
+								  <input type="radio" name="attr_rangeSelection" value="-4">
+								  <span class="custom-radio-button"></span>
+							</label>
+						</div>
+						
+						<div class="subitem-range-modifier-container-column">
+							<h2>17-32</h2>
+							<h2>-4</h2>
+						</div>
 					</div>
+					
 					<div class="subitem-tab-gear-slide-range-modifier-container">
-						<h2>65-125</h2>
-						<h2>-8</h2>
+						<div class="subitem-range-modifier-button-container">
+							<label class="custom-radio-button-container">
+								  <input type="radio" name="attr_rangeSelection" value="-6">
+								  <span class="custom-radio-button"></span>
+							</label>
+						</div>
+						
+						<div class="subitem-range-modifier-container-column">
+							<h2>33-64</h2>
+							<h2>-6</h2>
+						</div>
 					</div>
+					
 					<div class="subitem-tab-gear-slide-range-modifier-container">
-						<h2>126-250</h2>
-						<h2>-10</h2>
+						<div class="subitem-range-modifier-button-container">
+							<label class="custom-radio-button-container">
+								  <input type="radio" name="attr_rangeSelection" value="-8">
+								  <span class="custom-radio-button"></span>
+							</label>
+						</div>
+						
+						<div class="subitem-range-modifier-container-column">
+							<h2>65-125</h2>
+							<h2>-8</h2>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1247,7 +1247,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName01" title="@{martialManeuverName01}" value="" maxlength="34" tabindex="170"/>
+							<input type="text" name="attr_martialManeuverName01" title="@{martialManeuverName01}" value="Basic HTH Strike" maxlength="34" tabindex="170"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp01">
@@ -1268,8 +1268,8 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="" maxlength="100" tabindex="173"/>
-										<input type="number" value="0" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
+										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="Damage by STR" maxlength="100" tabindex="173"/>
+										<input type="number" value="2" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1280,7 +1280,7 @@
 										<input type="number" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" value="0" step="1" tabindex="176"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="0" maxlength="12" tabindex="177"/>
+										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="2d6" maxlength="12" tabindex="177"/>
 										
 										<h1>N:</h1>
 										
@@ -6133,7 +6133,7 @@
 <input type="hidden" name="attr_hiddenManeuverDamage07"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage08"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage09"  value="0"/>
-<input type="hidden" name="attr_hiddenBasicDamage"  value="0"/>
+<input type="hidden" name="attr_hiddenBasicDamage"  value="2d6"/>
 <input type="hidden" name="attr_hiddenBasicEndurance" value="2"/>
 
 <!-- Hidden variables for clean power dice strings -->
@@ -6520,31 +6520,31 @@
 	const maxComplicationNum = 6;
 
 	function arrayOf(num) {
-		// For use in our forEach loops, this creates an array of numbers 1 to num
+		// For use in our forEach loops, this creates an array of numbers 1 to num.
 		return Array.from({length: num}, (_, i) => i + 1);
 	}
 
 	function heroRoundHigh(theNumber) {
 		// In the Hero System rounding favors the player. Here where high is good.
-		let theIntegerPart = Math.floor(theNumber);
-		let theRemainder = Math.floor(100*(theNumber-theIntegerPart))/100;
+		let theIntegerPart = Math.trunc(theNumber);
+		let theRemainder = (theNumber%1).toFixed(4);
 		
-			if (theRemainder<=0.4) {
+			if (theRemainder <= 0.4) {
 				return theIntegerPart;
 			} else {
-				return theIntegerPart+1;
+				return theIntegerPart + 1;
 			}
 	}
 	
 	function heroRoundLow(theNumber) {
 		// In the Hero System rounding favors the player. Here where low is good.
-		let theIntegerPart = Math.floor(theNumber);
-		let theRemainder = Math.floor(100*(theNumber-theIntegerPart))/100;
+		let theIntegerPart = Math.trunc(theNumber);
+		let theRemainder = (theNumber%1).toFixed(4);
 		
-			if (theRemainder<0.6) {
-				return theIntegerPart;
+			if (theRemainder >= 0.6) {
+				return theIntegerPart + 1;
 			} else {
-				return theIntegerPart+1;
+				return theIntegerPart;
 			}
 	}
 	
@@ -8651,9 +8651,37 @@
 					"martialManeuverOCV"+lowId, "martialManeuverDCV"+lowId, "martialManeuverEffect"+lowId, "maneuverDamage"+lowId, "maneuverNormalDamage"+lowId, "maneuverBlock"+lowId, "maneuverEndurance"+lowId, "martialManeuverName"+highId, "martialManeuverPhase"+highId, "martialManeuverCP"+highId, "martialManeuverOCV"+highId, "martialManeuverDCV"+highId, "martialManeuverEffect"+highId, "maneuverDamage"+highId, "maneuverNormalDamage"+highId, "maneuverBlock"+highId, "maneuverEndurance"+highId], function(values)
 			{
 				var attributes = new Object();
-
-				attributes["martialManeuverName"+lowId] = values["martialManeuverName"+highId];
-				attributes["martialManeuverName"+highId] = values["martialManeuverName"+lowId];
+				
+				// Fix for empty strings. Only a problem because one maneuver is pre-assigned to Basic HTH Strike.
+				// A single space should be an acceptable compromise.
+				theString = values["martialManeuverName"+highId];
+				if ( (theString.length === 0) || (theString === null) ) {
+					attributes["martialManeuverName"+lowId] = " ";
+				} else {
+					attributes["martialManeuverName"+lowId] = values["martialManeuverName"+highId];
+				}
+				
+				theString = values["martialManeuverName"+lowId];
+				if ( (theString.length === 0) || (theString === null) ) {
+					attributes["martialManeuverName"+highId] = " ";
+				} else {
+					attributes["martialManeuverName"+highId] = values["martialManeuverName"+lowId];
+				}
+				
+				theString = values["martialManeuverEffect"+highId];
+				if ( (theString.length === 0) || (theString === null) ) {
+					attributes["martialManeuverEffect"+lowId] = " ";
+				} else {
+					attributes["martialManeuverEffect"+lowId] = values["martialManeuverEffect"+highId];
+				}
+				
+				theString = values["martialManeuverEffect"+lowId];
+				if ( (theString.length === 0) || (theString === null) ) {
+					attributes["martialManeuverEffect"+highId] = " ";
+				} else {
+					attributes["martialManeuverEffect"+highId] = values["martialManeuverEffect"+lowId];
+				}
+				
 				attributes["martialManeuverPhase"+lowId] = values["martialManeuverPhase"+highId];
 				attributes["martialManeuverPhase"+highId] = values["martialManeuverPhase"+lowId];
 				attributes["martialManeuverCP"+lowId] = values["martialManeuverCP"+highId];
@@ -8662,8 +8690,8 @@
 				attributes["martialManeuverOCV"+highId] = values["martialManeuverOCV"+lowId];
 				attributes["martialManeuverDCV"+lowId] = values["martialManeuverDCV"+highId];
 				attributes["martialManeuverDCV"+highId] = values["martialManeuverDCV"+lowId];
-				attributes["martialManeuverEffect"+lowId] = values["martialManeuverEffect"+highId];
-				attributes["martialManeuverEffect"+highId] = values["martialManeuverEffect"+lowId];
+				
+				// Rename to standard "martialManeuver"
 				attributes["maneuverDamage"+lowId] = values["maneuverDamage"+highId];
 				attributes["maneuverDamage"+highId] = values["maneuverDamage"+lowId];
 				attributes["maneuverNormalDamage"+lowId] = values["maneuverNormalDamage"+highId];
@@ -8672,7 +8700,7 @@
 				attributes["maneuverBlock"+highId] = values["maneuverBlock"+lowId];
 				attributes["maneuverEndurance"+lowId] = values["maneuverEndurance"+highId];
 				attributes["maneuverEndurance"+highId] = values["maneuverEndurance"+lowId];
-
+				
 				setAttrs(attributes);
 			});
 		});
@@ -8684,7 +8712,7 @@
 						
 	/* Calculate weapon endurance costs */
 	on("change:optionSuperHeroicEndurance change:weaponStrength01 change:weaponStrength02 change:weaponStrength03 change:weaponStrength04 change:weaponStrength05 change:shieldStrength change:strength", function() {
-		getAttrs(["optionSuperHeroicEndurance", "weaponStrength01", "weaponStrength02", "weaponStrength03", "weaponStrength04", "weaponStrength05","shieldStrength", "strength"], function(values) {
+		getAttrs(["optionSuperHeroicEndurance", "weaponStrength01", "weaponStrength02", "weaponStrength03", "weaponStrength04", "weaponStrength05","shieldStrength", "strength", "martialManeuverName01", "maneuverEndurance01", "treasures"], function(values) {
 			// If optionSuperHeroicEndurance is true, endurance cost is 1 per 5 strength, otherwise it is 1 per 10 strength used.
 											 
 			optionSuperHeroic = values.optionSuperHeroicEndurance;
@@ -8694,40 +8722,56 @@
 				enduranceCostFactor = 10;
 			}
 
-			let enduranceCost01= heroRoundLow( (parseInt(values.weaponStrength01)||0)/enduranceCostFactor );
+			let enduranceCost01 = heroRoundLow( (parseInt(values.weaponStrength01)||0)/enduranceCostFactor );
 			if ( (enduranceCost01<1) && (parseInt(values.weaponStrength01)||0)>0) {
 				enduranceCost01=1
 						}
 						
-			let enduranceCost02= heroRoundLow( (parseInt(values.weaponStrength02)||0)/enduranceCostFactor );
+			let enduranceCost02 = heroRoundLow( (parseInt(values.weaponStrength02)||0)/enduranceCostFactor );
 			if ( (enduranceCost02<1) && (parseInt(values.weaponStrength02)||0)>0) {
 				enduranceCost02=1
 			}
 						
-			let enduranceCost03= heroRoundLow( (parseInt(values.weaponStrength03)||0)/enduranceCostFactor );
+			let enduranceCost03 = heroRoundLow( (parseInt(values.weaponStrength03)||0)/enduranceCostFactor );
 			if ( (enduranceCost03<1) && (parseInt(values.weaponStrength03)||0)>0) {
 				enduranceCost03=1
 			}
 						
-			let enduranceCost04= heroRoundLow( (parseInt(values.weaponStrength04)||0)/enduranceCostFactor );
+			let enduranceCost04 = heroRoundLow( (parseInt(values.weaponStrength04)||0)/enduranceCostFactor );
 			if ( (enduranceCost04<1) && (parseInt(values.weaponStrength04)||0)>0) {
 				enduranceCost04=1
 						}
 						
-			let enduranceCost05= heroRoundLow( (parseInt(values.weaponStrength05)||0)/enduranceCostFactor );
+			let enduranceCost05 = heroRoundLow( (parseInt(values.weaponStrength05)||0)/enduranceCostFactor );
 			if ( (enduranceCost05<1) && (parseInt(values.weaponStrength05)||0)>0) {
 				enduranceCost05=1
 			}
 						
-			let enduranceCostShield= heroRoundLow( (parseInt(values.shieldStrength)||0)/enduranceCostFactor );
+			let enduranceCostShield = heroRoundLow( (parseInt(values.shieldStrength)||0)/enduranceCostFactor );
 			if ( (enduranceCostShield<1) && (parseInt(values.shieldStrength)||0)>0) {
 				enduranceCostShield=1
 			}
 
-			let enduranceCostBasic= heroRoundLow( (parseInt(values.strength)||0)/enduranceCostFactor );
+			let enduranceCostBasic = heroRoundLow( (parseInt(values.strength)||0)/enduranceCostFactor );
 			if ( (enduranceCostBasic<1) && (parseInt(values.strength)||0)>0) {
 				enduranceCostBasic=1
 			}
+			
+			// Check to see if the first maneuver remains the default.
+			// If it is, update its endurance.
+			let defaultName = "Basic HTH Strike";
+			let currentName = values.martialManeuverName01;
+			let theEndurance = enduranceCostBasic;
+			if (currentName.localeCompare(defaultName) === 1) {
+				theEndurance = parseInt( (values.maneuverEndurance01)||0);
+			}
+			
+			let debug = values.treasures||"";
+			// debug += " damage = " + values["hiddenManeuverDamage"+maneuverId];
+			debug += " " + (parseInt(values.strength)||0)/enduranceCostFactor;
+			setAttrs({
+				"treasures":debug
+			});
 			
 			setAttrs({
 				"weaponEndurance01":enduranceCost01,
@@ -8736,7 +8780,8 @@
 				"weaponEndurance04":enduranceCost04,
 				"weaponEndurance05":enduranceCost05,
 				"shieldEndurance":enduranceCostShield,
-				"hiddenBasicEndurance":enduranceCostBasic
+				"hiddenBasicEndurance":enduranceCostBasic,
+				"maneuverEndurance01":theEndurance
 			});
 		});
 	});
@@ -8886,7 +8931,7 @@
 		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "treasures", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
+			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
@@ -8931,13 +8976,6 @@
 						theRoll	+= "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
 					}
 				} 
-				
-				let debug = values.treasures||"";
-				// debug += " damage = " + values["hiddenManeuverDamage"+maneuverId];
-				debug += " roll = " + theRoll;
-				setAttrs({
-					"treasures":debug
-				});
 				
 				if (!isBlocking) {
 					startRoll(theRoll, (results) => {
@@ -9278,7 +9316,7 @@
 		// This function attempts to clean damage text input into text more likely to be rollable dice.
 		// Only characters 0-9, d, D, +, and - are passed to attack rolls.
 		
-		getAttrs(["shieldDamage", "weaponDamage01", "weaponDamage02", "weaponDamage03", "weaponDamage04", "weaponDamage05", "strength"], function(values) {
+		getAttrs(["shieldDamage", "weaponDamage01", "weaponDamage02", "weaponDamage03", "weaponDamage04", "weaponDamage05", "strength", "martialManeuverName01", "maneuverDamage01"], function(values) {
 		
 			var theShieldDamage=values.shieldDamage;
 			theShieldDamage=theShieldDamage.replace(/[^\ddD\\+\\-]/g,"");
@@ -9310,6 +9348,15 @@
 			
 			var theStrengthDamage=theNumberOfD6.concat("d6+",theNumberOfD3.toString(),"d3");
 			
+			// Check to see if the first maneuver remains the default.
+			// If it is, update its damage.
+			let defaultName = "Basic HTH Strike";
+			let currentName = values.martialManeuverName01;
+			let theDamage = theStrengthDamage;
+			if (currentName.localeCompare(defaultName) === 1) {
+				theDamage = values.maneuverDamage01;
+			}
+			
 			setAttrs({
 				"hiddenShieldDamage01":theShieldDamage,
 				"hiddenWeaponDamage01":theWeaponDamage01,
@@ -9317,7 +9364,8 @@
 				"hiddenWeaponDamage03":theWeaponDamage03,
 				"hiddenWeaponDamage04":theWeaponDamage04,
 				"hiddenWeaponDamage05":theWeaponDamage05,
-				"hiddenBasicDamage":theStrengthDamage
+				"hiddenBasicDamage":theStrengthDamage,
+				"maneuverDamage01":theDamage
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -611,9 +611,6 @@
 					<h1>Mass</h1>
 				</div>
 				
-				<input type="hidden" name="attr_targetOCVpenalty" value="0"/>
-				<input type="hidden" name="attr_targetHitRoll" value="3d6cs0cf0"/>
-				
 				<div class="subitem-tab-gear-flex-container-shield-row">
 					<input type="text" name="attr_shieldName" title="@{shieldName}" value="" maxlength="20" tabindex="76"/>
 					<input type="number" name="attr_shieldDCV" title="@{shieldDCV}" step="1"  min="0" value="0" tabindex="77"/>
@@ -1893,7 +1890,7 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="-2">
+								  <input type="radio" name="attr_rangeSelection" value="9">
 								  <span class="custom-radio-button"></span>
 							</label>
 						</div>
@@ -1907,7 +1904,7 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="-4">
+								  <input type="radio" name="attr_rangeSelection" value="17">
 								  <span class="custom-radio-button"></span>
 							</label>
 						</div>
@@ -1921,7 +1918,7 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="-6">
+								  <input type="radio" name="attr_rangeSelection" value="33">
 								  <span class="custom-radio-button"></span>
 							</label>
 						</div>
@@ -1935,7 +1932,7 @@
 					<div class="subitem-tab-gear-slide-range-modifier-container">
 						<div class="subitem-range-modifier-button-container">
 							<label class="custom-radio-button-container">
-								  <input type="radio" name="attr_rangeSelection" value="-8">
+								  <input type="radio" name="attr_rangeSelection" value="65">
 								  <span class="custom-radio-button"></span>
 							</label>
 						</div>
@@ -6150,6 +6147,11 @@
 	</div>
 </div>
 
+<!-- Hidden variables for combat rolls -->
+<input type="hidden" name="attr_targetOCVpenalty" value="0"/>
+<input type="hidden" name="attr_rangeOCVpenalty" value="0"/>
+<input type="hidden" name="attr_targetHitRoll" value="3d6cs0cf0"/>
+
 <!-- Hidden variables to protect characteristics during option changes -->
 <input type="hidden" name="attr_hiddenSTUN" value="20"/>
 <input type="hidden" name="CurrentBODY_max" value="10"/>
@@ -8756,15 +8758,15 @@
 	/* -------------------------------------------------- */
 	/* Functions used for gear tab                        */
 	/* -------------------------------------------------- */
-						
+		
 	/* Calculate weapon endurance costs */
 	on("change:optionSuperHeroicEndurance change:weaponStrength01 change:weaponStrength02 change:weaponStrength03 change:weaponStrength04 change:weaponStrength05 change:shieldStrength change:strength", function() {
 		getAttrs(["optionSuperHeroicEndurance", "weaponStrength01", "weaponStrength02", "weaponStrength03", "weaponStrength04", "weaponStrength05","shieldStrength", "strength"], function(values) {
 			// If optionSuperHeroicEndurance is true, endurance cost is 1 per 5 strength, otherwise it is 1 per 10 strength used.
-											 
+			
 			optionSuperHeroic = values.optionSuperHeroicEndurance;
 			let enduranceCostFactor = 5;
-							
+			
 			if (optionSuperHeroic != 0) {
 				enduranceCostFactor = 10;
 			}
@@ -8772,28 +8774,28 @@
 			let enduranceCost01 = heroRoundLow( (parseInt(values.weaponStrength01)||0)/enduranceCostFactor );
 			if ( (enduranceCost01<1) && (parseInt(values.weaponStrength01)||0)>0) {
 				enduranceCost01=1
-						}
-						
+			}
+			
 			let enduranceCost02 = heroRoundLow( (parseInt(values.weaponStrength02)||0)/enduranceCostFactor );
 			if ( (enduranceCost02<1) && (parseInt(values.weaponStrength02)||0)>0) {
 				enduranceCost02=1
 			}
-						
+			
 			let enduranceCost03 = heroRoundLow( (parseInt(values.weaponStrength03)||0)/enduranceCostFactor );
 			if ( (enduranceCost03<1) && (parseInt(values.weaponStrength03)||0)>0) {
 				enduranceCost03=1
 			}
-						
+			
 			let enduranceCost04 = heroRoundLow( (parseInt(values.weaponStrength04)||0)/enduranceCostFactor );
 			if ( (enduranceCost04<1) && (parseInt(values.weaponStrength04)||0)>0) {
 				enduranceCost04=1
-						}
-						
+			}
+			
 			let enduranceCost05 = heroRoundLow( (parseInt(values.weaponStrength05)||0)/enduranceCostFactor );
 			if ( (enduranceCost05<1) && (parseInt(values.weaponStrength05)||0)>0) {
 				enduranceCost05=1
 			}
-						
+			
 			let enduranceCostShield = heroRoundLow( (parseInt(values.shieldStrength)||0)/enduranceCostFactor );
 			if ( (enduranceCostShield<1) && (parseInt(values.shieldStrength)||0)>0) {
 				enduranceCostShield=1
@@ -8995,7 +8997,7 @@
 		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
+			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess", "rangeSelection"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
@@ -9011,30 +9013,22 @@
 				
 				if (!isBlocking) {
 					// If isNormalDamage is TRUE, use the Normal Damage template. Else use the killing template.
-					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "") 
-						+ "-attack} {{title=@{character_name} - @{character_title}}} " 
-						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") 
-						+ " attack with @{martialManeuverName"+maneuverId+"}}} ";
+					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "") + "-attack} {{title=@{character_name} - @{character_title}}} " + "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{martialManeuverName"+maneuverId+"}}} ";
 					if (values.displayDegreeOfSuccess != 0) {
-						theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifiers|0}[Modifier]]]}} ";
+						theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]-@{rangeOCVPenalty}[RangeOCV]+?{Modifiers|0}[Modifier]]]}}";
 					} else {
-						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifiers|0}[Modifier] ]]}} " 
-							+ "{{Result=[[3d6cf6cs1]]}}";
+						theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]-@{rangeOCVPenalty}[RangeOCV]+?{Modifiers|0}[Modifier] ]]}}" + "{{Result=[[3d6cf6cs1]]}}";
 					}
-					theRoll	+= (subtractENDAmt ? "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}} " : "") 
-						+ "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}} " 
-						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
+					theRoll	+= (subtractENDAmt ? "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}" : "") + "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}}" + "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 					if (useHitLocations)
-						theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
+						theRoll += "{{HITLOC=[[@{targetHitRoll}]]}}";
 				} else {
 					// Use the Blocking template.
-					theRoll += "&{template:custom-defense} {{title=@{character_name} - @{character_title}}} " 
-						+ "{{subtitle=Blocks with @{martialManeuverName"+maneuverId+"}}} ";
+					theRoll += "&{template:custom-defense} {{title=@{character_name}-@{character_title}}}" + "{{subtitle=Blocks with @{martialManeuverName"+maneuverId+"}}} ";
 					if (values.displayDegreeOfSuccess != 0) {
-						theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll] + @{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} ";
+						theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]+?{Modifiers|0}[Modifier]]]}} ";
 					} else {
-						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} " 
-							+ "{{Result=[[3d6cf6cs1]]}} ";
+						theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]+?{Modifiers|0}[Modifier]]]}}" + "{{Result=[[3d6cf6cs1]]}} ";
 					}
 					if (subtractENDAmt != 0) {
 						theRoll	+= "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
@@ -9089,6 +9083,20 @@
 					});
 				}
 			});
+		});
+	});
+	
+	
+	/* Update range penalty */
+	on("change:rangeSelection", function () {
+		getAttrs(["rangeSelection"], function(values) {
+			let debug = values.treasures||"";
+			let theSelection = parseFloat(values.rangeSelection)||0;
+			let theOCVpenalty = parseInt(getRangePenalty(theSelection));
+			
+			setAttrs({
+				"rangeOCVpenalty":theOCVpenalty
+			})
 		});
 	});
 	
@@ -9372,6 +9380,31 @@
 					}
 		return computed;
 	}
+	
+		
+	function getRangePenalty(range) {
+		// Uses a lookup table or for longer ranges calculates the range penalty for an attack.
+		let thePenalty = 0;
+		range = heroRoundLow(range);
+		
+		if (range <= 8) {
+			thePenalty = 0;
+		} else if (range <= 16) {
+			thePenalty = -2;
+		} else if (range <= 32) {
+			thePenalty = -4;
+		} else if (range <= 64) {
+			thePenalty = -6;
+		} else if (range <= 125) {
+			thePenalty = -10;
+		} else {
+			thePenalty = -(8 + 2 * Math.ceil((Math.log2( range/125 ))));
+		}
+		
+		// Return positive value. We'll make it negative in the roll.
+		return -thePenalty;
+	}
+
 
 	/* ------------------------ */
 	/* --- Weapon Attacks   --- */
@@ -9445,23 +9478,13 @@
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 				
 				// If isNormalDamage is TRUE, use the Normal Damage template.
-				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")
-					+ "-attack} {{title=@{character_name} - @{character_title}}} "
-					+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") 
-					+ " attack with @{weaponName"+weaponId+"}}} ";
+				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "") + "-attack} {{title=@{character_name} - @{character_title}}} " + "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{weaponName"+weaponId+"}}} ";
 				if (values.displayDegreeOfSuccess != 0) {
-					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["
-						+ (areaOfEffect ? 0 : 1) 	
-						+ "*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} ";
+					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[[" + (areaOfEffect ? 0 : 1) + "*@{targetOCVPenalty}]][TargetOCV]-@{rangeOCVPenalty}[RangeOCV]+?{Modifiers|0}[Modifier]]]}} ";
 				} else {
-					theRoll += "{{OCV=[[@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[["
-						+ (areaOfEffect ? 0 : 1) 
-						+ "*@{targetOCVPenalty}]][TargetOCV]+?{Modifiers|0}[Modifier]]]}} "
-						+ "{{Result=[[3d6cf6cs1]]}}"
+					theRoll += "{{OCV=[[@{ocv}[OCV]+@{weaponOCV"+weaponId+"}[WeaponOCV]-[[" + (areaOfEffect ? 0 : 1) + "*@{targetOCVPenalty}]][TargetOCV]-@{rangeOCVPenalty}[RangeOCV]+?{Modifiers|0}[Modifier]]]}}" + "{{Result=[[3d6cf6cs1]]}}"
 				}
-				theRoll	+= (subtractENDAmt ? "{{END=[[@{weaponEndurance"+weaponId+"}]] (@{currentEND})}} " : "")
-						+ "{{"+dmgType+"=[[@{hiddenWeaponDamage"+weaponId+"}]]}} "
-						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
+				theRoll	+= (subtractENDAmt ? "{{END=[[@{weaponEndurance"+weaponId+"}]] (@{currentEND})}}" : "") + "{{"+dmgType+"=[[@{hiddenWeaponDamage"+weaponId+"}]]}} " + "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 				if (useHitLocations)
 					theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
 					

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -254,7 +254,7 @@
 				<h2>STUN</h2>
 				<div class="item-health-stat">
 					<input type="text" name="attr_CurrentSTUN" title="@{CurrentSTUN}" value="20" maxlength="3" pattern="[0-9]+" tabindex="27"/>
-					<div class="item-health-stat-plus-minus-enclosure ">
+					<div class="item-health-stat-plus-minus-enclosure">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_stunPlus">
 							<span>&#10095;</span>
 						</button>
@@ -266,7 +266,7 @@
 				<h2>END</h2>
 				<div class="item-health-stat">
 					<input type="text" name="attr_CurrentEND" title="@{CurrentEND}" value="20" maxlength="3" pattern="[0-9]+" tabindex="28"/>
-					<div class="item-health-stat-plus-minus-enclosure ">
+					<div class="item-health-stat-plus-minus-enclosure">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_endurancePlus">
 							<span>&#10095;</span>
 						</button>
@@ -4017,7 +4017,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-01">
 							<button type="action" class="buttonExpand" name="act_powerExpand01">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4117,7 +4117,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-02">
 							<button type="action" class="buttonExpand" name="act_powerExpand02">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4217,7 +4217,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-03">
 							<button type="action" class="buttonExpand" name="act_powerExpand03">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4317,7 +4317,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-04">
 							<button type="action" class="buttonExpand" name="act_powerExpand04">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4417,7 +4417,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-05">
 							<button type="action" class="buttonExpand" name="act_powerExpand05">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4517,7 +4517,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-02">
 							<button type="action" class="buttonExpand" name="act_powerExpand06">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4617,7 +4617,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-07">
 							<button type="action" class="buttonExpand" name="act_powerExpand07">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4717,7 +4717,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-08">
 							<button type="action" class="buttonExpand" name="act_powerExpand08">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>
@@ -4817,7 +4817,7 @@
 					<div class="custom-expand-button-container">
 						<div class="custom-expand-button-container-09">
 							<button type="action" class="buttonExpand" name="act_powerExpand09">
-								<div class=custom-button-triangle>
+								<div class=custom-button-triangle-alt>
 								</div>
 							</button>
 						</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1448,7 +1448,7 @@
 							</div>
 						</div>
 					</div>
-
+					
 					<!-- Maneuver 04 -->
 					<div class="item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
@@ -1520,7 +1520,7 @@
 							</div>
 						</div>
 					</div>
-
+					
 					<!-- Maneuver 05 -->
 					<div class="item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
@@ -1592,7 +1592,7 @@
 							</div>
 						</div>
 					</div>
-
+					
 					<!-- Maneuver 06 -->
 					<div class="item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
@@ -3997,7 +3997,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName01" title="@powerName01" maxlength="35" tabindex="400"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType01" title="@powerType01">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4053,7 +4053,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations01" min="0" value="0" step="0.25" tabindex="406"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND01">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4097,7 +4097,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName02" title="@powerName02" maxlength="35" tabindex="410"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType02" title="@powerType02">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4153,7 +4153,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations02" min="0" value="0" step="0.25" tabindex="416"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND02">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4197,7 +4197,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName03" title="@powerName03" maxlength="35" tabindex="420"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType03" title="@powerType03">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4253,7 +4253,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations03" min="0" value="0" step="0.25" tabindex="426"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND03">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4297,7 +4297,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName04" title="@powerName04" maxlength="35" tabindex="430"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType04" title="@powerType04">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4353,7 +4353,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations04" min="0" value="0" step="0.25" tabindex="436"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND04">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4397,7 +4397,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName05" title="@powerName05" maxlength="35" tabindex="440"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType05" title="@powerType05">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4453,7 +4453,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations05" min="0" value="0" step="0.25" tabindex="446"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND05">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4497,7 +4497,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName06" title="@powerName06" maxlength="35" tabindex="450"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType06" title="@powerType06">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4553,7 +4553,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations06" min="0" value="0" step="0.25" tabindex="456"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND06">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4597,7 +4597,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName07" title="@powerName07" maxlength="35" tabindex="460"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType07" title="@powerType07">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4653,7 +4653,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations07" min="0" value="0" step="0.25" tabindex="466"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND07">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4697,7 +4697,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName08" title="@powerName08" maxlength="35" tabindex="470"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType08" title="@powerType08">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4753,7 +4753,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations08" min="0" value="0" step="0.25" tabindex="476"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND08">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4797,7 +4797,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName09" title="@powerName09" maxlength="35" tabindex="480"/>
-					<div class="custom-select">
+					<div class="custom-select-alternate">
 						<select name="attr_powerType09" title="@powerType09">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -4853,7 +4853,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations09" min="0" value="0" step="0.25" tabindex="486"/>
 						<h1>END:</h1>
-						<div class="custom-select">
+						<div class="custom-select-alternate">
 							<select name="attr_powerReducedEND09">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -4957,7 +4957,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName10" title="@powerName10" maxlength="35" tabindex="490"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType10" title="@powerType10">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5013,7 +5013,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations10" min="0" value="0" step="0.25" tabindex="496"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND10">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5058,7 +5058,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName11" title="@powerName11" maxlength="35" tabindex="500"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType11" title="@powerType11">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5114,7 +5114,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations11" min="0" value="0" step="0.25" tabindex="506"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND11">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5158,7 +5158,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName12" title="@powerName12" maxlength="35" tabindex="510"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType12" title="@powerType12">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5214,7 +5214,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations12" min="0" value="0" step="0.25" tabindex="516"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND12">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5258,7 +5258,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName13" title="@powerName13" maxlength="35" tabindex="520"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType13" title="@powerType13">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5314,7 +5314,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations13" min="0" value="0" step="0.25" tabindex="526"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND13">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5358,7 +5358,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName14" title="@powerName14" maxlength="35" tabindex="530"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType14" title="@powerType14">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5414,7 +5414,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations14" min="0" value="0" step="0.25" tabindex="536"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND14">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5458,7 +5458,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName15" title="@powerName15" maxlength="35" tabindex="540"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType15" title="@powerType15">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5514,7 +5514,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations15" min="0" value="0" step="0.25" tabindex="546"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND15">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5557,7 +5557,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName16" title="@powerName16" maxlength="35" tabindex="550"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType16" title="@powerType16">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5613,7 +5613,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations16" min="0" value="0" step="0.25" tabindex="556"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND16">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5656,7 +5656,7 @@
 					</div>
 					
 					<input type="text" value="" name="attr_powerName17" title="@powerName17" maxlength="35" tabindex="560"/>
-					<div class="custom-select-alternate">
+					<div class="custom-select">
 						<select name="attr_powerType17" title="@powerType17">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
@@ -5712,7 +5712,7 @@
 						<h1>Lim:</h1>
 						<input type="number" name="attr_powerLimitations17" min="0" value="0" step="0.25" tabindex="566"/>
 						<h1>END:</h1>
-						<div class="custom-select-alternate">
+						<div class="custom-select">
 							<select name="attr_powerReducedEND17">
 								<option value="noEND">None</option>
 								<option value="costsENDhalf">Costs END (half)</option>
@@ -5912,7 +5912,7 @@
 			
 			<!-- Complication 01 -->
 			<div class="item-complication-heading">
-				<div class="talent-mover-plus-minus-enclosure">
+				<div class="complication-mover-plus-minus-button">
 					<div class="talent-mover-plus-minus-button">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_complicationUp01">
 							<span>&#10095;</span>
@@ -5934,7 +5934,7 @@
 			
 			<!-- Complication 02 -->
 			<div class="item-complication-heading">
-				<div class="talent-mover-plus-minus-enclosure">
+				<div class="complication-mover-plus-minus-button">
 					<div class="talent-mover-plus-minus-button">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_complicationUp02">
 							<span>&#10095;</span>
@@ -5956,7 +5956,7 @@
 			
 			<!-- Complication 03 -->
 			<div class="item-complication-heading">
-				<div class="talent-mover-plus-minus-enclosure">
+				<div class="complication-mover-plus-minus-button">
 					<div class="talent-mover-plus-minus-button">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_complicationUp03">
 							<span>&#10095;</span>
@@ -5978,7 +5978,7 @@
 			
 			<!-- Complication 04 -->
 			<div class="item-complication-heading">
-				<div class="talent-mover-plus-minus-enclosure">
+				<div class="complication-mover-plus-minus-button">
 					<div class="talent-mover-plus-minus-button">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_complicationUp04">
 							<span>&#10095;</span>
@@ -6000,7 +6000,7 @@
 			
 			<!-- Complication 05 -->
 			<div class="item-complication-heading">
-				<div class="talent-mover-plus-minus-enclosure">
+				<div class="complication-mover-plus-minus-button">
 					<div class="talent-mover-plus-minus-button">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_complicationUp05">
 							<span>&#10095;</span>
@@ -6022,7 +6022,7 @@
 			
 			<!-- Complication 06 -->
 			<div class="item-complication-heading">
-				<div class="talent-mover-plus-minus-enclosure">
+				<div class="complication-mover-plus-minus-button">
 					<div class="talent-mover-plus-minus-button">
 						<button type="action" class="button buttonPlus" tabindex="-1" name="act_complicationUp06">
 							<span>&#10095;</span>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1222,6 +1222,17 @@
 					<input type="hidden" class="maneuver-normal-damage08" name="attr_maneuverNormalDamage08" value="on">
 					<input type="hidden" class="maneuver-normal-damage09" name="attr_maneuverNormalDamage09" value="on">
 					
+					<!-- These are needed here for Maneuver Roll button defense coloring. -->
+					<input type="hidden" class="maneuver-block01" name="attr_maneuverBlock01">
+					<input type="hidden" class="maneuver-block02" name="attr_maneuverBlock02">
+					<input type="hidden" class="maneuver-block03" name="attr_maneuverBlock03">
+					<input type="hidden" class="maneuver-block04" name="attr_maneuverBlock04">
+					<input type="hidden" class="maneuver-block05" name="attr_maneuverBlock05">
+					<input type="hidden" class="maneuver-block06" name="attr_maneuverBlock06">
+					<input type="hidden" class="maneuver-block07" name="attr_maneuverBlock07">
+					<input type="hidden" class="maneuver-block08" name="attr_maneuverBlock08">
+					<input type="hidden" class="maneuver-block09" name="attr_maneuverBlock09">
+					
 					<!-- Set first maneuver to expanded state as default. -->
 					<input type="hidden" class="sheet-maneuver-toggle" name="attr_maneuverToggle"  value="maneuverExpand01" />
 					

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -3765,9 +3765,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName01" maxlength="35" tabindex="400"/>
+					<input type="text" value="" name="attr_powerName01" title="@powerName01" maxlength="35" tabindex="400"/>
 					<div class="custom-select">
-						<select name="attr_powerType01">
+						<select name="attr_powerType01" title="@powerType01">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -3777,8 +3777,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND01" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND01" tabindex="-1">END</button>
+					<input type="text" name="attr_powerEND01" title="@powerEND01" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND01" title="%{buttonPowerEND01}" tabindex="-1">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -3791,11 +3791,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect01" maxlength="25" tabindex="401"/>
-					<input type="text" name="attr_powerDice01" value="0d6" maxlength="16" tabindex="402"/>
+					<input type="text" name="attr_powerEffect01" title="@powerEffect01" maxlength="25" tabindex="401"/>
+					<input type="text" name="attr_powerDice01" title="@powerDice01" value="0d6" maxlength="16" tabindex="402"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll01" value="18" min="0" max="30" tabindex="403"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll01">Roll</button>
+					<input type="number" name="attr_powerSkillRoll01" title="@powerSkillRoll01" value="18" min="0" max="30" tabindex="403"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll01" title="%powerRoll01">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -3844,7 +3844,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText01" maxlength="512" tabindex="407"></textarea>
+					<textarea name="attr_powerText01" title="@powerText01" maxlength="512" tabindex="407"></textarea>
 				</div>
 			</div>
 			
@@ -3865,9 +3865,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName02" maxlength="35" tabindex="410"/>
+					<input type="text" value="" name="attr_powerName02" title="@powerName02" maxlength="35" tabindex="410"/>
 					<div class="custom-select">
-						<select name="attr_powerType02">
+						<select name="attr_powerType02" title="@powerType02">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -3877,8 +3877,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND02" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND02">END</button>
+					<input type="text" name="attr_powerEND02" title="@powerEND02" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND02" title="%{buttonPowerEND02}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -3891,11 +3891,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect02" maxlength="25" tabindex="411"/>
-					<input type="text" name="attr_powerDice02" value="0d6" maxlength="16" tabindex="412"/>
+					<input type="text" name="attr_powerEffect02" title="@powerEffect02" maxlength="25" tabindex="411"/>
+					<input type="text" name="attr_powerDice02" title="@powerDice02" value="0d6" maxlength="16" tabindex="412"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll02" value="18" min="0" max="30" tabindex="413"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll02">Roll</button>
+					<input type="number" name="attr_powerSkillRoll02" title="@powerSkillRoll02" value="18" min="0" max="30" tabindex="413"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll02" title="%powerRoll02">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -3944,7 +3944,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText02" maxlength="512" tabindex="417"></textarea>
+					<textarea name="attr_powerText02" title="@powerText02" maxlength="512" tabindex="417"></textarea>
 				</div>
 			</div>
 			
@@ -3965,9 +3965,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName03" maxlength="35" tabindex="420"/>
+					<input type="text" value="" name="attr_powerName03" title="@powerName03" maxlength="35" tabindex="420"/>
 					<div class="custom-select">
-						<select name="attr_powerType03">
+						<select name="attr_powerType03" title="@powerType03">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -3977,8 +3977,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND03" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND03">END</button>
+					<input type="text" name="attr_powerEND03" title="@powerEND03" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND03" title="%{buttonPowerEND03}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -3991,11 +3991,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect03" maxlength="25" tabindex="421"/>
-					<input type="text" name="attr_powerDice03" value="0d6" maxlength="16" tabindex="422"/>
+					<input type="text" name="attr_powerEffect03" title="@powerEffect03" maxlength="25" tabindex="421"/>
+					<input type="text" name="attr_powerDice03" title="@powerDice03" value="0d6" maxlength="16" tabindex="422"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll03" value="18" min="0" max="30" tabindex="423"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll03">Roll</button>
+					<input type="number" name="attr_powerSkillRoll03" title="@powerSkillRoll03" value="18" min="0" max="30" tabindex="423"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll03" title="%powerRoll03">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4044,7 +4044,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText03" maxlength="512" tabindex="427"></textarea>
+					<textarea name="attr_powerText03" title="@powerText03" maxlength="512" tabindex="427"></textarea>
 				</div>
 			</div>
 			
@@ -4065,9 +4065,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName04" maxlength="35" tabindex="430"/>
+					<input type="text" value="" name="attr_powerName04" title="@powerName04" maxlength="35" tabindex="430"/>
 					<div class="custom-select">
-						<select name="attr_powerType04">
+						<select name="attr_powerType04" title="@powerType04">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4077,8 +4077,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND04" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND04">END</button>
+					<input type="text" name="attr_powerEND04" title="@powerEND04" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND04" title="%{buttonPowerEND04}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4091,11 +4091,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect04" maxlength="25" tabindex="431"/>
-					<input type="text" name="attr_powerDice04" value="0d6" maxlength="16" tabindex="432"/>
+					<input type="text" name="attr_powerEffect04" title="@powerEffect04" maxlength="25" tabindex="431"/>
+					<input type="text" name="attr_powerDice04" title="@powerDice04" value="0d6" maxlength="16" tabindex="432"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll04" value="18" min="0" max="30" tabindex="433"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll04">Roll</button>
+					<input type="number" name="attr_powerSkillRoll04" title="@powerSkillRoll04" value="18" min="0" max="30" tabindex="433"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll04" title="%powerRoll04">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4144,7 +4144,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText04" maxlength="512" tabindex="437"></textarea>
+					<textarea name="attr_powerText04" title="@powerText04" maxlength="512" tabindex="437"></textarea>
 				</div>
 			</div>
 			
@@ -4165,9 +4165,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName05" maxlength="35" tabindex="440"/>
+					<input type="text" value="" name="attr_powerName05" title="@powerName05" maxlength="35" tabindex="440"/>
 					<div class="custom-select">
-						<select name="attr_powerType05">
+						<select name="attr_powerType05" title="@powerType05">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4177,8 +4177,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND05" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND05">END</button>
+					<input type="text" name="attr_powerEND05" title="@powerEND05" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND05" title="%{buttonPowerEND05}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4191,11 +4191,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect05" maxlength="25" tabindex="441"/>
-					<input type="text" name="attr_powerDice05" value="0d6" maxlength="16" tabindex="442"/>
+					<input type="text" name="attr_powerEffect05" title="@powerEffect05" maxlength="25" tabindex="441"/>
+					<input type="text" name="attr_powerDice05" title="@powerDice05" value="0d6" maxlength="16" tabindex="442"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll05" value="18" min="0" max="30" tabindex="443"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll05">Roll</button>
+					<input type="number" name="attr_powerSkillRoll05" title="@powerSkillRoll05" value="18" min="0" max="30" tabindex="443"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll05" title="%powerRoll05">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4244,7 +4244,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText05" maxlength="512" tabindex="447"></textarea>
+					<textarea name="attr_powerText05" title="@powerText05" maxlength="512" tabindex="447"></textarea>
 				</div>
 			</div>
 			
@@ -4265,9 +4265,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName06" maxlength="35" tabindex="450"/>
+					<input type="text" value="" name="attr_powerName06" title="@powerName06" maxlength="35" tabindex="450"/>
 					<div class="custom-select">
-						<select name="attr_powerType06">
+						<select name="attr_powerType06" title="@powerType06">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4277,8 +4277,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND06" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND06">END</button>
+					<input type="text" name="attr_powerEND06" title="@powerEND06" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND06" title="%{buttonPowerEND06}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4291,11 +4291,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect06" maxlength="25" tabindex="451"/>
-					<input type="text" name="attr_powerDice06" value="0d6" maxlength="16" tabindex="452"/>
+					<input type="text" name="attr_powerEffect06" title="@powerEffect06" maxlength="25" tabindex="451"/>
+					<input type="text" name="attr_powerDice06" title="@powerDice06" value="0d6" maxlength="16" tabindex="452"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll06" value="18" min="0" max="30" tabindex="453"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll06">Roll</button>
+					<input type="number" name="attr_powerSkillRoll06" title="@powerSkillRoll06" value="18" min="0" max="30" tabindex="453"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll06" title="%powerRoll06">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4344,7 +4344,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText06" maxlength="512" tabindex="457"></textarea>
+					<textarea name="attr_powerText06" title="@powerText06" maxlength="512" tabindex="457"></textarea>
 				</div>
 			</div>
 			
@@ -4365,9 +4365,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName07" maxlength="35" tabindex="460"/>
+					<input type="text" value="" name="attr_powerName07" title="@powerName07" maxlength="35" tabindex="460"/>
 					<div class="custom-select">
-						<select name="attr_powerType07">
+						<select name="attr_powerType07" title="@powerType07">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4377,8 +4377,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND07" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND07">END</button>
+					<input type="text" name="attr_powerEND07" title="@powerEND07" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND07" title="%{buttonPowerEND07}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4391,11 +4391,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect07" maxlength="25" tabindex="461"/>
-					<input type="text" name="attr_powerDice07" value="0d6" maxlength="16" tabindex="462"/>
+					<input type="text" name="attr_powerEffect07" title="@powerEffect07" maxlength="25" tabindex="461"/>
+					<input type="text" name="attr_powerDice07" title="@powerDice07" value="0d6" maxlength="16" tabindex="462"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll07" value="18" min="0" max="30" tabindex="463"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll07">Roll</button>
+					<input type="number" name="attr_powerSkillRoll07" title="@powerSkillRoll07" value="18" min="0" max="30" tabindex="463"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll07" title="%powerRoll07">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4444,7 +4444,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText07" maxlength="512" tabindex="467"></textarea>
+					<textarea name="attr_powerText07" title="@powerText07" maxlength="512" tabindex="467"></textarea>
 				</div>
 			</div>
 			
@@ -4465,9 +4465,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName08" maxlength="35" tabindex="470"/>
+					<input type="text" value="" name="attr_powerName08" title="@powerName08" maxlength="35" tabindex="470"/>
 					<div class="custom-select">
-						<select name="attr_powerType08">
+						<select name="attr_powerType08" title="@powerType08">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4477,8 +4477,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND08" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND08">END</button>
+					<input type="text" name="attr_powerEND08" title="@powerEND08" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND08" title="%{buttonPowerEND08}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4491,11 +4491,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect08" maxlength="25" tabindex="471"/>
-					<input type="text" name="attr_powerDice08" value="0d6" maxlength="16" tabindex="472"/>
+					<input type="text" name="attr_powerEffect08" title="@powerEffect08" maxlength="25" tabindex="471"/>
+					<input type="text" name="attr_powerDice08" title="@powerDice08" value="0d6" maxlength="16" tabindex="472"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll08" value="18" min="0" max="30" tabindex="473"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll08">Roll</button>
+					<input type="number" name="attr_powerSkillRoll08" title="@powerSkillRoll08" value="18" min="0" max="30" tabindex="473"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll08" title="%powerRoll08">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4544,7 +4544,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText08" maxlength="512" tabindex="477"></textarea>
+					<textarea name="attr_powerText08" title="@powerText08" maxlength="512" tabindex="477"></textarea>
 				</div>
 			</div>
 			
@@ -4565,9 +4565,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName09" maxlength="35" tabindex="480"/>
+					<input type="text" value="" name="attr_powerName09" title="@powerName09" maxlength="35" tabindex="480"/>
 					<div class="custom-select">
-						<select name="attr_powerType09">
+						<select name="attr_powerType09" title="@powerType09">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4577,8 +4577,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND09" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND09">END</button>
+					<input type="text" name="attr_powerEND09" title="@powerEND09" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-left" tabindex="-1" name="act_buttonPowerEND09" title="%{buttonPowerEND09}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4591,11 +4591,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect09" maxlength="25" tabindex="481"/>
-					<input type="text" name="attr_powerDice09" value="0d6" maxlength="16" tabindex="482"/>
+					<input type="text" name="attr_powerEffect09" title="@powerEffect09" maxlength="25" tabindex="481"/>
+					<input type="text" name="attr_powerDice09" title="@powerDice09" value="0d6" maxlength="16" tabindex="482"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll09" value="18" min="0" max="30" tabindex="483"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll09">Roll</button>
+					<input type="number" name="attr_powerSkillRoll09" title="@powerSkillRoll09" value="18" min="0" max="30" tabindex="483"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll09" title="%powerRoll09">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4644,7 +4644,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText09" maxlength="512" tabindex="487"></textarea>
+					<textarea name="attr_powerText09" title="@powerText09" maxlength="512" tabindex="487"></textarea>
 				</div>
 			</div>
 		</div>
@@ -4725,9 +4725,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName10" maxlength="35" tabindex="490"/>
+					<input type="text" value="" name="attr_powerName10" title="@powerName10" maxlength="35" tabindex="490"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType10">
+						<select name="attr_powerType10" title="@powerType10">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4737,8 +4737,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND10" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND10">END</button>
+					<input type="text" name="attr_powerEND10" title="@powerEND10" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND10" title="%{buttonPowerEND10}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4751,11 +4751,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect10" maxlength="25" tabindex="491"/>
-					<input type="text" name="attr_powerDice10" value="0d6" maxlength="16" tabindex="492"/>
+					<input type="text" name="attr_powerEffect10" title="@powerEffect10" maxlength="25" tabindex="491"/>
+					<input type="text" name="attr_powerDice10" title="@powerDice10" value="0d6" maxlength="16" tabindex="492"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll10" value="18" min="0" max="30" tabindex="493"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll10">Roll</button>
+					<input type="number" name="attr_powerSkillRoll10" title="@powerSkillRoll10" value="18" min="0" max="30" tabindex="493"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll10" title="%powerRoll10">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4804,7 +4804,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText10" maxlength="512" tabindex="497"></textarea>
+					<textarea name="attr_powerText10" title="@powerText10" maxlength="512" tabindex="497"></textarea>
 				</div>
 			</div>
 			
@@ -4826,9 +4826,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName11" maxlength="35" tabindex="500"/>
+					<input type="text" value="" name="attr_powerName11" title="@powerName11" maxlength="35" tabindex="500"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType11">
+						<select name="attr_powerType11" title="@powerType11">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4838,8 +4838,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND11" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND11">END</button>
+					<input type="text" name="attr_powerEND11" title="@powerEND11" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND11" title="%{buttonPowerEND11}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4852,11 +4852,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect11" maxlength="25" tabindex="501"/>
-					<input type="text" name="attr_powerDice11" value="0d6" maxlength="16" tabindex="502"/>
+					<input type="text" name="attr_powerEffect11" title="@powerEffect11" maxlength="25" tabindex="501"/>
+					<input type="text" name="attr_powerDice11" title="@powerDice11" value="0d6" maxlength="16" tabindex="502"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll11" value="18" min="0" max="30" tabindex="503"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll11">Roll</button>
+					<input type="number" name="attr_powerSkillRoll11" title="@powerSkillRoll11" value="18" min="0" max="30" tabindex="503"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll11" title="%powerRoll11">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -4905,7 +4905,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText11" maxlength="512" tabindex="507"></textarea>
+					<textarea name="attr_powerText11" title="@powerText11" maxlength="512" tabindex="507"></textarea>
 				</div>
 			</div>
 			
@@ -4926,9 +4926,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName12" maxlength="35" tabindex="510"/>
+					<input type="text" value="" name="attr_powerName12" title="@powerName12" maxlength="35" tabindex="510"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType12">
+						<select name="attr_powerType12" title="@powerType12">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -4938,8 +4938,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND12" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND12">END</button>
+					<input type="text" name="attr_powerEND12" title="@powerEND12" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND12" title="%{buttonPowerEND12}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -4952,11 +4952,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect12" maxlength="25" tabindex="511"/>
-					<input type="text" name="attr_powerDice12" value="0d6" maxlength="16" tabindex="512"/>
+					<input type="text" name="attr_powerEffect12" title="@powerEffect12" maxlength="25" tabindex="511"/>
+					<input type="text" name="attr_powerDice12" title="@powerDice12" value="0d6" maxlength="16" tabindex="512"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll12" value="18" min="0" max="30" tabindex="513"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll12">Roll</button>
+					<input type="number" name="attr_powerSkillRoll12" title="@powerSkillRoll12" value="18" min="0" max="30" tabindex="513"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll12" title="%powerRoll12">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -5005,7 +5005,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText12" maxlength="512" tabindex="517"></textarea>
+					<textarea name="attr_powerText12" title="@powerText12" maxlength="512" tabindex="517"></textarea>
 				</div>
 			</div>
 			
@@ -5026,9 +5026,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName13" maxlength="35" tabindex="520"/>
+					<input type="text" value="" name="attr_powerName13" title="@powerName13" maxlength="35" tabindex="520"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType13">
+						<select name="attr_powerType13" title="@powerType13">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -5038,8 +5038,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND13" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND13">END</button>
+					<input type="text" name="attr_powerEND13" title="@powerEND13" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND13" title="%{buttonPowerEND13}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -5052,11 +5052,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect13" maxlength="25" tabindex="521"/>
-					<input type="text" name="attr_powerDice13" value="0d6" maxlength="16" tabindex="522"/>
+					<input type="text" name="attr_powerEffect13" title="@powerEffect13" maxlength="25" tabindex="521"/>
+					<input type="text" name="attr_powerDice13" title="@powerDice13" value="0d6" maxlength="16" tabindex="522"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll13" value="18" min="0" max="30" tabindex="523"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll13">Roll</button>
+					<input type="number" name="attr_powerSkillRoll13" title="@powerSkillRoll13" value="18" min="0" max="30" tabindex="523"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll13" title="%powerRoll13">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -5105,7 +5105,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText13" maxlength="512" tabindex="527"></textarea>
+					<textarea name="attr_powerText13" title="@powerText13" maxlength="512" tabindex="527"></textarea>
 				</div>
 			</div>
 			
@@ -5126,9 +5126,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName14" maxlength="35" tabindex="530"/>
+					<input type="text" value="" name="attr_powerName14" title="@powerName14" maxlength="35" tabindex="530"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType14">
+						<select name="attr_powerType14" title="@powerType14">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -5138,8 +5138,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND14" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND14">END</button>
+					<input type="text" name="attr_powerEND14" title="@powerEND14" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND14" title="%{buttonPowerEND14}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -5152,11 +5152,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect14" maxlength="25" tabindex="531"/>
-					<input type="text" name="attr_powerDice14" value="0d6" maxlength="16" tabindex="532"/>
+					<input type="text" name="attr_powerEffect14" title="@powerEffect14" maxlength="25" tabindex="531"/>
+					<input type="text" name="attr_powerDice14" title="@powerDice14" value="0d6" maxlength="16" tabindex="532"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll14" value="18" min="0" max="30" tabindex="533"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll14">Roll</button>
+					<input type="number" name="attr_powerSkillRoll14" title="@powerSkillRoll14" value="18" min="0" max="30" tabindex="533"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll14" title="%powerRoll14">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -5205,7 +5205,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText14" maxlength="512" tabindex="537"></textarea>
+					<textarea name="attr_powerText14" title="@powerText14" maxlength="512" tabindex="537"></textarea>
 				</div>
 			</div>
 			
@@ -5226,9 +5226,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName15" maxlength="35" tabindex="540"/>
+					<input type="text" value="" name="attr_powerName15" title="@powerName15" maxlength="35" tabindex="540"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType15">
+						<select name="attr_powerType15" title="@powerType15">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -5238,8 +5238,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND15" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND15">END</button>
+					<input type="text" name="attr_powerEND15" title="@powerEND15" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND15" title="%{buttonPowerEND15}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -5252,11 +5252,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect15" maxlength="25" tabindex="541"/>
-					<input type="text" name="attr_powerDice15" value="0d6" maxlength="16" tabindex="542"/>
+					<input type="text" name="attr_powerEffect15" title="@powerEffect15" maxlength="25" tabindex="541"/>
+					<input type="text" name="attr_powerDice15" title="@powerDice15" value="0d6" maxlength="16" tabindex="542"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll15" value="18" min="0" max="30" tabindex="543"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll15">Roll</button>
+					<input type="number" name="attr_powerSkillRoll15" title="@powerSkillRoll15" value="18" min="0" max="30" tabindex="543"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll15" title="%powerRoll15">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -5305,7 +5305,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText15" maxlength="512" tabindex="547"></textarea>
+					<textarea name="attr_powerText15" title="@powerText15" maxlength="512" tabindex="547"></textarea>
 				</div>
 			</div>
 			
@@ -5325,9 +5325,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName16" maxlength="35" tabindex="550"/>
+					<input type="text" value="" name="attr_powerName16" title="@powerName16" maxlength="35" tabindex="550"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType16">
+						<select name="attr_powerType16" title="@powerType16">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -5337,8 +5337,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND16" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND16">END</button>
+					<input type="text" name="attr_powerEND16" title="@powerEND16" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND16" title="%{buttonPowerEND16}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -5351,11 +5351,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect16" maxlength="25" tabindex="551"/>
-					<input type="text" name="attr_powerDice16" value="0d6" maxlength="16" tabindex="552"/>
+					<input type="text" name="attr_powerEffect16" title="@powerEffect16" maxlength="25" tabindex="551"/>
+					<input type="text" name="attr_powerDice16" title="@powerDice16" value="0d6" maxlength="16" tabindex="552"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll16" value="18" min="0" max="30" tabindex="553"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll16">Roll</button>
+					<input type="number" name="attr_powerSkillRoll16" title="@powerSkillRoll16" value="18" min="0" max="30" tabindex="553"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll16" title="%powerRoll16">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -5404,7 +5404,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText16" maxlength="512" tabindex="557"></textarea>
+					<textarea name="attr_powerText16" title="@powerText16" maxlength="512" tabindex="557"></textarea>
 				</div>
 			</div>
 			
@@ -5424,9 +5424,9 @@
 						</div>
 					</div>
 					
-					<input type="text" value="" name="attr_powerName17" maxlength="35" tabindex="560"/>
+					<input type="text" value="" name="attr_powerName17" title="@powerName17" maxlength="35" tabindex="560"/>
 					<div class="custom-select-alternate">
-						<select name="attr_powerType17">
+						<select name="attr_powerType17" title="@powerType17">
 							<option value="single" selected>Single Power</option>
 							<option value="multipower">Multipower</option>
 							<option value="variableSlot">Variable Slot</option>
@@ -5436,8 +5436,8 @@
 							<option value="unified">Unified</option>
 						</select>
 					</div>
-					<input type="text" name="attr_powerEND17" value="0" readonly tabindex="-1"/>
-					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND17">END</button>
+					<input type="text" name="attr_powerEND17" title="@powerEND17" value="0" readonly tabindex="-1"/>
+					<button type="action" class="button button-Power-END-right" tabindex="-1" tabindex="-1" name="act_buttonPowerEND17" title="%{buttonPowerEND17}">END</button>
 				</div>
 				
 				<!-- Power effect -->
@@ -5450,11 +5450,11 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect17" maxlength="25" tabindex="561"/>
-					<input type="text" name="attr_powerDice17" value="0d6" maxlength="16" tabindex="562"/>
+					<input type="text" name="attr_powerEffect17" title="@powerEffect17" maxlength="25" tabindex="561"/>
+					<input type="text" name="attr_powerDice17" title="@powerDice17" value="0d6" maxlength="16" tabindex="562"/>
 					<h1>Roll:</h1>
-					<input type="number" name="attr_powerSkillRoll17" value="18" min="0" max="30" tabindex="563"/>
-					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll17">Roll</button>
+					<input type="number" name="attr_powerSkillRoll17" title="@powerSkillRoll17" value="18" min="0" max="30" tabindex="563"/>
+					<button type="action" class="button buttonRollPower" tabindex="-1" name="act_powerRoll17" title="%powerRoll17">Roll</button>
 				</div>
 				
 				<!-- Points Block -->
@@ -5503,7 +5503,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText17" maxlength="512" tabindex="567"></textarea>
+					<textarea name="attr_powerText17" title="@powerText17" maxlength="512" tabindex="567"></textarea>
 				</div>
 			</div>
 		</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1204,7 +1204,7 @@
 			<div class="item-tab-gear-slide-flex-container-martial-maneuvers">
 				<!-- Slide showing special martial arts maneuvers. Entries need to be supplied by the user. -->
 				<div class="subitem-tab-gear-slide-flex-container-martial-maneuvers-heading">
-					<h1>Martial Maneuver</h1>
+					<h1>Martial Maneuvers</h1>
 					<h1>Phase</h1>
 					<h1>CP</h1>
 				</div>
@@ -1212,7 +1212,7 @@
 				<div class="item-tab-gear-slide-flex-container-martial-maneuvers-block">
 					
 					<!-- Standard Attack -->
-					<div class=".item-flex-maneuver">
+					<div class="item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
 							<div class="subitem-tab-gear-slide-flex-container-standard-attack">
 								<h1>Basic Attack:</h1>
@@ -1275,7 +1275,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage01">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage01}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck01">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck01}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -1334,7 +1341,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage02">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage02}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck02">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck02}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -1393,7 +1407,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage03">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage03}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck03">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck03}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -1452,7 +1473,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage04">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage04}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck04">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck04}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -1512,7 +1540,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage05">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage05}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck05">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck05}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -1571,7 +1606,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage06">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage06}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck06">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck06}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -1630,7 +1672,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage07">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage07}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck07">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck07}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -1689,7 +1738,14 @@
 										<label class="container-checkbox-small-gray">
 											<input type="checkbox" checked="checked" name="attr_martialNormalDamage08">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage08}"></span>
-										</label>	
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialBlockCheck08">
+											<span class="checkmark-small-gray" title="@{martialBlockCheck08}"></span>
+										</label>
 									</div>
 								</div>
 								
@@ -8679,7 +8735,6 @@
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["martialNormalDamage"+maneuverId] != 0;
-				// let stunMod = parseInt(values["weaponStunMod"+weaponId])||0;
 			
 				let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
 			
@@ -8688,7 +8743,7 @@
 				
 				// If isNormalDamage is TRUE, use the Normal Damage template.
 				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
-						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{martialManeuverName"+maneuverId+"}}} ";
+						+ "{{subtitle= Uses @{martialManeuverName"+maneuverId+"} to make a " + (isNormalDamage ? "normal" : "killing") + " attack.}} ";
 				if (values.displayDegreeOfSuccess != 0) {
 					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
 				} else {
@@ -8950,11 +9005,14 @@
 		//		killMessage += " x" + STUNx + "STUN*";
 		//	}
 		if (NSTUN != 1) {
-			normalMessage += " x" + NSTUN + "STUN";
+			// normalMessage += " x" + NSTUN + "STUN";
+			normalMessage += " STUNx" + NSTUN;
 		}
 		if (BODYx != 1) {
-			normalMessage += " x" + BODYx + " BODY";
-			killMessage += " x" + BODYx + " BODY";
+			// normalMessage += " x" + BODYx + "BODY";
+			// killMessage += " x" + BODYx + "BODY";
+			normalMessage += " BODYx" + BODYx;
+			killMessage += " BODYx" + BODYx;
 		}
 
 		var theHitLocation = {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -8859,14 +8859,17 @@
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');	
 		on(`clicked:showMartialRoll${maneuverId}`, (info) => {
-			getAttrs(["whisperToGM"], function(values) {
+			getAttrs(["whisperToGM", "maneuverNormalDamage"+maneuverId], function(values) {
 				var theRoll = values.whisperToGM||"";
+				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
 				
 				theRoll += "&{template:custom-show} {{title=@{character_name} - @{character_title}}} "
-					+ "{{subtitle= Martial Maneuver - @{martialManeuverName"+maneuverId+"}}} "
+					+ "{{subtitle= Maneuver - @{martialManeuverName"+maneuverId+"}}} "
 					+ "{{Phases=@{martialManeuverPhase"+maneuverId+"}}} "
+					+ "{{END = @{maneuverEndurance"+maneuverId+"}}} "
 					+ "{{OCV = @{martialManeuverOCV"+maneuverId+"}}} "
 					+ "{{DCV = @{martialManeuverDCV"+maneuverId+"}}} "
+					+ "{{Damage = @{maneuverDamage"+maneuverId+"}" + (isNormalDamage ? " N" : " K") + "}} "
 					+ "{{desc=@{martialManeuverEffect"+maneuverId+"}}}";
 				
 				startRoll(theRoll, (results) => {
@@ -8883,7 +8886,7 @@
 		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "treasures", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
+			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "treasures", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
@@ -8925,12 +8928,11 @@
 					if (subtractENDAmt != 0) {
 						theRoll	+= "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
 					}
-					
 				} 
 				
 				let debug = values.treasures||"";
 				// debug += " damage = " + values["hiddenManeuverDamage"+maneuverId];
-				debug += " roll = " + otherDmgType;
+				debug += " roll = " + theRoll;
 				setAttrs({
 					"treasures":debug
 				});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1257,19 +1257,18 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="169"/>
-										
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="167"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" tabindex="167"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" tabindex="168"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="168"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="169"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage01" title="@{martialDamage01}" value="0" maxlength="16" tabindex="169"/>
+										<input type="text" name="attr_martialDamage01" title="@{martialDamage01}" value="0" maxlength="12" tabindex="170"/>
 										
 										<h1>N:</h1>
 										
@@ -1278,7 +1277,6 @@
 											<span class="checkmark-small-gray" title="@{martialNormalDamage01}"></span>
 										</label>	
 									</div>
-									
 								</div>
 								
 								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
@@ -1297,7 +1295,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="170"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="172"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp02">
@@ -1308,23 +1306,39 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" tabindex="171"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}" tabindex="172"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll02" title="%{showMartialRoll02}" >Show</button>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" tabindex="173"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}" tabindex="174"/>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll02" title="%{martialAttackRoll02}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-02">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
-										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" tabindex="173"/>
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" tabindex="175"/>
 									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" tabindex="176"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" tabindex="174"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" tabindex="177"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage02" title="@{martialDamage02}" value="0" maxlength="12" tabindex="178"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage02">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage02}"></span>
+										</label>	
 									</div>
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" placeholder="Effect" tabindex="175"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll02" title="%{showMartialRoll02}" >Show</button>
 							</div>
 						</div>
 					</div>
@@ -1340,7 +1354,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName03" title="@{martialManeuverName03}" tabindex="176"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName03" title="@{martialManeuverName03}" tabindex="180"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp03">
@@ -1351,23 +1365,39 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" tabindex="177"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}" tabindex="178"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll03" title="%{showMartialRoll03}" >Show</button>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" tabindex="181"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}" tabindex="182"/>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll03" title="%{martialAttackRoll03}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-03">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
-										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" tabindex="179"/>
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" tabindex="183"/>
 									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" tabindex="184"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" tabindex="180"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" tabindex="185"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage03" title="@{martialDamage03}" value="0" maxlength="12" tabindex="186"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage03">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage03}"></span>
+										</label>	
 									</div>
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" placeholder="Effect" tabindex="181"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll03" title="%{showMartialRoll03}" >Show</button>
 							</div>
 						</div>
 					</div>
@@ -1383,7 +1413,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="182"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="188"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp04">
@@ -1394,26 +1424,43 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" tabindex="183"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}" tabindex="184"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll04" title="%{showMartialRoll04}" >Show</button>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" tabindex="189"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}" tabindex="190"/>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll04" title="%{martialAttackRoll04}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-04">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
-										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" tabindex="185"/>
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" tabindex="191"/>
 									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" tabindex="192"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" tabindex="186"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" tabindex="193"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage04" title="@{martialDamage04}" value="0" maxlength="12" tabindex="194"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage04">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage04}"></span>
+										</label>	
 									</div>
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" placeholder="Effect" tabindex="187"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll04" title="%{showMartialRoll04}" >Show</button>
 							</div>
 						</div>
 					</div>
+
 
 					<!-- Maneuver 05 -->
 					<div class="item-flex-maneuver">
@@ -1426,7 +1473,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="188"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="196"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp05">
@@ -1437,23 +1484,39 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" tabindex="189"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}" tabindex="190"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll05" title="%{showMartialRoll05}" >Show</button>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" tabindex="197"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}" tabindex="198"/>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll05" title="%{martialAttackRoll05}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-05">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
-										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" tabindex="191"/>
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" tabindex="199"/>
 									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" tabindex="200"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" tabindex="192"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" tabindex="201"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage05" title="@{martialDamage05}" value="0" maxlength="12" tabindex="202"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage05">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage05}"></span>
+										</label>	
 									</div>
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" placeholder="Effect" tabindex="193"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll05" title="%{showMartialRoll05}" >Show</button>
 							</div>
 						</div>
 					</div>
@@ -1469,7 +1532,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="194"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="204"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp06">
@@ -1480,23 +1543,39 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" tabindex="195"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}" tabindex="196"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll06" title="%{showMartialRoll06}" >Show</button>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" tabindex="205"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}" tabindex="206"/>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll06" title="%{martialAttackRoll06}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-06">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
-										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" tabindex="197"/>
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" tabindex="207"/>
 									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" tabindex="208"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" tabindex="198"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" tabindex="209"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage06" title="@{martialDamage06}" value="0" maxlength="12" tabindex="210"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage06">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage06}"></span>
+										</label>	
 									</div>
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" placeholder="Effect" tabindex="199"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll06" title="%{showMartialRoll06}" >Show</button>
 							</div>
 						</div>
 					</div>
@@ -1512,7 +1591,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="200"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="212"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp07">
@@ -1523,23 +1602,39 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" tabindex="201"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}" tabindex="202"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll07" title="%{showMartialRoll07}" >Show</button>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" tabindex="213"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}" tabindex="214"/>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll07" title="%{martialAttackRoll07}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-07">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
-										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" tabindex="203"/>
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" tabindex="215"/>
 									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" tabindex="216"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" tabindex="204"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" tabindex="217"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage07" title="@{martialDamage07}" value="0" maxlength="12" tabindex="218"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage07">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage07}"></span>
+										</label>	
 									</div>
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" placeholder="Effect" tabindex="205"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll07" title="%{showMartialRoll07}">Show</button>
 							</div>
 						</div>
 					</div>
@@ -1555,7 +1650,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="206"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="220"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp08">
@@ -1566,27 +1661,43 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" tabindex="207"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}" tabindex="208"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll08" title="%{showMartialRoll08}" >Show</button>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" tabindex="221"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}" tabindex="222"/>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll08" title="%{martialAttackRoll08}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-08">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
-										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" tabindex="209"/>
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" tabindex="223"/>
 									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" tabindex="224"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" tabindex="210"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" tabindex="225"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage08" title="@{martialDamage08}" value="0" maxlength="12" tabindex="226"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage08">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage08}"></span>
+										</label>	
 									</div>
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" placeholder="Effect" tabindex="211"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll08" title="%{showMartialRoll08}">Show</button>
 							</div>
 						</div>
-					</div>
-				</div>		
+					</div>	
+				</div>
 				
 				<!-- Range Modifier Table -->
 				<div class="subitem-tab-gear-slide-flex-container-range-modifiers">

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1236,7 +1236,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="164"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="164"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp01">
@@ -1279,7 +1279,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="170"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="170"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp02">
@@ -1322,7 +1322,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName03" title="@{martialManeuverName03}" tabindex="176"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName03" title="@{martialManeuverName03}" tabindex="176"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp03">
@@ -1365,7 +1365,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="182"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="182"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp04">
@@ -1408,7 +1408,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="188"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="188"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp05">
@@ -1451,7 +1451,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="194"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="194"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp06">
@@ -1494,7 +1494,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="200"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="200"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp07">
@@ -1537,7 +1537,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="24" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="206"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="206"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp08">

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1247,7 +1247,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="170"/>
+							<input type="text" name="attr_martialManeuverName01" title="@{martialManeuverName01}" value="" maxlength="34" tabindex="170"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp01">
@@ -1258,8 +1258,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" tabindex="171"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" tabindex="172"/>
+							<input type="text" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" value="1/2" tabindex="171"/>
+							<input type="number" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" value="0" min="0" step="1" tabindex="172"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack01" title="%{maneuverAttack01}">Roll</button>
 						</div>
 						
@@ -1268,19 +1268,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="173"/>
-										<input type="number" value="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
+										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="" maxlength="100" tabindex="173"/>
+										<input type="number" value="0" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" tabindex="175"/>
+										<input type="number" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" value="0" step="1" tabindex="175"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="176"/>
+										<input type="number" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" value="0" step="1" tabindex="176"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="" name="attr_maneuverDamage01" title="@{maneuverDamage01}" maxlength="12" tabindex="177"/>
+										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="0" maxlength="12" tabindex="177"/>
 										
 										<h1>N:</h1>
 										
@@ -1317,7 +1317,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="180"/>
+							<input type="text" name="attr_martialManeuverName02" title="@{martialManeuverName02}" value="" maxlength="34" tabindex="180"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp02">
@@ -1328,8 +1328,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" tabindex="181"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}" tabindex="182"/>
+							<input type="text" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" value="1/2" tabindex="181"/>
+							<input type="number" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}"  value="0" min="0" step="1" tabindex="182"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack02" title="%{maneuverAttack02}">Roll</button>
 						</div>
 						
@@ -1338,19 +1338,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value=" " maxlength="100" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" tabindex="183"/>
-										<input type="number" value="0" name="attr_maneuverEndurance02" title="@{maneuverEndurance02}" tabindex="184"/>
+										<input type="text" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" value="" maxlength="100" tabindex="183"/>
+										<input type="number" name="attr_maneuverEndurance02" title="@{maneuverEndurance02}" value="0" step="1" min="0" tabindex="184"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" tabindex="185"/>
+										<input type="number" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" value="0" step="1" tabindex="185"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" tabindex="186"/>
+										<input type="number" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" value="0" step="1" tabindex="186"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage02" title="@{maneuverDamage02}" maxlength="12" tabindex="187"/>
+										<input type="text" name="attr_maneuverDamage02" title="@{maneuverDamage02}" value="0" maxlength="12" tabindex="187"/>
 										
 										<h1>N:</h1>
 										
@@ -1387,7 +1387,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName03" title="@{martialManeuverName03}" tabindex="190"/>
+							<input type="text" name="attr_martialManeuverName03" title="@{martialManeuverName03}" value="" maxlength="34" tabindex="190"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp03">
@@ -1398,8 +1398,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" tabindex="191"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}" tabindex="192"/>
+							<input type="text" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" value="1/2" tabindex="191"/>
+							<input type="number" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}"  value="0" min="0" step="1" tabindex="192"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack03" title="%{maneuverAttack03}">Roll</button>
 						</div>
 						
@@ -1408,19 +1408,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value=" " maxlength="100" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" tabindex="193"/>
-										<input type="number" value="0" name="attr_maneuverEndurance03" title="@{maneuverEndurance03}" tabindex="194"/>
+										<input type="text" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" value="" maxlength="100" tabindex="193"/>
+										<input type="number" name="attr_maneuverEndurance03" title="@{maneuverEndurance03}" value="0" step="1" min="0" tabindex="194"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" tabindex="195"/>
+										<input type="number" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" value="0" step="1" tabindex="195"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" tabindex="196"/>
+										<input type="number" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" value="0" step="1" tabindex="196"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage03" title="@{maneuverDamage03}" maxlength="12" tabindex="197"/>
+										<input type="text" name="attr_maneuverDamage03" title="@{maneuverDamage03}" value="0" maxlength="12" tabindex="197"/>
 										
 										<h1>N:</h1>
 										
@@ -1457,7 +1457,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="200"/>
+							<input type="text" name="attr_martialManeuverName04" title="@{martialManeuverName04}" value="" maxlength="34" tabindex="200"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp04">
@@ -1468,8 +1468,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" tabindex="201"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}" tabindex="202"/>
+							<input type="text" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" value="1/2" tabindex="201"/>
+							<input type="number" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}"  value="0" min="0" step="1" tabindex="202"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack04" title="%{maneuverAttack04}">Roll</button>
 						</div>
 						
@@ -1478,19 +1478,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" tabindex="203"/>
-										<input type="number" value="0" name="attr_maneuverEndurance04" title="@{maneuverEndurance04}" tabindex="204"/>
+										<input type="text" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" value="" maxlength="100" tabindex="203"/>
+										<input type="number" name="attr_maneuverEndurance04" title="@{maneuverEndurance04}" value="0" step="1" min="0" tabindex="204"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" tabindex="205"/>
+										<input type="number" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" value="0" step="1" tabindex="205"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" tabindex="206"/>
+										<input type="number" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" value="0" step="1" tabindex="206"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage04" title="@{maneuverDamage04}" maxlength="12" tabindex="207"/>
+										<input type="text" name="attr_maneuverDamage04" title="@{maneuverDamage04}" value="0" maxlength="12" tabindex="207"/>
 										
 										<h1>N:</h1>
 										
@@ -1527,7 +1527,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="210"/>
+							<input type="text" name="attr_martialManeuverName05" title="@{martialManeuverName05}" value="" maxlength="34" tabindex="210"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp05">
@@ -1538,8 +1538,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" tabindex="211"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}" tabindex="212"/>
+							<input type="text" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" value="1/2" tabindex="211"/>
+							<input type="number" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}"  value="0" min="0" step="1" tabindex="212"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack05" title="%{maneuverAttack05}">Roll</button>
 						</div>
 						
@@ -1548,19 +1548,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" tabindex="213"/>
-										<input type="number" value="0" name="attr_maneuverEndurance05" title="@{maneuverEndurance05}" tabindex="214"/>
+										<input type="text" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" value="" maxlength="100" tabindex="213"/>
+										<input type="number" name="attr_maneuverEndurance05" title="@{maneuverEndurance05}" value="0" step="1" min="0" tabindex="214"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" tabindex="215"/>
+										<input type="number" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" value="0" step="1" tabindex="215"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" tabindex="216"/>
+										<input type="number" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" value="0" step="1" tabindex="216"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage05" title="@{maneuverDamage05}" maxlength="12" tabindex="217"/>
+										<input type="text" name="attr_maneuverDamage05" title="@{maneuverDamage05}" value="0" maxlength="12" tabindex="217"/>
 										
 										<h1>N:</h1>
 										
@@ -1597,7 +1597,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="220"/>
+							<input type="text" name="attr_martialManeuverName06" title="@{martialManeuverName06}" value="" maxlength="34" tabindex="220"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp06">
@@ -1608,8 +1608,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" tabindex="221"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}" tabindex="222"/>
+							<input type="text" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" value="1/2" tabindex="221"/>
+							<input type="number" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}"  value="0" min="0" step="1" tabindex="222"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack06" title="%{maneuverAttack06}">Roll</button>
 						</div>
 						
@@ -1618,19 +1618,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" tabindex="223"/>
-										<input type="number" value="0" name="attr_maneuverEndurance06" title="@{maneuverEndurance06}" tabindex="224"/>
+										<input type="text" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" value="" maxlength="100" tabindex="223"/>
+										<input type="number" name="attr_maneuverEndurance06" title="@{maneuverEndurance06}" value="0" step="1" min="0" tabindex="224"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" tabindex="225"/>
+										<input type="number" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" value="0" step="1" tabindex="225"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" tabindex="226"/>
+										<input type="number" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" value="0" step="1" tabindex="226"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage06" title="@{maneuverDamage06}" maxlength="12" tabindex="227"/>
+										<input type="text" name="attr_maneuverDamage06" title="@{maneuverDamage06}" value="0" maxlength="12" tabindex="227"/>
 										
 										<h1>N:</h1>
 										
@@ -1667,7 +1667,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="230"/>
+							<input type="text" name="attr_martialManeuverName07" title="@{martialManeuverName07}" value="" maxlength="34" tabindex="230"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp07">
@@ -1678,8 +1678,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" tabindex="231"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}" tabindex="232"/>
+							<input type="text" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" value="1/2" tabindex="231"/>
+							<input type="number" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}"  value="0" min="0" step="1" tabindex="232"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack07" title="%{maneuverAttack07}">Roll</button>
 						</div>
 						
@@ -1688,19 +1688,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" tabindex="233"/>
-										<input type="number" value="0" name="attr_maneuverEndurance07" title="@{maneuverEndurance07}" tabindex="234"/>
+										<input type="text" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" value="" maxlength="100" tabindex="233"/>
+										<input type="number" name="attr_maneuverEndurance07" title="@{maneuverEndurance07}" value="0" step="1" min="0" tabindex="234"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" tabindex="235"/>
+										<input type="number" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" value="0" step="1" tabindex="235"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" tabindex="236"/>
+										<input type="number" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" value="0" step="1" tabindex="236"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage07" title="@{maneuverDamage07}" maxlength="12" tabindex="237"/>
+										<input type="text" name="attr_maneuverDamage07" title="@{maneuverDamage07}" value="0" maxlength="12" tabindex="237"/>
 										
 										<h1>N:</h1>
 										
@@ -1737,7 +1737,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="240"/>
+							<input type="text" name="attr_martialManeuverName08" title="@{martialManeuverName08}" value="" maxlength="34" tabindex="240"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp08">
@@ -1748,8 +1748,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" tabindex="241"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}" tabindex="242"/>
+							<input type="text" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" value="1/2" tabindex="241"/>
+							<input type="number" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}"  value="0" min="0" step="1" tabindex="242"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack08" title="%{maneuverAttack08}">Roll</button>
 						</div>
 						
@@ -1758,19 +1758,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" tabindex="243"/>
-										<input type="number" value="0" name="attr_maneuverEndurance08" title="@{maneuverEndurance08}" tabindex="244"/>
+										<input type="text" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" value="" maxlength="100" tabindex="243"/>
+										<input type="number" name="attr_maneuverEndurance08" title="@{maneuverEndurance08}" value="0" step="1" min="0" tabindex="244"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" tabindex="245"/>
+										<input type="number" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" value="0" step="1" tabindex="245"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" tabindex="246"/>
+										<input type="number" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" value="0" step="1" tabindex="246"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage08" title="@{maneuverDamage08}" maxlength="12" tabindex="247"/>
+										<input type="text" name="attr_maneuverDamage08" title="@{maneuverDamage08}" value="0" maxlength="12" tabindex="247"/>
 										
 										<h1>N:</h1>
 										
@@ -1807,7 +1807,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value=" " maxlength="34" name="attr_martialManeuverName09" title="@{martialManeuverName09}" tabindex="250"/>
+							<input type="text" name="attr_martialManeuverName09" title="@{martialManeuverName09}" value="" maxlength="34" tabindex="250"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp09">
@@ -1818,8 +1818,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase09" title="@{martialManeuverPhase09}" tabindex="251"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP09" title="@{martialManeuverCP09}" tabindex="252"/>
+							<input type="text" name="attr_martialManeuverPhase09" title="@{martialManeuverPhase09}" value="1/2" tabindex="251"/>
+							<input type="number" name="attr_martialManeuverCP09" title="@{martialManeuverCP09}"  value="0" min="0" step="1" tabindex="252"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack09" title="%{maneuverAttack09}">Roll</button>
 						</div>
 						
@@ -1828,19 +1828,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" tabindex="253"/>
-										<input type="number" value="0" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" tabindex="254"/>
+										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="" maxlength="100" tabindex="253"/>
+										<input type="number" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" value="0" step="1" min="0" tabindex="254"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV09" title="@{martialManeuverOCV09}" tabindex="255"/>
+										<input type="number" name="attr_martialManeuverOCV09" title="@{martialManeuverOCV09}" value="0" step="1" tabindex="255"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" tabindex="256"/>
+										<input type="number" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" value="0" step="1" tabindex="256"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="0" name="attr_maneuverDamage09" title="@{maneuverDamage09}" maxlength="12" tabindex="257"/>
+										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="0" maxlength="12" tabindex="257"/>
 										
 										<h1>N:</h1>
 										
@@ -6071,7 +6071,8 @@
 				</div>
 				
 				<div class="item-version-information">
-					<input type="text" value="2.2" name="attr_version" title="@{version}" readonly tabindex="-1"/>
+					<!-- Update version before release. -->
+					<input type="text" value="2.3" name="attr_version" title="@{version}" readonly tabindex="-1"/>
 				</div>
 			</div>
 		</div>	
@@ -6123,7 +6124,7 @@
 <input type="hidden" name="attr_hiddenWeaponDamage03"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage04"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage05"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage01"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage01"  value="2d6"/>
 <input type="hidden" name="attr_hiddenManeuverDamage02"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage03"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage04"  value="0"/>
@@ -6287,72 +6288,6 @@
 	</div>
 </rolltemplate>
 
-<!-- Jackob's Roll Template for killing damage maneuvers -->
-<!-- <rolltemplate class="sheet-rolltemplate-custom-maneuver">
-	<div class="sheet-template-wrapper">
-		<div class="sheet-container sheet-color-{{color}}">
-			<div class="sheet-header">
-				{{#title}}<div class="sheet-title">{{title}}</div>{{/title}}
-				{{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
-			</div>
-			<div class="sheet-content">
-				{{#allprops() title subtitle desc color HITLOC STUN BODY}}
-				<div class="sheet-key">{{key}}</div>
-				<div class="sheet-value">{{value}}</div>
-				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
-				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}} -->
-				
-				<!-- Stun, Body, and Hit Location go at the end -->
-				<!-- {{#STUN}}
-				<div class="sheet-key">STUN</div>
-				<div class="sheet-value">{{computed::STUN}}</div>
-				{{/STUN}}
-				{{#BODY}}
-				<div class="sheet-key">BODY</div>
-				<div class="sheet-value">{{computed::BODY}}</div>
-				{{/BODY}}
-				{{#HITLOC}}
-				<div class="sheet-key">Hit Location</div>
-				<div class="sheet-value">{{computed::HITLOC}}</div>
-				{{/HITLOC}}
-			</div>
-		</div>
-	</div>
-</rolltemplate> -->
-
-<!-- Jackob's Roll Template for normal damage maneuvers -->
-<!-- <rolltemplate class="sheet-rolltemplate-custom-normal-maneuver">
-	<div class="sheet-template-wrapper">
-		<div class="sheet-container sheet-color-{{color}}">
-			<div class="sheet-header">
-				{{#title}}<div class="sheet-title">{{title}}</div>{{/title}}
-				{{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
-			</div>
-			<div class="sheet-content">
-				{{#allprops() title subtitle desc color HITLOC STUN BODY}}
-				<div class="sheet-key">{{key}}</div>
-				<div class="sheet-value">{{value}}</div>
-				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
-				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}} -->
-				
-				<!-- Stun, Body, and Hit Location go at the end -->
-				<!-- {{#STUN}}
-				<div class="sheet-key">STUN</div>
-				<div class="sheet-value">{{computed::STUN}}</div>
-				{{/STUN}}
-				{{#BODY}}
-				<div class="sheet-key">BODY</div>
-				<div class="sheet-value">{{computed::BODY}}</div>
-				{{/BODY}}
-				{{#HITLOC}}
-				<div class="sheet-key">Hit Location</div>
-				<div class="sheet-value">{{computed::HITLOC}}</div>
-				{{/HITLOC}}
-			</div>
-		</div>
-	</div>
-</rolltemplate> -->
-
 <!-- Jackob's Roll Template for armor activation-->
 <rolltemplate class="sheet-rolltemplate-custom-activate">
 	<div class="sheet-template-wrapper">
@@ -6497,7 +6432,7 @@
 		
 		if (version < 1.1) {
 			values = await _getAttrs(["intelligenceChance", "enhancedPerceptionModifier", "body", "stun", "endurance", "strength", "optionSuperHeroicEndurance"]);
-			var hiddenBasicEndurance = (parseInt(values.strength)||0) / (values.optionSuperHeroicEndurance != 0 ? 5 : 10);
+			var hiddenBasicEndurance = (parseInt(values.strength)||0) / (values.optionSuperHeroicEndurance != 0 ? 10 : 5);
 
 			attributes.perceptionEnhanced = parseInt(values.intelligenceChance)||11 + parseInt(values.enhancedPerceptionModifier)||0;
 			attributes.CurrentBODY_max = parseInt(values.body)||0;
@@ -8749,14 +8684,14 @@
 						
 	/* Calculate weapon endurance costs */
 	on("change:optionSuperHeroicEndurance change:weaponStrength01 change:weaponStrength02 change:weaponStrength03 change:weaponStrength04 change:weaponStrength05 change:shieldStrength change:strength", function() {
-		getAttrs(["optionSuperHeroicEndurance", "weaponStrength01","weaponStrength02","weaponStrength03","weaponStrength04","weaponStrength05","shieldStrength","strength"], function(values) {
+		getAttrs(["optionSuperHeroicEndurance", "weaponStrength01", "weaponStrength02", "weaponStrength03", "weaponStrength04", "weaponStrength05","shieldStrength", "strength"], function(values) {
 			// If optionSuperHeroicEndurance is true, endurance cost is 1 per 5 strength, otherwise it is 1 per 10 strength used.
 											 
 			optionSuperHeroic = values.optionSuperHeroicEndurance;
-			let enduranceCostFactor = 10;
+			let enduranceCostFactor = 5;
 							
 			if (optionSuperHeroic != 0) {
-				enduranceCostFactor=5;
+				enduranceCostFactor = 10;
 			}
 
 			let enduranceCost01= heroRoundLow( (parseInt(values.weaponStrength01)||0)/enduranceCostFactor );
@@ -8960,32 +8895,38 @@
 				let dmgType = isNormalDamage ? "STUN" : "BODY";
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 				
-				if (isBlocking) {
-					// Use the Blocking template.
-					theRoll += "&{template:custom-defense} {{title=@{character_name} - @{character_title}}} " + "{{subtitle=Blocks with @{martialManeuverName"+maneuverId+"}}} ";
-					if (values.displayDegreeOfSuccess != 0) {
-						theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll] + @{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} ";
-					} else {
-						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} " + "{{Result=[[3d6cf6cs1]]}} ";
-					}
-					if (subtractENDAmt != 0) {
-						theRoll	+= "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
-					}
-					
-				} else {
+				if (!isBlocking) {
 					// If isNormalDamage is TRUE, use the Normal Damage template. Else use the killing template.
-					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "") + "-attack} {{title=@{character_name} - @{character_title}}} " + "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{martialManeuverName"+maneuverId+"}}} ";
+					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "") 
+						+ "-attack} {{title=@{character_name} - @{character_title}}} " 
+						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") 
+						+ " attack with @{martialManeuverName"+maneuverId+"}}} ";
 					if (values.displayDegreeOfSuccess != 0) {
 						theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifiers|0}[Modifier]]]}} ";
 					} else {
-						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifiers|0}[Modifier] ]]}} " + "{{Result=[[3d6cf6cs1]]}}";
+						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifiers|0}[Modifier] ]]}} " 
+							+ "{{Result=[[3d6cf6cs1]]}}";
 					}
 					theRoll	+= (subtractENDAmt ? "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}} " : "") 
 						+ "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}} " 
 						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 					if (useHitLocations)
 						theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
-				}
+				} else {
+					// Use the Blocking template.
+					theRoll += "&{template:custom-defense} {{title=@{character_name} - @{character_title}}} " 
+						+ "{{subtitle=Blocks with @{martialManeuverName"+maneuverId+"}}} ";
+					if (values.displayDegreeOfSuccess != 0) {
+						theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll] + @{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} ";
+					} else {
+						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] + ?{Modifiers|0}[Modifier]]]}} " 
+							+ "{{Result=[[3d6cf6cs1]]}} ";
+					}
+					if (subtractENDAmt != 0) {
+						theRoll	+= "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
+					}
+					
+				} 
 				
 				let debug = values.treasures||"";
 				// debug += " damage = " + values["hiddenManeuverDamage"+maneuverId];
@@ -9331,7 +9272,7 @@
 		// This function attempts to clean damage text input into text more likely to be rollable dice.
 		// Only characters 0-9, d, D, +, and - are passed to attack rolls.
 		
-		getAttrs(["shieldDamage","weaponDamage01","weaponDamage02","weaponDamage03","weaponDamage04","weaponDamage05","strength"], function(values) {
+		getAttrs(["shieldDamage", "weaponDamage01", "weaponDamage02", "weaponDamage03", "weaponDamage04", "weaponDamage05", "strength"], function(values) {
 		
 			var theShieldDamage=values.shieldDamage;
 			theShieldDamage=theShieldDamage.replace(/[^\ddD\\+\\-]/g,"");
@@ -9364,21 +9305,22 @@
 			var theStrengthDamage=theNumberOfD6.concat("d6+",theNumberOfD3.toString(),"d3");
 			
 			setAttrs({
-				hiddenShieldDamage01:theShieldDamage,
-				hiddenWeaponDamage01:theWeaponDamage01,
-				hiddenWeaponDamage02:theWeaponDamage02,
-				hiddenWeaponDamage03:theWeaponDamage03,
-				hiddenWeaponDamage04:theWeaponDamage04,
-				hiddenWeaponDamage05:theWeaponDamage05,
-				hiddenBasicDamage:theStrengthDamage
+				"hiddenShieldDamage01":theShieldDamage,
+				"hiddenWeaponDamage01":theWeaponDamage01,
+				"hiddenWeaponDamage02":theWeaponDamage02,
+				"hiddenWeaponDamage03":theWeaponDamage03,
+				"hiddenWeaponDamage04":theWeaponDamage04,
+				"hiddenWeaponDamage05":theWeaponDamage05,
+				"hiddenBasicDamage":theStrengthDamage
 			});
 		});
 	});
 
+
+	// Roll attack and damage dice for Weapon XX.
 	arrayOf(maxWeaponNum).forEach(num => {
 		var weaponId = String(num).padStart(2,'0');	
 		on(`clicked:attackWeapon${weaponId}`, (info) => {
-			// Roll attack and damage dice for Weapon XX.
 			
 			getAttrs(["weaponNormalDamage"+weaponId, "weaponStunMod"+weaponId, "weaponEndurance"+weaponId, "weaponAreaEffect"+weaponId,
 					"optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1209,26 +1209,26 @@
 				<div class="item-tab-gear-slide-flex-container-martial-maneuvers-block">
 					
 					<!-- These are needed here for Maneuver Roll button Normal/Killing coloring. -->
-					<input type="hidden" class="maneuver-normal-damage01" name="attr_maneuverNormalDamage01" value="on">
-					<input type="hidden" class="maneuver-normal-damage02" name="attr_maneuverNormalDamage02" value="on">
-					<input type="hidden" class="maneuver-normal-damage03" name="attr_maneuverNormalDamage03" value="on">
-					<input type="hidden" class="maneuver-normal-damage04" name="attr_maneuverNormalDamage04" value="on">
-					<input type="hidden" class="maneuver-normal-damage05" name="attr_maneuverNormalDamage05" value="on">
-					<input type="hidden" class="maneuver-normal-damage06" name="attr_maneuverNormalDamage06" value="on">
-					<input type="hidden" class="maneuver-normal-damage07" name="attr_maneuverNormalDamage07" value="on">
-					<input type="hidden" class="maneuver-normal-damage08" name="attr_maneuverNormalDamage08" value="on">
-					<input type="hidden" class="maneuver-normal-damage09" name="attr_maneuverNormalDamage09" value="on">
+					<input type="hidden" class="maneuver-normal-damage01" name="attr_martialManeuverNormal01" value="on">
+					<input type="hidden" class="maneuver-normal-damage02" name="attr_martialManeuverNormal02" value="on">
+					<input type="hidden" class="maneuver-normal-damage03" name="attr_martialManeuverNormal03" value="on">
+					<input type="hidden" class="maneuver-normal-damage04" name="attr_martialManeuverNormal04" value="on">
+					<input type="hidden" class="maneuver-normal-damage05" name="attr_martialManeuverNormal05" value="on">
+					<input type="hidden" class="maneuver-normal-damage06" name="attr_martialManeuverNormal06" value="on">
+					<input type="hidden" class="maneuver-normal-damage07" name="attr_martialManeuverNormal07" value="on">
+					<input type="hidden" class="maneuver-normal-damage08" name="attr_martialManeuverNormal08" value="on">
+					<input type="hidden" class="maneuver-normal-damage09" name="attr_martialManeuverNormal09" value="on">
 					
 					<!-- These are needed here for Maneuver Roll button defense coloring. -->
-					<input type="hidden" class="maneuver-block01" name="attr_maneuverBlock01">
-					<input type="hidden" class="maneuver-block02" name="attr_maneuverBlock02">
-					<input type="hidden" class="maneuver-block03" name="attr_maneuverBlock03">
-					<input type="hidden" class="maneuver-block04" name="attr_maneuverBlock04">
-					<input type="hidden" class="maneuver-block05" name="attr_maneuverBlock05">
-					<input type="hidden" class="maneuver-block06" name="attr_maneuverBlock06">
-					<input type="hidden" class="maneuver-block07" name="attr_maneuverBlock07">
-					<input type="hidden" class="maneuver-block08" name="attr_maneuverBlock08">
-					<input type="hidden" class="maneuver-block09" name="attr_maneuverBlock09">
+					<input type="hidden" class="maneuver-block01" name="attr_martialManeuverBlock01">
+					<input type="hidden" class="maneuver-block02" name="attr_martialManeuverBlock02">
+					<input type="hidden" class="maneuver-block03" name="attr_martialManeuverBlock03">
+					<input type="hidden" class="maneuver-block04" name="attr_martialManeuverBlock04">
+					<input type="hidden" class="maneuver-block05" name="attr_martialManeuverBlock05">
+					<input type="hidden" class="maneuver-block06" name="attr_martialManeuverBlock06">
+					<input type="hidden" class="maneuver-block07" name="attr_martialManeuverBlock07">
+					<input type="hidden" class="maneuver-block08" name="attr_martialManeuverBlock08">
+					<input type="hidden" class="maneuver-block09" name="attr_martialManeuverBlock09">
 					
 					<!-- Set the first maneuver to its expanded state as default. -->
 					<input type="hidden" class="sheet-maneuver-toggle" name="attr_maneuverToggle"  value="maneuverExpand01" />
@@ -1268,7 +1268,7 @@
 										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="" maxlength="100" tabindex="183"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod01" title="@{martialManeuverStunMod01}" value="0" min="0" max="9" step="1" tabindex="184"/>
-										<input type="number" value="" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="185"/>
+										<input type="number" value="" step="1" min="0" name="attr_martialManeuverEndurance01" title="@{martialManeuverEndurance01}" tabindex="185"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1279,27 +1279,27 @@
 										<input type="number" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" value="0" step="1" tabindex="187"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="" maxlength="12" tabindex="188"/>
+										<input type="text" name="attr_martialManeuverDamage01" title="@{martialManeuverDamage01}" value="" maxlength="12" tabindex="188"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage01">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage01}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal01">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal01}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock01">
-											<span class="checkmark-small-gray" title="@{maneuverBlock01}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock01">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock01}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND01" title="%{buttonManeuverEND01}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll01" title="%{showManeuverRoll01}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1340,7 +1340,7 @@
 										<input type="text" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" value="" maxlength="100" tabindex="193"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod02" title="@{martialManeuverStunMod02}" value="0" min="0" max="9" step="1" tabindex="194"/>
-										<input type="number" name="attr_maneuverEndurance02" title="@{maneuverEndurance02}" value="0" step="1" min="0" tabindex="195"/>
+										<input type="number" name="attr_martialManeuverEndurance02" title="@{martialManeuverEndurance02}" value="0" step="1" min="0" tabindex="195"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1351,27 +1351,27 @@
 										<input type="number" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" value="0" step="1" tabindex="197"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage02" title="@{maneuverDamage02}" value="0" maxlength="12" tabindex="198"/>
+										<input type="text" name="attr_martialManeuverDamage02" title="@{martialManeuverDamage02}" value="0" maxlength="12" tabindex="198"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage02">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage02}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal02">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal02}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock02">
-											<span class="checkmark-small-gray" title="@{maneuverBlock02}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock02">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock02}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND02" title="%{buttonManeuverEND02}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll02" title="%{showMartialRoll02}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll02" title="%{showManeuverRoll02}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1412,7 +1412,7 @@
 										<input type="text" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" value="" maxlength="100" tabindex="203"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod03" title="@{martialManeuverStunMod03}" value="0" min="0" max="9" step="1" tabindex="204"/>
-										<input type="number" name="attr_maneuverEndurance03" title="@{maneuverEndurance03}" value="0" step="1" min="0" tabindex="205"/>
+										<input type="number" name="attr_martialManeuverEndurance03" title="@{martialManeuverEndurance03}" value="0" step="1" min="0" tabindex="205"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1423,27 +1423,27 @@
 										<input type="number" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" value="0" step="1" tabindex="207"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage03" title="@{maneuverDamage03}" value="0" maxlength="12" tabindex="208"/>
+										<input type="text" name="attr_martialManeuverDamage03" title="@{martialManeuverDamage03}" value="0" maxlength="12" tabindex="208"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage03">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage03}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal03">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal03}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock03">
-											<span class="checkmark-small-gray" title="@{maneuverBlock03}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock03">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock03}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND03" title="%{buttonManeuverEND03}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll03" title="%{showMartialRoll03}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll03" title="%{showManeuverRoll03}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1484,7 +1484,7 @@
 										<input type="text" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" value="" maxlength="100" tabindex="213"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod04" title="@{martialManeuverStunMod04}" value="0" min="0" max="9" step="1" tabindex="214"/>
-										<input type="number" name="attr_maneuverEndurance04" title="@{maneuverEndurance04}" value="0" step="1" min="0" tabindex="215"/>
+										<input type="number" name="attr_martialManeuverEndurance04" title="@{martialManeuverEndurance04}" value="0" step="1" min="0" tabindex="215"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1495,27 +1495,27 @@
 										<input type="number" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" value="0" step="1" tabindex="217"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage04" title="@{maneuverDamage04}" value="0" maxlength="12" tabindex="218"/>
+										<input type="text" name="attr_martialManeuverDamage04" title="@{martialManeuverDamage04}" value="0" maxlength="12" tabindex="218"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage04">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage04}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal04">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal04}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock04">
-											<span class="checkmark-small-gray" title="@{maneuverBlock04}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock04">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock04}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND04" title="%{buttonManeuverEND04}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll04" title="%{showMartialRoll04}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll04" title="%{showManeuverRoll04}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1556,7 +1556,7 @@
 										<input type="text" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" value="" maxlength="100" tabindex="223"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod05" title="@{martialManeuverStunMod05}" value="0" min="0" max="9" step="1" tabindex="224"/>
-										<input type="number" name="attr_maneuverEndurance05" title="@{maneuverEndurance05}" value="0" step="1" min="0" tabindex="225"/>
+										<input type="number" name="attr_martialManeuverEndurance05" title="@{martialManeuverEndurance05}" value="0" step="1" min="0" tabindex="225"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1567,27 +1567,27 @@
 										<input type="number" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" value="0" step="1" tabindex="227"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage05" title="@{maneuverDamage05}" value="0" maxlength="12" tabindex="228"/>
+										<input type="text" name="attr_martialManeuverDamage05" title="@{martialManeuverDamage05}" value="0" maxlength="12" tabindex="228"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage05">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage05}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal05">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal05}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock05">
-											<span class="checkmark-small-gray" title="@{maneuverBlock05}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock05">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock05}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND05" title="%{buttonManeuverEND05}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll05" title="%{showMartialRoll05}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll05" title="%{showManeuverRoll05}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1628,7 +1628,7 @@
 										<input type="text" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" value="" maxlength="100" tabindex="233"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod06" title="@{martialManeuverStunMod06}" value="0" min="0" max="9" step="1" tabindex="234"/>
-										<input type="number" name="attr_maneuverEndurance06" title="@{maneuverEndurance06}" value="0" step="1" min="0" tabindex="235"/>
+										<input type="number" name="attr_martialManeuverEndurance06" title="@{martialManeuverEndurance06}" value="0" step="1" min="0" tabindex="235"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1639,27 +1639,27 @@
 										<input type="number" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" value="0" step="1" tabindex="237"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage06" title="@{maneuverDamage06}" value="0" maxlength="12" tabindex="238"/>
+										<input type="text" name="attr_martialManeuverDamage06" title="@{martialManeuverDamage06}" value="0" maxlength="12" tabindex="238"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage06">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage06}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal06">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal06}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock06">
-											<span class="checkmark-small-gray" title="@{maneuverBlock06}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock06">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock06}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND06" title="%{buttonManeuverEND06}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll06" title="%{showMartialRoll06}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll06" title="%{showManeuverRoll06}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1700,7 +1700,7 @@
 										<input type="text" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" value="" maxlength="100" tabindex="243"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod07" title="@{martialManeuverStunMod07}" value="0" min="0" max="9" step="1" tabindex="244"/>
-										<input type="number" name="attr_maneuverEndurance07" title="@{maneuverEndurance07}" value="0" step="1" min="0" tabindex="245"/>
+										<input type="number" name="attr_martialManeuverEndurance07" title="@{martialManeuverEndurance07}" value="0" step="1" min="0" tabindex="245"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1711,27 +1711,27 @@
 										<input type="number" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" value="0" step="1" tabindex="247"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage07" title="@{maneuverDamage07}" value="0" maxlength="12" tabindex="248"/>
+										<input type="text" name="attr_martialManeuverDamage07" title="@{martialManeuverDamage07}" value="0" maxlength="12" tabindex="248"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage07">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage07}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal07">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal07}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock07">
-											<span class="checkmark-small-gray" title="@{maneuverBlock07}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock07">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock07}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND07" title="%{buttonManeuverEND07}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll07" title="%{showMartialRoll07}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll07" title="%{showManeuverRoll07}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1772,7 +1772,7 @@
 										<input type="text" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" value="" maxlength="100" tabindex="253"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod08" title="@{martialManeuverStunMod08}" value="0" min="0" max="9" step="1" tabindex="254"/>
-										<input type="number" name="attr_maneuverEndurance08" title="@{maneuverEndurance08}" value="0" step="1" min="0" tabindex="255"/>
+										<input type="number" name="attr_martialManeuverEndurance08" title="@{martialManeuverEndurance08}" value="0" step="1" min="0" tabindex="255"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1783,27 +1783,27 @@
 										<input type="number" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" value="0" step="1" tabindex="257"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage08" title="@{maneuverDamage08}" value="0" maxlength="12" tabindex="258"/>
+										<input type="text" name="attr_martialManeuverDamage08" title="@{martialManeuverDamage08}" value="0" maxlength="12" tabindex="258"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage08">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage08}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal08">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal08}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock08">
-											<span class="checkmark-small-gray" title="@{maneuverBlock08}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock08">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock08}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND08" title="%{buttonManeuverEND08}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll08" title="%{showMartialRoll08}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll08" title="%{showManeuverRoll08}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -1844,7 +1844,7 @@
 										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="Damage by STR or by weapon" maxlength="100" tabindex="263"/>
 										<h1>Sx:</h1>
 										<input type="number" name="attr_martialManeuverStunMod09" title="@{martialManeuverStunMod09}" value="0" min="0" max="9" step="1" tabindex="264"/>
-										<input type="number" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" value="2" step="1" min="0" tabindex="265"/>
+										<input type="number" name="attr_martialManeuverEndurance09" title="@{martialManeuverEndurance09}" value="2" step="1" min="0" tabindex="265"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1855,27 +1855,27 @@
 										<input type="number" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" value="0" step="1" tabindex="267"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="2d6" maxlength="12" tabindex="268"/>
+										<input type="text" name="attr_martialManeuverDamage09" title="@{martialManeuverDamage09}" value="2d6" maxlength="12" tabindex="268"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage09">
-											<span class="checkmark-small-gray" title="@{maneuverNormalDamage09}"></span>
+											<input type="checkbox" checked="checked" name="attr_martialManeuverNormal09">
+											<span class="checkmark-small-gray" title="@{martialManeuverNormal09}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_maneuverBlock09">
-											<span class="checkmark-small-gray" title="@{maneuverBlock09}"></span>
+											<input type="checkbox" name="attr_martialManeuverBlock09">
+											<span class="checkmark-small-gray" title="@{martialManeuverBlock09}"></span>
 										</label>
 									</div>
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
 									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND09" title="%{buttonManeuverEND09}">END</button>
-									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll09" title="%{showMartialRoll09}" >Show</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showManeuverRoll09" title="%{showManeuverRoll09}" >Show</button>
 								</div>
 							</div>
 						</div>
@@ -6200,15 +6200,15 @@
 <input type="hidden" name="attr_hiddenWeaponDamage03"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage04"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage05"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage01"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage02"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage03"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage04"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage05"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage06"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage07"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage08"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage09"  value="2d6"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage01"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage02"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage03"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage04"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage05"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage06"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage07"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage08"  value="0"/>
+<input type="hidden" name="attr_hiddenMartialManeuverDamage09"  value="2d6"/>
 <input type="hidden" name="attr_hiddenBasicDamage"  value="2d6"/>
 <input type="hidden" name="attr_hiddenBasicEndurance" value="2"/>
 
@@ -8737,7 +8737,7 @@
 		var highId = String(num == maxManeuverNum ? 1 : num + 1).padStart(2,'0');
 		on("clicked:martialManeuverDown"+lowId+" clicked:martialManeuverUp"+highId, function() {
 			getAttrs(["martialManeuverName"+lowId, "martialManeuverPhase"+lowId, "martialManeuverCP"+lowId,
-					"martialManeuverOCV"+lowId, "martialManeuverDCV"+lowId, "martialManeuverEffect"+lowId, "maneuverDamage"+lowId, "maneuverNormalDamage"+lowId, "maneuverBlock"+lowId, "maneuverEndurance"+lowId, "martialManeuverName"+highId, "martialManeuverPhase"+highId, "martialManeuverCP"+highId, "martialManeuverOCV"+highId, "martialManeuverDCV"+highId, "martialManeuverEffect"+highId, "maneuverDamage"+highId, "maneuverNormalDamage"+highId, "maneuverBlock"+highId, "maneuverEndurance"+highId], function(values)
+					"martialManeuverOCV"+lowId, "martialManeuverDCV"+lowId, "martialManeuverEffect"+lowId, "martialManeuverDamage"+lowId, "martialManeuverNormal"+lowId, "martialManeuverBlock"+lowId, "martialManeuverEndurance"+lowId, "martialManeuverName"+highId, "martialManeuverPhase"+highId, "martialManeuverCP"+highId, "martialManeuverOCV"+highId, "martialManeuverDCV"+highId, "martialManeuverEffect"+highId, "martialManeuverDamage"+highId, "martialManeuverNormal"+highId, "martialManeuverBlock"+highId, "martialManeuverEndurance"+highId], function(values)
 			{
 				var attributes = new Object();
 				
@@ -8779,16 +8779,14 @@
 				attributes["martialManeuverOCV"+highId] = values["martialManeuverOCV"+lowId];
 				attributes["martialManeuverDCV"+lowId] = values["martialManeuverDCV"+highId];
 				attributes["martialManeuverDCV"+highId] = values["martialManeuverDCV"+lowId];
-				
-				// Rename to standard "martialManeuver"
-				attributes["maneuverDamage"+lowId] = values["maneuverDamage"+highId];
-				attributes["maneuverDamage"+highId] = values["maneuverDamage"+lowId];
-				attributes["maneuverNormalDamage"+lowId] = values["maneuverNormalDamage"+highId];
-				attributes["maneuverNormalDamage"+highId] = values["maneuverNormalDamage"+lowId];
-				attributes["maneuverBlock"+lowId] = values["maneuverBlock"+highId];
-				attributes["maneuverBlock"+highId] = values["maneuverBlock"+lowId];
-				attributes["maneuverEndurance"+lowId] = values["maneuverEndurance"+highId];
-				attributes["maneuverEndurance"+highId] = values["maneuverEndurance"+lowId];
+				attributes["martialManeuverDamage"+lowId] = values["martialManeuverDamage"+highId];
+				attributes["martialManeuverDamage"+highId] = values["martialManeuverDamage"+lowId];
+				attributes["martialManeuverNormal"+lowId] = values["martialManeuverNormal"+highId];
+				attributes["martialManeuverNormal"+highId] = values["martialManeuverNormal"+lowId];
+				attributes["martialManeuverBlock"+lowId] = values["martialManeuverBlock"+highId];
+				attributes["martialManeuverBlock"+highId] = values["martialManeuverBlock"+lowId];
+				attributes["martialManeuverEndurance"+lowId] = values["martialManeuverEndurance"+highId];
+				attributes["martialManeuverEndurance"+highId] = values["martialManeuverEndurance"+lowId];
 				
 				setAttrs(attributes);
 			});
@@ -8980,16 +8978,16 @@
 		
 		var maneuverId = String(num).padStart(2,'0');
 		
-		on(`change:hiddenBasicDamage change:hiddenBasicEndurance change:maneuverNormalDamage${maneuverId}`, function() {
-			getAttrs(["hiddenBasicEndurance", "hiddenBasicDamage", "martialManeuverEffect"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverDamage"+maneuverId, "hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId], function(values) {
+		on(`change:hiddenBasicDamage change:hiddenBasicEndurance change:martialManeuverNormal${maneuverId}`, function() {
+			getAttrs(["hiddenBasicEndurance", "hiddenBasicDamage", "martialManeuverEffect"+maneuverId, "martialManeuverEndurance"+maneuverId, "martialManeuverDamage"+maneuverId, "hiddenMartialManeuverDamage"+maneuverId, "martialManeuverNormal"+maneuverId], function(values) {
 				var attributes = new Object();
 				
 				let keywordPhrase = "Damage by STR";
 				let currentEffect = values["martialManeuverEffect"+maneuverId]||"";
-				let theEndurance = parseInt(values["maneuverEndurance"+maneuverId])||0;
-				let theDamage = values["maneuverDamage"+maneuverId]||0;
-				let theHiddenDamage = values["hiddenManeuverDamage"+maneuverId]||0;
-				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
+				let theEndurance = parseInt(values["martialManeuverEndurance"+maneuverId])||0;
+				let theDamage = values["martialManeuverDamage"+maneuverId]||0;
+				let theHiddenDamage = values["hiddenMartialManeuverDamage"+maneuverId]||0;
+				let isNormalDamage = values["martialManeuverNormal"+maneuverId] != 0;
 				
 				if (currentEffect.includes(keywordPhrase) && isNormalDamage) {
 					// The effect includes the keyword phrase and the maneuver is still a normal damage attack.
@@ -8999,9 +8997,9 @@
 					theHiddenDamage = values.hiddenBasicDamage;
 				}
 				
-				attributes["maneuverEndurance"+maneuverId] = theEndurance;
-				attributes["maneuverDamage"+maneuverId] = theDamage;
-				attributes["hiddenManeuverDamage"+maneuverId] = theHiddenDamage;
+				attributes["martialManeuverEndurance"+maneuverId] = theEndurance;
+				attributes["martialManeuverDamage"+maneuverId] = theDamage;
+				attributes["hiddenMartialManeuverDamage"+maneuverId] = theHiddenDamage;
 				setAttrs(attributes);
 			});
 		});
@@ -9011,16 +9009,16 @@
 	/* Show Maneuver XX */
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');	
-		on(`clicked:showMartialRoll${maneuverId}`, (info) => {
-			getAttrs(["whisperToGM", "maneuverNormalDamage"+maneuverId, "martialManeuverStunMod"+maneuverId], function(values) {
+		on(`clicked:showManeuverRoll${maneuverId}`, (info) => {
+			getAttrs(["whisperToGM", "martialManeuverNormal"+maneuverId, "martialManeuverStunMod"+maneuverId], function(values) {
 				var theRoll = values.whisperToGM||"";
-				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
+				let isNormalDamage = values["martialManeuverNormal"+maneuverId] != 0;
 				let theStunMod = parseInt(values["martialManeuverStunMod"+maneuverId])||0;
 				
 				theRoll += "&{template:custom-show} {{title=@{character_name} - @{character_title}}} "
 					+ "{{subtitle= Maneuver - @{martialManeuverName"+maneuverId+"}}} "
 					+ "{{Phases=@{martialManeuverPhase"+maneuverId+"}}} "
-					+ "{{END = @{maneuverEndurance"+maneuverId+"}}} "
+					+ "{{END = @{martialManeuverEndurance"+maneuverId+"}}} "
 					+ "{{OCV = @{martialManeuverOCV"+maneuverId+"}}} "
 					+ "{{DCV = @{martialManeuverDCV"+maneuverId+"}}} ";
 					
@@ -9028,7 +9026,7 @@
 					theRoll += "{{STUNx = @{martialManeuverStunMod"+maneuverId+"}}} ";
 				}
 					
-					theRoll += "{{Damage = @{maneuverDamage"+maneuverId+"}" + (isNormalDamage ? " N" : " K") + "}} "
+					theRoll += "{{Damage = @{martialManeuverDamage"+maneuverId+"}" + (isNormalDamage ? " N" : " K") + "}} "
 					+ "{{desc=@{martialManeuverEffect"+maneuverId+"}}}";
 				
 				startRoll(theRoll, (results) => {
@@ -9045,15 +9043,15 @@
 		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverStunMod"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess", "rangeSelection"], function(values) {
+			getAttrs(["hiddenMartialManeuverDamage"+maneuverId, "martialManeuverNormal"+maneuverId, "martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverStunMod"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "martialManeuverEndurance"+maneuverId, "martialManeuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess", "rangeSelection"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
-				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
+				let isNormalDamage = values["martialManeuverNormal"+maneuverId] != 0;
 				let stunMod = parseInt(values["martialManeuverStunMod"+maneuverId])||0;
-				let isBlocking = values["maneuverBlock"+maneuverId] != 0;
+				let isBlocking = values["martialManeuverBlock"+maneuverId] != 0;
 				
 				// Martial maneuvers by default cost no endurance. Endurance costs used for flexibility.
-				let subtractENDAmt =  parseInt(values["maneuverEndurance"+maneuverId])||0;
+				let subtractENDAmt =  parseInt(values["martialManeuverEndurance"+maneuverId])||0;
 				
 				let dmgType = isNormalDamage ? "STUN" : "BODY";
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
@@ -9067,7 +9065,7 @@
 					} else {
 						theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]-@{rangeOCVPenalty}[RangeOCV]+?{Modifiers|0}[Modifier] ]]}}" + "{{Result=[[3d6cf6cs1]]}}";
 					}
-					theRoll	+= (subtractENDAmt ? "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}" : "") + "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}}" + "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
+					theRoll	+= (subtractENDAmt ? "{{END=[[@{martialManeuverEndurance"+maneuverId+"}]] (@{currentEND})}}" : "") + "{{"+dmgType+"=[[@{hiddenMartialManeuverDamage"+maneuverId+"}]]}}" + "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 					if (useHitLocations)
 						theRoll += "{{HITLOC=[[@{targetHitRoll}]]}}";
 				} else {
@@ -9079,7 +9077,7 @@
 						theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]+?{Modifiers|0}[Modifier]]]}}" + "{{Result=[[3d6cf6cs1]]}} ";
 					}
 					if (subtractENDAmt != 0) {
-						theRoll	+= "{{END=[[@{maneuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
+						theRoll	+= "{{END=[[@{martialManeuverEndurance"+maneuverId+"}]] (@{currentEND})}}";
 					}
 				} 
 				
@@ -9139,8 +9137,8 @@
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');
 		on("clicked:buttonManeuverEND"+maneuverId, function() {
-			getAttrs(["maneuverEndurance"+maneuverId], function(values) {
-				subtractEndurance(parseInt(values["maneuverEndurance"+maneuverId]));
+			getAttrs(["martialManeuverEndurance"+maneuverId], function(values) {
+				subtractEndurance(parseInt(values["martialManeuverEndurance"+maneuverId]));
 			});
 		});
 	});
@@ -9161,49 +9159,49 @@
 	
 	
 	/* Clean Maneuver Damage Dice */
-	on("change:maneuverDamage01 change:maneuverDamage02 change:maneuverDamage03 change:maneuverDamage04 change:maneuverDamage05 change:maneuverDamage06 change:maneuverDamage07 change:maneuverDamage08 change:maneuverDamage09", function () {
+	on("change:martialManeuverDamage01 change:martialManeuverDamage02 change:martialManeuverDamage03 change:martialManeuverDamage04 change:martialManeuverDamage05 change:martialManeuverDamage06 change:martialManeuverDamage07 change:martialManeuverDamage08 change:martialManeuverDamage09", function () {
 		// This function attempts to clean damage text input into text more likely to be rollable dice.
 		// Only characters 0-9, d, D, +, and - are passed to martial attack rolls.
 		
-		getAttrs(["maneuverDamage01","maneuverDamage02","maneuverDamage03","maneuverDamage04","maneuverDamage05","maneuverDamage06","maneuverDamage07", "maneuverDamage08", "maneuverDamage09"], function(values) {
+		getAttrs(["martialManeuverDamage01","martialManeuverDamage02","martialManeuverDamage03","martialManeuverDamage04","martialManeuverDamage05","martialManeuverDamage06","martialManeuverDamage07", "martialManeuverDamage08", "martialManeuverDamage09"], function(values) {
 			
-			var maneuverDamage01=values.maneuverDamage01;
-			maneuverDamage01=maneuverDamage01.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage01=values.martialManeuverDamage01;
+			martialManeuverDamage01=martialManeuverDamage01.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage02=values.maneuverDamage02;
-			maneuverDamage02=maneuverDamage02.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage02=values.martialManeuverDamage02;
+			martialManeuverDamage02=martialManeuverDamage02.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage03=values.maneuverDamage03;
-			maneuverDamage03=maneuverDamage03.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage03=values.martialManeuverDamage03;
+			martialManeuverDamage03=martialManeuverDamage03.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage04=values.maneuverDamage04;
-			maneuverDamage04=maneuverDamage04.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage04=values.martialManeuverDamage04;
+			martialManeuverDamage04=martialManeuverDamage04.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage05=values.maneuverDamage05;
-			maneuverDamage05=maneuverDamage05.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage05=values.martialManeuverDamage05;
+			martialManeuverDamage05=martialManeuverDamage05.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage06=values.maneuverDamage06;
-			maneuverDamage06=maneuverDamage06.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage06=values.martialManeuverDamage06;
+			martialManeuverDamage06=martialManeuverDamage06.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage07=values.maneuverDamage07;
-			maneuverDamage07=maneuverDamage07.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage07=values.martialManeuverDamage07;
+			martialManeuverDamage07=martialManeuverDamage07.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage08=values.maneuverDamage08;
-			maneuverDamage08=maneuverDamage08.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage08=values.martialManeuverDamage08;
+			martialManeuverDamage08=martialManeuverDamage08.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var maneuverDamage09=values.maneuverDamage09;
-			maneuverDamage09=maneuverDamage09.replace(/[^\ddD\\+\\-]/g,"");
+			var martialManeuverDamage09=values.martialManeuverDamage09;
+			martialManeuverDamage09=martialManeuverDamage09.replace(/[^\ddD\\+\\-]/g,"");
 			
 			setAttrs({
-				"hiddenManeuverDamage01":maneuverDamage01,
-				"hiddenManeuverDamage02":maneuverDamage02,
-				"hiddenManeuverDamage03":maneuverDamage03,
-				"hiddenManeuverDamage04":maneuverDamage04,
-				"hiddenManeuverDamage05":maneuverDamage05,
-				"hiddenManeuverDamage06":maneuverDamage06,
-				"hiddenManeuverDamage07":maneuverDamage07,
-				"hiddenManeuverDamage08":maneuverDamage08,
-				"hiddenManeuverDamage09":maneuverDamage09
+				"hiddenMartialManeuverDamage01":martialManeuverDamage01,
+				"hiddenMartialManeuverDamage02":martialManeuverDamage02,
+				"hiddenMartialManeuverDamage03":martialManeuverDamage03,
+				"hiddenMartialManeuverDamage04":martialManeuverDamage04,
+				"hiddenMartialManeuverDamage05":martialManeuverDamage05,
+				"hiddenMartialManeuverDamage06":martialManeuverDamage06,
+				"hiddenMartialManeuverDamage07":martialManeuverDamage07,
+				"hiddenMartialManeuverDamage08":martialManeuverDamage08,
+				"hiddenMartialManeuverDamage09":martialManeuverDamage09
 			});
 		});
 	});
@@ -9462,7 +9460,7 @@
 		// This function attempts to clean damage text input into text more likely to be rollable dice.
 		// Only characters 0-9, d, D, +, and - are passed to attack rolls.
 		
-		getAttrs(["shieldDamage", "weaponDamage01", "weaponDamage02", "weaponDamage03", "weaponDamage04", "weaponDamage05", "strength", "martialManeuverName01", "maneuverDamage01"], function(values) {
+		getAttrs(["shieldDamage", "weaponDamage01", "weaponDamage02", "weaponDamage03", "weaponDamage04", "weaponDamage05", "strength", "martialManeuverName01", "martialManeuverDamage01"], function(values) {
 		
 			var theShieldDamage=values.shieldDamage;
 			theShieldDamage=theShieldDamage.replace(/[^\ddD\\+\\-]/g,"");

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1210,7 +1210,7 @@
 				</div>
 					
 				<div class="item-tab-gear-slide-flex-container-martial-maneuvers-block">
-
+					
 					<!-- Standard Attack -->
 					<div class=".item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
@@ -1273,7 +1273,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage01">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage01">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage01}"></span>
 										</label>	
 									</div>
@@ -1332,7 +1332,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage02">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage02">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage02}"></span>
 										</label>	
 									</div>
@@ -1391,7 +1391,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage03">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage03">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage03}"></span>
 										</label>	
 									</div>
@@ -1450,7 +1450,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage04">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage04">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage04}"></span>
 										</label>	
 									</div>
@@ -1510,7 +1510,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage05">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage05">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage05}"></span>
 										</label>	
 									</div>
@@ -1569,7 +1569,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage06">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage06">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage06}"></span>
 										</label>	
 									</div>
@@ -1628,7 +1628,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage07">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage07">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage07}"></span>
 										</label>	
 									</div>
@@ -1687,7 +1687,7 @@
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialNormalDamage08">
+											<input type="checkbox" checked="checked" name="attr_martialNormalDamage08">
 											<span class="checkmark-small-gray" title="@{martialNormalDamage08}"></span>
 										</label>	
 									</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -4905,7 +4905,7 @@
 							</select>
 						</div>
 					</div>
-					<textarea name="attr_powerText11" maxlength="512" tabindex="450"></textarea>
+					<textarea name="attr_powerText11" maxlength="512" tabindex="507"></textarea>
 				</div>
 			</div>
 			
@@ -4952,7 +4952,7 @@
 							</button>
 						</div>
 					</div>
-					<input type="text" name="attr_powerEffect12" maxlength="25" tabindex="451"/>
+					<input type="text" name="attr_powerEffect12" maxlength="25" tabindex="511"/>
 					<input type="text" name="attr_powerDice12" value="0d6" maxlength="16" tabindex="512"/>
 					<h1>Roll:</h1>
 					<input type="number" name="attr_powerSkillRoll12" value="18" min="0" max="30" tabindex="513"/>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1233,7 +1233,7 @@
 					<input type="hidden" class="maneuver-block08" name="attr_maneuverBlock08">
 					<input type="hidden" class="maneuver-block09" name="attr_maneuverBlock09">
 					
-					<!-- Set first maneuver to expanded state as default. -->
+					<!-- Set the first maneuver to its expanded state as default. -->
 					<input type="hidden" class="sheet-maneuver-toggle" name="attr_maneuverToggle"  value="maneuverExpand01" />
 					
 					<!-- Maneuver 01 -->
@@ -1247,7 +1247,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName01" title="@{martialManeuverName01}" value="Basic HTH Strike" maxlength="34" tabindex="170"/>
+							<input type="text" name="attr_martialManeuverName01" title="@{martialManeuverName01}" value="" maxlength="34" tabindex="170"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp01">
@@ -1268,8 +1268,8 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="Damage by STR" maxlength="100" tabindex="173"/>
-										<input type="number" value="2" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
+										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="" maxlength="100" tabindex="173"/>
+										<input type="number" value="" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1280,7 +1280,7 @@
 										<input type="number" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" value="0" step="1" tabindex="176"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="2d6" maxlength="12" tabindex="177"/>
+										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="" maxlength="12" tabindex="177"/>
 										
 										<h1>N:</h1>
 										
@@ -1807,7 +1807,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName09" title="@{martialManeuverName09}" value="" maxlength="34" tabindex="250"/>
+							<input type="text" name="attr_martialManeuverName09" title="@{martialManeuverName09}" value="Basic HTH Strike" maxlength="34" tabindex="250"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp09">
@@ -1828,8 +1828,8 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="" maxlength="100" tabindex="253"/>
-										<input type="number" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" value="0" step="1" min="0" tabindex="254"/>
+										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="Damage by STR" maxlength="100" tabindex="253"/>
+										<input type="number" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" value="2" step="1" min="0" tabindex="254"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1840,7 +1840,7 @@
 										<input type="number" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" value="0" step="1" tabindex="256"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="0" maxlength="12" tabindex="257"/>
+										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="2d6" maxlength="12" tabindex="257"/>
 										
 										<h1>N:</h1>
 										
@@ -6124,7 +6124,7 @@
 <input type="hidden" name="attr_hiddenWeaponDamage03"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage04"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage05"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage01"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage01"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage02"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage03"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage04"  value="0"/>
@@ -6132,7 +6132,7 @@
 <input type="hidden" name="attr_hiddenManeuverDamage06"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage07"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage08"  value="0"/>
-<input type="hidden" name="attr_hiddenManeuverDamage09"  value="0"/>
+<input type="hidden" name="attr_hiddenManeuverDamage09"  value="2d6"/>
 <input type="hidden" name="attr_hiddenBasicDamage"  value="2d6"/>
 <input type="hidden" name="attr_hiddenBasicEndurance" value="2"/>
 
@@ -8891,26 +8891,25 @@
 		var maneuverId = String(num).padStart(2,'0');
 		
 		on(`change:hiddenBasicDamage change:hiddenBasicEndurance change:maneuverNormalDamage${maneuverId}`, function() {
-			getAttrs(["treasures", "hiddenBasicEndurance", "hiddenBasicDamage", "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId], function(values) {
+			getAttrs(["hiddenBasicEndurance", "hiddenBasicDamage", "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverDamage"+maneuverId, "hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId], function(values) {
 				var attributes = new Object();
 				
 				let defaultName = "Basic HTH Strike";
 				let currentName = values["martialManeuverName"+maneuverId]||"";
 				let theEndurance = parseInt(values["maneuverEndurance"+maneuverId])||0;
 				let theDamage = values["maneuverDamage"+maneuverId]||0;
+				let theHiddenDamage = values["hiddenManeuverDamage"+maneuverId]||0;
 				
 				if ( (currentName.localeCompare(defaultName) === 0) && (values["maneuverNormalDamage"+maneuverId] === "on")) {
-					// The name is the keyword defaultName.
+					// The name is the keyword defaultName and the maneuver is still a normal damage attack.
 					theEndurance = parseInt(values.hiddenBasicEndurance)||0;
 					theDamage = values.hiddenBasicDamage;
+					theHiddenDamage = values.hiddenBasicDamage;
 				}
-				
-				let debug = values.treasures;
-				debug += maneuverId;
 				
 				attributes["maneuverEndurance"+maneuverId] = theEndurance;
 				attributes["maneuverDamage"+maneuverId] = theDamage;
-				attributes["treasures"] = debug;
+				attributes["hiddenManeuverDamage"+maneuverId] = theHiddenDamage;
 				setAttrs(attributes);
 			});
 		});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1215,7 +1215,7 @@
 					<div class=".item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
 							<div class="subitem-tab-gear-slide-flex-container-standard-attack">
-								<h1>Basic Attack</h1>
+								<h1>Basic Attack:</h1>
 								<h2 title="@{hiddenManeuverDamage01}">HA STR/5</h2>
 								<input type="text" value="1/2" name="attr_normalPhase01" title="@{normalPhase01}" tabindex="-1" readonly="">
 								<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_standardAttackRoll" title="%{standardAttackRoll}">Roll</button>
@@ -6249,9 +6249,36 @@
 			version = 2.1;
 		}
 		
-		if (version < 2.2) {
-			// No updates to attributes needed except version number (for now).
-			version = 2.2;
+		if (version < 2.3) {
+			// Update martial maneuver text CVs to integers.
+			
+			values = await _getAttrs(["martialManeuverOCV01", "martialManeuverOCV02", "martialManeuverOCV03", "martialManeuverOCV04", "martialManeuverOCV05", "martialManeuverOCV06", "martialManeuverOCV07", "martialManeuverOCV08", "martialManeuverDCV01", "martialManeuverDCV02", "martialManeuverDCV03", "martialManeuverDCV04", "martialManeuverDCV05", "martialManeuverDCV06", "martialManeuverDCV07", "martialManeuverDCV08"]);
+			
+			attributes.martialManeuverOCV01 = parseInt(values.martialManeuverOCV01)||0;
+			attributes.martialManeuverDCV01 = parseInt(values.martialManeuverDCV01)||0;
+			
+			attributes.martialManeuverOCV02 = parseInt(values.martialManeuverOCV02)||0;
+			attributes.martialManeuverDCV02 = parseInt(values.martialManeuverDCV02)||0;
+			
+			attributes.martialManeuverOCV03 = parseInt(values.martialManeuverOCV03)||0;
+			attributes.martialManeuverDCV03 = parseInt(values.martialManeuverDCV03)||0;
+			
+			attributes.martialManeuverOCV04 = parseInt(values.martialManeuverOCV04)||0;
+			attributes.martialManeuverDCV04 = parseInt(values.martialManeuverDCV04)||0;
+			
+			attributes.martialManeuverOCV05 = parseInt(values.martialManeuverOCV05)||0;
+			attributes.martialManeuverDCV05 = parseInt(values.martialManeuverDCV05)||0;
+			
+			attributes.martialManeuverOCV06 = parseInt(values.martialManeuverOCV06)||0;
+			attributes.martialManeuverDCV06 = parseInt(values.martialManeuverDCV06)||0;
+			
+			attributes.martialManeuverOCV07 = parseInt(values.martialManeuverOCV07)||0;
+			attributes.martialManeuverDCV07 = parseInt(values.martialManeuverDCV07)||0;
+			
+			attributes.martialManeuverOCV08 = parseInt(values.martialManeuverOCV08)||0;
+			attributes.martialManeuverDCV08 = parseInt(values.martialManeuverDCV08)||0;
+			
+			version = 2.3;
 		}
 
 		if (version != origVersion) {

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -8240,19 +8240,19 @@
 			} else {
 				bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
 			}
-					
+			
 			let skillRollChance12=calculateSkillChance(values.skillType12, (parseInt(values.skillCP12)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-							
+			
 			// Skill 13 
 			let skillRollChance13=calculateSkillChance(values.skillType13, (parseInt(values.skillCP13)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 14 
 			let skillRollChance14=calculateSkillChance(values.skillType14, (parseInt(values.skillCP14)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 15
 			bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
 			let skillRollChance15=calculateSkillChance(values.skillType15, (parseInt(values.skillCP15)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 16
 			// Bonus Levels for Skills 16, 17, and 18 may include group levels if Skill 15 is of type "group".
 			if (values.skillType15==="group") {
@@ -8262,25 +8262,25 @@
 			}
 			
 			let skillRollChance16=calculateSkillChance(values.skillType16, (parseInt(values.skillCP16)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 17 
 			let skillRollChance17=calculateSkillChance(values.skillType17, (parseInt(values.skillCP17)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-											 
+			
 			// Skill 18 
 			let skillRollChance18=calculateSkillChance(values.skillType18, (parseInt(values.skillCP18)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-							
-						
+			
+			
 			// Skill 19
 			// Skills 19 and 20 aren't available for group levels.
 			bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
 			let skillRollChance19=calculateSkillChance(values.skillType19, (parseInt(values.skillCP19)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 20
 			let skillRollChance20=calculateSkillChance(values.skillType20, (parseInt(values.skillCP20)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill Set 2 total character point cost
 			let setSkillsCost=(parseInt(values.skillCP11)||0)+(parseInt(values.skillCP12)||0)+(parseInt(values.skillCP13)||0)+(parseInt(values.skillCP14)||0)+(parseInt(values.skillCP15)||0)+(parseInt(values.skillCP16)||0)+(parseInt(values.skillCP17)||0)+(parseInt(values.skillCP18)||0)+(parseInt(values.skillCP19)||0)+(parseInt(values.skillCP20)||0); 
-						
+			
 			// Assign calculated skill rolls.
 			setAttrs({
 				"skillRollChance11":skillRollChance11,
@@ -8342,25 +8342,24 @@
 					}
 					
 			let skillRollChance26=calculateSkillChance(values.skillType26, (parseInt(values.skillCP26)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-					
+			
 			// Skill 27 
 			let skillRollChance27=calculateSkillChance(values.skillType27, (parseInt(values.skillCP27)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-							
+			
 			// Skill 28 
 			let skillRollChance28=calculateSkillChance(values.skillType28, (parseInt(values.skillCP28)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
-						
+			
 			// Skill 29
 			// Skills 29 and 30 aren't available for group levels.
 			bonusLevels=(parseInt(values.noncombatLevels)||0)+(parseInt(values.overallLevels)||0);
 			let skillRollChance29=calculateSkillChance(values.skillType29, (parseInt(values.skillCP29)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-						
+			
 			// Skill 30
 			let skillRollChance30=calculateSkillChance(values.skillType30, (parseInt(values.skillCP30)||0), values.enhancerJack, values.enhancerSch, values.enhancerSci, values.enhancerTrav, (parseInt(values.strengthChance)||0), (parseInt(values.dexterityChance)||0), (parseInt(values.constitutionChance)||0), (parseInt(values.intelligenceChance)||0), (parseInt(values.egoChance)||0), (parseInt(values.presenceChance)||0), (parseInt(values.interactionLevels)||0), (parseInt(values.intellectLevels)||0), (parseInt(values.agilityLevels)||0), bonusLevels);
-					
+			
 			// Skill Set 3 total character point cost
 			let setSkillsCost=(parseInt(values.skillCP21)||0)+(parseInt(values.skillCP22)||0)+(parseInt(values.skillCP23)||0)+(parseInt(values.skillCP24)||0)+(parseInt(values.skillCP25)||0)+(parseInt(values.skillCP26)||0)+(parseInt(values.skillCP27)||0)+(parseInt(values.skillCP28)||0)+(parseInt(values.skillCP29)||0)+(parseInt(values.skillCP30)||0); 
-					
+			
 			// Assign calculated skill rolls.
 					setAttrs({
 				"skillRollChance21":skillRollChance21,
@@ -8389,7 +8388,7 @@
 		// Skill level costs for all HTH, all ranged, and all combat are calculated here without the calculateCombatSkillCost(..).
 		//
 		getAttrs(["skillLevels31", "skillType31", "skillLevels32", "skillType32", "skillLevels33", "skillType33", "skillLevels34", "skillType34", "skillLevels35", "skillType35", "skillLevels36", "skillType36", "skillLevels37", "skillType37", "skillLevels38","skillLevels39","skillLevels40"], function(values) {
-											 
+			
 			// Skills 31-37 are general combat skills with costs determined by their skill type or levels.
 			let skill31Cost = calculateCombatSkillCost(values.skillType31, (parseInt(values.skillLevels31)||0) );
 			let skill32Cost = calculateCombatSkillCost(values.skillType32, (parseInt(values.skillLevels32)||0) );
@@ -8398,18 +8397,18 @@
 			let skill35Cost = calculateCombatSkillCost(values.skillType35, (parseInt(values.skillLevels35)||0) );
 			let skill36Cost = calculateCombatSkillCost(values.skillType36, (parseInt(values.skillLevels36)||0) );
 			let skill37Cost = calculateCombatSkillCost(values.skillType37, (parseInt(values.skillLevels37)||0) );
-							
+			
 			// Skill 38: All HTH Combat Levels cost 8 CP each.
 			let skill38Cost = 8*(parseInt(values.skillLevels38)||0);
-						
+			
 			// Skill 39: All Range Combat Levels cost 8 CP each.
 			let skill39Cost = 8*(parseInt(values.skillLevels39)||0);
-						
+			
 			// Skill 40: All Combat Levels cost 10 CP each.
 			let skill40Cost = 10*(parseInt(values.skillLevels40)||0);
-						
+			
 			let combatSkillsCost = skill31Cost+skill32Cost+skill33Cost+skill34Cost+skill35Cost+skill36Cost+skill37Cost+skill38Cost+skill39Cost+skill40Cost;
-						
+			
 			setAttrs({
 				"hiddenCombatSkillsCost":combatSkillsCost,
 				"skillCP31":skill31Cost,
@@ -8435,64 +8434,64 @@
 			case "none": skillLevelCost=0;
 			skillBaseCost = 0;
 			break;
-					
+			
 			case "Fam1": skillLevelCost=0;
 			skillBaseCost = 1;
 			break;
-					
+			
 			case "Fam2": skillLevelCost=0;
 			skillBaseCost = 2;
 			break;
-					
+			
 			case "CSL2": skillLevelCost=2;
 			skillBaseCost = 0;
 			break;
-					
+			
 			case "CSL3": skillLevelCost=3;
 			skillBaseCost = 0;
 			break;
-											 
+			
 			case "CSL5": skillLevelCost=5;
 			skillBaseCost = 0;
 			break;
-					
+			
 			case "CSL8": skillLevelCost=8;
 			skillBaseCost = 0;
 			break;
-							
+			
 			case "PSL1": skillLevelCost=1;
 			skillBaseCost = 0;
 			break;
-						
+			
 			case "PSL2": skillLevelCost=2;
 			skillBaseCost = 0;
 			break;
-						
+			
 			case "PSL3": skillLevelCost=3;
 			skillBaseCost = 0;
 			break;
-						
+			
 			default: skillLevelCost=0;
 			skillBaseCost = 0;
 			break;
 		}	
 		return skillBaseCost+numberOfLevels*skillLevelCost;
 	}
-							
-						
+	
+	
 	/* Language Skills */
 	on("change:enhancerLing change:skillFluency41 change:skillLiteracy41 change:skillFluency42 change:skillLiteracy42 change:skillFluency43 change:skillLiteracy43 change:skillFluency44 change:skillLiteracy44 change:skillFluency45 change:skillLiteracy45 change:skillFluency46 change:skillLiteracy46 change:skillFluency47 change:skillLiteracy47 change:skillFluency48 change:skillLiteracy48 change:skillFluency49 change:skillLiteracy49, optionLiteracyCostsPoints", function () {
 		// Language skills are relatively simple without levels or roll calculations. The linguist enhancer is the only complication. 
 		// All calculations handled by the function calculateLanguageSkillCost(...).
-											 
+		
 		getAttrs(["enhancerLing", "skillFluency41","skillLiteracy41", "skillFluency42","skillLiteracy42", "skillFluency43","skillLiteracy43", "skillFluency44","skillLiteracy44", "skillFluency45","skillLiteracy45", "skillFluency46","skillLiteracy46", "skillFluency47","skillLiteracy47", "skillFluency48","skillLiteracy48", "skillFluency49","skillLiteracy49","optionLiteracyCostsPoints"], function(values) {
 			const linguist = values.enhancerLing;
 			let literacyCost = 0;
-							
+			
 			if (values.optionLiteracyCostsPoints!=0) {
 				literacyCost = 1;
 			}
-						
+			
 			let skill41Cost = calculateLanguageSkillCost( values.skillFluency41 , values.skillLiteracy41, linguist, literacyCost);
 			let skill42Cost = calculateLanguageSkillCost( values.skillFluency42 , values.skillLiteracy42, linguist, literacyCost);
 			let skill43Cost = calculateLanguageSkillCost( values.skillFluency43 , values.skillLiteracy43, linguist, literacyCost);
@@ -8502,9 +8501,9 @@
 			let skill47Cost = calculateLanguageSkillCost( values.skillFluency47 , values.skillLiteracy47, linguist, literacyCost);
 			let skill48Cost = calculateLanguageSkillCost( values.skillFluency48 , values.skillLiteracy48, linguist, literacyCost);
 			let skill49Cost = calculateLanguageSkillCost( values.skillFluency49 , values.skillLiteracy49, linguist, literacyCost);
-						
+			
 			let totalLanguageCosts = skill41Cost+skill42Cost+skill43Cost+skill44Cost+skill45Cost+skill46Cost+skill47Cost+skill48Cost+skill49Cost;
-						
+			
 			setAttrs({
 				"hiddenLanguageSkillsCost":totalLanguageCosts,
 				"skillCP41":skill41Cost,
@@ -8525,9 +8524,9 @@
 		// If any of the enhancers or wide-scope noncombat levels change (anything in the lower right skill block) recalculate their costs.
 		// Because enhancers lower the costs of other skills and wide-scope levels change the rolls of other other skills, the
 		// non-combat skills 01-30 will have their costs and roll chances recalculated as well.
-					
+		
 		getAttrs(["enhancerJack","enhancerLing","enhancerSch","enhancerSci","enhancerTrav","enhancerWell","interactionLevels","intellectLevels","agilityLevels","noncombatLevels","overallLevels"], function(values) {
-					
+			
 			// Check for purchased enhancers and assign costs of 3 CP for each.
 			const enhancerJackStatus=values.enhancerJack;
 			const enhancerLingStatus=values.enhancerLing;
@@ -8544,23 +8543,23 @@
 					
 			if (enhancerJackStatus!=0) {
 				enhancerJackCost = 3;
-								  }
+			}
 			if (enhancerLingStatus!=0) {
 				enhancerLingCost = 3;
-							}
+			}
 			if (enhancerSchStatus!=0) {
 				enhancerSchCost = 3;
-								  }
+			}
 			if (enhancerSciStatus!=0) {
 				enhancerSciCost = 3;
-							}
+			}
 			if (enhancerTravStatus!=0) {
 				enhancerTravCost = 3;
-						}
+			}
 			if (enhancerWellStatus!=0) {
 				enhancerWellCost = 3;
-					}
-					
+			}
+			
 			setAttrs({
 				"enhancerJackCP":enhancerJackCost,
 				"enhancerLingCP":enhancerLingCost,
@@ -8569,31 +8568,31 @@
 				"enhancerWellCP":enhancerWellCost,
 				"enhancerTravCP":enhancerTravCost
 			});
-					
+			
 			// Calculate costs for each wide-scope non-combat level.
 			const interactionSkillLevels=parseInt(values.interactionLevels)||0;
 			const intellectSkillLevels=parseInt(values.intellectLevels)||0;
 			const agilitySkillLevels=parseInt(values.agilityLevels)||0;
 			const noncombatSkillLevels=parseInt(values.noncombatLevels)||0;
 			const overallSkillLevels=parseInt(values.overallLevels)||0;
-							
+			
 			let interactionSkillLevelsCost= interactionSkillLevels*4;
 			let intellectSkillLevelsCost= intellectSkillLevels*4;
 			let agilitySkillLevelsCost= agilitySkillLevels*6;
 			let noncombatSkillLevelsCost= noncombatSkillLevels*10;
 			let overallSkillLevelsCost= overallSkillLevels*12;
-						
-						setAttrs({
+			
+			setAttrs({
 				"interactionLevelsCP":interactionSkillLevelsCost,
 				"intellectLevelsCP":intellectSkillLevelsCost,
 				"agilityLevelsCP":agilitySkillLevelsCost,
 				"noncombatLevelsCP":noncombatSkillLevelsCost,
 				"overallLevelsCP":overallSkillLevelsCost
-						});
-						
+			});
+			
 			skillEnhancersCost = enhancerJackCost+enhancerLingCost+enhancerSchCost+enhancerSciCost+enhancerTravCost+enhancerWellCost;
 			skillLevelsCost=interactionSkillLevelsCost+intellectSkillLevelsCost+agilitySkillLevelsCost+noncombatSkillLevelsCost+overallSkillLevelsCost;
-						
+			
 			setAttrs({
 				"hiddenEnhancerSkillsCost":skillEnhancersCost+skillLevelsCost,
 			});
@@ -8712,7 +8711,7 @@
 						
 	/* Calculate weapon endurance costs */
 	on("change:optionSuperHeroicEndurance change:weaponStrength01 change:weaponStrength02 change:weaponStrength03 change:weaponStrength04 change:weaponStrength05 change:shieldStrength change:strength", function() {
-		getAttrs(["optionSuperHeroicEndurance", "weaponStrength01", "weaponStrength02", "weaponStrength03", "weaponStrength04", "weaponStrength05","shieldStrength", "strength", "martialManeuverName01", "maneuverEndurance01", "treasures"], function(values) {
+		getAttrs(["optionSuperHeroicEndurance", "weaponStrength01", "weaponStrength02", "weaponStrength03", "weaponStrength04", "weaponStrength05","shieldStrength", "strength"], function(values) {
 			// If optionSuperHeroicEndurance is true, endurance cost is 1 per 5 strength, otherwise it is 1 per 10 strength used.
 											 
 			optionSuperHeroic = values.optionSuperHeroicEndurance;
@@ -8751,27 +8750,11 @@
 			if ( (enduranceCostShield<1) && (parseInt(values.shieldStrength)||0)>0) {
 				enduranceCostShield=1
 			}
-
+			
 			let enduranceCostBasic = heroRoundLow( (parseInt(values.strength)||0)/enduranceCostFactor );
 			if ( (enduranceCostBasic<1) && (parseInt(values.strength)||0)>0) {
 				enduranceCostBasic=1
 			}
-			
-			// Check to see if the first maneuver remains the default.
-			// If it is, update its endurance.
-			let defaultName = "Basic HTH Strike";
-			let currentName = values.martialManeuverName01;
-			let theEndurance = enduranceCostBasic;
-			if (currentName.localeCompare(defaultName) === 1) {
-				theEndurance = parseInt( (values.maneuverEndurance01)||0);
-			}
-			
-			let debug = values.treasures||"";
-			// debug += " damage = " + values["hiddenManeuverDamage"+maneuverId];
-			debug += " " + (parseInt(values.strength)||0)/enduranceCostFactor;
-			setAttrs({
-				"treasures":debug
-			});
 			
 			setAttrs({
 				"weaponEndurance01":enduranceCost01,
@@ -8780,8 +8763,7 @@
 				"weaponEndurance04":enduranceCost04,
 				"weaponEndurance05":enduranceCost05,
 				"shieldEndurance":enduranceCostShield,
-				"hiddenBasicEndurance":enduranceCostBasic,
-				"maneuverEndurance01":theEndurance
+				"hiddenBasicEndurance":enduranceCostBasic
 			});
 		});
 	});
@@ -8899,6 +8881,41 @@
 	/* -------------------------- */
 	/* --- Maneuver Functions --- */
 	/* -------------------------- */
+
+	/* Update Basic HTH Strike */
+	arrayOf(maxManeuverNum).forEach(num => {
+		// If strength changes enough so that hiddenBasicDamage and hiddenBasicEndurance change,
+		// look at each maneuver to see if it is a "Basic HTH Strike." If so, update its damage and endurance values.
+		// A basic strike does normal damage, so hold off if the maneuver's normal damage option is unchecked.
+		
+		var maneuverId = String(num).padStart(2,'0');
+		
+		on(`change:hiddenBasicDamage change:hiddenBasicEndurance change:maneuverNormalDamage${maneuverId}`, function() {
+			getAttrs(["treasures", "hiddenBasicEndurance", "hiddenBasicDamage", "martialManeuverName"+maneuverId, "maneuverEndurance"+maneuverId, "maneuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId], function(values) {
+				var attributes = new Object();
+				
+				let defaultName = "Basic HTH Strike";
+				let currentName = values["martialManeuverName"+maneuverId]||"";
+				let theEndurance = parseInt(values["maneuverEndurance"+maneuverId])||0;
+				let theDamage = values["maneuverDamage"+maneuverId]||0;
+				
+				if ( (currentName.localeCompare(defaultName) === 0) && (values["maneuverNormalDamage"+maneuverId] === "on")) {
+					// The name is the keyword defaultName.
+					theEndurance = parseInt(values.hiddenBasicEndurance)||0;
+					theDamage = values.hiddenBasicDamage;
+				}
+				
+				let debug = values.treasures;
+				debug += maneuverId;
+				
+				attributes["maneuverEndurance"+maneuverId] = theEndurance;
+				attributes["maneuverDamage"+maneuverId] = theDamage;
+				attributes["treasures"] = debug;
+				setAttrs(attributes);
+			});
+		});
+	});
+
 
 	/* Show Maneuver XX */
 	arrayOf(maxManeuverNum).forEach(num => {
@@ -9075,15 +9092,15 @@
 			maneuverDamage09=maneuverDamage09.replace(/[^\ddD\\+\\-]/g,"");
 			
 			setAttrs({
-				hiddenManeuverDamage01:maneuverDamage01,
-				hiddenManeuverDamage02:maneuverDamage02,
-				hiddenManeuverDamage03:maneuverDamage03,
-				hiddenManeuverDamage04:maneuverDamage04,
-				hiddenManeuverDamage05:maneuverDamage05,
-				hiddenManeuverDamage06:maneuverDamage06,
-				hiddenManeuverDamage07:maneuverDamage07,
-				hiddenManeuverDamage08:maneuverDamage08,
-				hiddenManeuverDamage09:maneuverDamage09
+				"hiddenManeuverDamage01":maneuverDamage01,
+				"hiddenManeuverDamage02":maneuverDamage02,
+				"hiddenManeuverDamage03":maneuverDamage03,
+				"hiddenManeuverDamage04":maneuverDamage04,
+				"hiddenManeuverDamage05":maneuverDamage05,
+				"hiddenManeuverDamage06":maneuverDamage06,
+				"hiddenManeuverDamage07":maneuverDamage07,
+				"hiddenManeuverDamage08":maneuverDamage08,
+				"hiddenManeuverDamage09":maneuverDamage09
 			});
 		});
 	});
@@ -9167,6 +9184,7 @@
 			});
 		});
 	});
+	
 	
 	function hitLocationDetails(hitLocation) {
 		// Used to get information about a hit location.
@@ -9348,15 +9366,6 @@
 			
 			var theStrengthDamage=theNumberOfD6.concat("d6+",theNumberOfD3.toString(),"d3");
 			
-			// Check to see if the first maneuver remains the default.
-			// If it is, update its damage.
-			let defaultName = "Basic HTH Strike";
-			let currentName = values.martialManeuverName01;
-			let theDamage = theStrengthDamage;
-			if (currentName.localeCompare(defaultName) === 1) {
-				theDamage = values.maneuverDamage01;
-			}
-			
 			setAttrs({
 				"hiddenShieldDamage01":theShieldDamage,
 				"hiddenWeaponDamage01":theWeaponDamage01,
@@ -9364,8 +9373,7 @@
 				"hiddenWeaponDamage03":theWeaponDamage03,
 				"hiddenWeaponDamage04":theWeaponDamage04,
 				"hiddenWeaponDamage05":theWeaponDamage05,
-				"hiddenBasicDamage":theStrengthDamage,
-				"maneuverDamage01":theDamage
+				"hiddenBasicDamage":theStrengthDamage
 			});
 		});
 	});
@@ -9539,53 +9547,8 @@
 			});				
 		});
 	});
+		
 	
-// 	on('clicked:standardAttackRoll', (info) => {
-// 		// Roll attack and damage dice for standardAttack
-// 
-// 		getAttrs(["hiddenBasicEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
-// 			var theRoll = values.whisperToGM||"";
-// 			let useHitLocations = values.optionHitLocationSystem != 0;
-// 
-// 			let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
-// 
-// 			theRoll += "&{template:custom-normal-attack} {{title=@{character_name} - @{character_title}}} "
-// 				+ "{{subtitle= Makes a normal attack with Strength @{strength}}} ";
-// 			if (values.displayDegreeOfSuccess != 0) {
-// 				theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll] + @{ocv}[OCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifier|0}[Modifier]]]}} ";
-// 			} else {
-// 				theRoll += "{{OCV=[[@{ocv}[OCV] - @{targetOCVPenalty}[TargetOCV] + ?{Modifier|0}[Modifier]]]}} " + "{{Result=[[3d6cf6cs1]]}}";
-// 			}
-// 			theRoll += (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
-// 				+ "{{STUN=[[@{hiddenManeuverDamage01}]]}} "
-// 				+ "{{BODY=[[0[See STUN]]]}}";
-// 			if (useHitLocations)
-// 				theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
-// 
-// 			startRoll(theRoll, (results) => {
-// 				let theMessage = " ";
-// 				let computed = convertStunToBody(results.results.STUN.rolls);
-// 
-// 				// Get hit location message if system used.
-// 				if (useHitLocations) {
-// 					theMessage = hitLocationDetails(results.results.HITLOC.result).normalMessage;
-// 				}
-// 
-// 				let theResult = new Object();
-// 				theResult.BODY = computed;
-// 				theResult.HITLOC = theMessage;
-// 					
-// 				// Subtract END cost if option checked.
-// 				if (values.optionAutoSubtractEND != 0) {
-// 					subtractEndurance(subtractENDAmt);
-// 				}
-// 
-// 				finishRoll(results.rollId, theResult);
-// 			});					
-// 		});
-// 	});
-	
-						
 	/* ---------------- */
 	/* Equipment Movers */
 	/* ---------------- */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -345,8 +345,10 @@
 					<div class="subitem-characteristics-perception-stat-container">
 						<h1>Perception</h1>
 						<div class="subitem-characteristics-perception-column-container">
-							<input type="text" name="attr_intelligenceChance" title="@{intelligenceChance}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_enhancedPerceptionModifier" title="@{enhancedPerceptionModifier}" value="0" min="-10" max="10" step="1" tabindex="29"></span>
+							
+							<input type="text" name="attr_perceptionEnhanced" title="@{perceptionEnhanced}" value="11" readonly tabindex="-1">
+							
 							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRoll" title="%{perceptionRoll}" >Roll</button>
 						</div>
 					</div>
@@ -354,8 +356,10 @@
 					<div class="subitem-characteristics-perception-stat-container">
 						<input type="text" value="Vision" name="attr_perceptionVisionLabel" title="@{perceptionVisionLabel}" maxlength="12" tabindex="30">
 						<div class="subitem-characteristics-perception-column-container">
-							<input type="text" name="attr_perceptionEnhanced" title="@{perceptionEnhanced}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_perceptionModifierVision" title="@{perceptionModifierVision}" value="0" min="-10" max="10" step="1" tabindex="31"></span>
+							
+							<input type="text" name="attr_perceptionVision" title="@{perceptionVision}" value="11" readonly tabindex="-1">
+							
 							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRollVision" title="%{roll_perceptionRollVision}" >Roll</button>
 						</div>
 					</div>
@@ -363,8 +367,10 @@
 					<div class="subitem-characteristics-perception-stat-container">
 						<input type="text" value="Hearing" name="attr_perceptionHearingLabel" title="@{perceptionHearingLabel}" maxlength="12" tabindex="32">
 						<div class="subitem-characteristics-perception-column-container">
-							<input type="text" name="attr_perceptionEnhanced" title="@{perceptionEnhanced}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_perceptionModifierHearing" title="@{perceptionModifierHearing}" value="0" min="-10" max="10" step="1" tabindex="33"></span>
+							
+							<input type="text" name="attr_perceptionHearing" title="@{perceptionHearing}" value="11" readonly tabindex="-1">
+							
 							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRollHearing" title="%{roll_perceptionRollHearing}" >Roll</button>
 						</div>
 					</div>
@@ -372,8 +378,10 @@
 					<div class="subitem-characteristics-perception-stat-container">
 						<input type="text" value="Smell" name="attr_perceptionSmellLabel" title="@{perceptionSmellLabel}" maxlength="12" tabindex="34">
 						<div class="subitem-characteristics-perception-column-container">
-							<input type="text" name="attr_perceptionEnhanced" title="@{perceptionEnhanced}" value="11" readonly tabindex="-1">
 							<span>+<input type="number" name="attr_perceptionModifierSmell" title="@{perceptionModifierSmell}" value="0" min="-10" max="10" step="1" tabindex="35"></span>
+							
+							<input type="text" name="attr_perceptionSmell" title="@{perceptionSmell}" value="11" readonly tabindex="-1">
+							
 							<button type="action" class="button buttonRoll" tabindex="-1" name="act_perceptionRollSmell" title="%{roll_perceptionRollSmell}" >Roll</button>
 						</div>
 					</div>
@@ -6883,28 +6891,28 @@
 				const dcvCost = parseInt(values.dcvCP)||0;
 				const omcvCost = parseInt(values.omcvCP)||0;
 				const dmcvCost = parseInt(values.dmcvCP)||0;
-	
+				
 				const speedCost = parseInt(values.speedCP)||0;
-			
+				
 				const pdCost = parseInt(values.pdCP)||0;
 				const edCost = parseInt(values.edCP)||0;
 				const bodyCost = parseInt(values.bodyCP)||0;
 				const stunCost = parseInt(values.stunCP)||0;
 				const endCost = parseInt(values.enduranceCP)||0;
 				const recCost = parseInt(values.recoveryCP)||0;
-	
+				
 				const runningCost = parseInt(values.runningCP)||0;
 				const leapingCost = parseInt(values.leapingCP)||0;
 				const swimmingCost = parseInt(values.swimmingCP)||0;
-			
+				
 				let primaryAttributesCost = strengthCost+dexterityCost+constitutionCost+intelligenceCost+egoCost+presenceCost;	
 				let combatValuesCost = ocvCost+dcvCost+omcvCost+dmcvCost;
 				let defenseCost = pdCost+edCost;
 				let healthCost = bodyCost+stunCost+endCost+recCost;
 				let movementCost = runningCost+leapingCost+swimmingCost;
-			
+				
 				let characterAttributeCost = primaryAttributesCost+combatValuesCost+speedCost+defenseCost+healthCost+movementCost;
-			
+				
 			setAttrs({
 					"characteristicsCost":parseInt(characterAttributeCost)
 			});
@@ -6923,7 +6931,7 @@
 			let statCP = 0;
 			var liftCapability;
 			var freeCarry;
-	
+			
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
 			} else {
@@ -6943,7 +6951,7 @@
 						break;
 				default: liftCapability=Math.round(25*Math.pow(2,(statValue/5)));
 			}
-	
+			
 			freeCarry=liftCapability/10;
 			
 			// Update cost and roll chance		
@@ -6969,7 +6977,7 @@
 			const maxStat = 20;
 			const costStat = 2;
 			let statCP = 0;
-	
+			
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
 			} else {
@@ -6997,7 +7005,7 @@
 			const maxStat = 20;
 			const costStat = 1;
 			let statCP = 0;
-	
+			
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
 			} else {
@@ -7015,9 +7023,9 @@
 		});
 	});
 	
-	// Update Intelligence
-	on("change:intelligence change:enhancedPerceptionModifier change:useCharacteristicMaximums", function () {
-		getAttrs(["intelligence","useCharacteristicMaximums","enhancedPerceptionModifier"], function(values) {
+	// Update Intelligence and Perception
+	on("change:intelligence change:enhancedPerceptionModifier change:perceptionModifierVision change:perceptionModifierHearing change:perceptionModifierSmell change:useCharacteristicMaximums", function () {
+		getAttrs(["intelligence", "useCharacteristicMaximums", "enhancedPerceptionModifier", "perceptionModifierVision", "perceptionModifierHearing", "perceptionModifierSmell"], function(values) {
 			
 			const statValue = parseInt(values.intelligence)||0;
 			const useMaximums = values.useCharacteristicMaximums;
@@ -7029,26 +7037,32 @@
 			// The base value of perception is the intelligence roll. The Perception roll is the base value plus the enhancedPerceptionModifier. 
 			// Individual senses start at Intelligence Chance + Perception modifier.
 			const enhancedPerceptionMod = parseInt(values.enhancedPerceptionModifier)||0;
+			const perceptionModVision = parseInt(values.perceptionModifierVision)||0;
+			const perceptionModHearing = parseInt(values.perceptionModifierHearing)||0;
+			const perceptionModSmell = parseInt(values.perceptionModifierSmell)||0;
 				
 			let statCP = 0;
 			
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
-					} else {
+			} else {
 				statCP=(statValue-baseStat)*costStat;
 			}
-	
+			
 			// Update cost and roll chance		
-				setAttrs({
+			setAttrs({
 				"intelligenceCP":statCP,
 				"intelligenceChance":calculateRoll(statValue),
-				"perceptionEnhanced":calculateRoll(statValue)+enhancedPerceptionMod
-	});
-
+				"perceptionEnhanced":calculateRoll(statValue)+enhancedPerceptionMod,
+				"perceptionVision":calculateRoll(statValue)+enhancedPerceptionMod+perceptionModVision,
+				"perceptionHearing":calculateRoll(statValue)+enhancedPerceptionMod+perceptionModHearing,
+				"perceptionSmell":calculateRoll(statValue)+enhancedPerceptionMod+perceptionModSmell
+			});
+				
 			// Update costs
 			sumCharacteristicPoints();
-				});
-		});
+			});
+	});
 
 	// Update Ego
 	on("change:ego change:useCharacteristicMaximums", function () {
@@ -7060,7 +7074,7 @@
 			const maxStat = 20;
 			const costStat = 1;
 			let statCP = 0;
-	
+			
 			if ( (statValue>maxStat) && (useMaximums != 0) ) {
 				statCP=(statValue-maxStat)*costStat+(statValue-baseStat)*costStat;
 			} else {
@@ -8174,6 +8188,7 @@
 		});
 	});
 
+
 	var perceptionTypes = ['', 'Vision', 'Hearing', 'Smell']
 	perceptionTypes.forEach(percType => {
 		var subtitleExt = (percType != '') ? " - @{perception"+percType+"Label}" : "";
@@ -8203,6 +8218,7 @@
 			});
 		});
 	});
+
 
 	arrayOf(maxSkillNum).forEach(num => {
 		var skillId = String(num).padStart(2,'0');	

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1239,7 +1239,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-01">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand01">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1311,7 +1311,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-02">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand02">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1383,7 +1383,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-03">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand03">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1455,7 +1455,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-04">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand04">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1527,7 +1527,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-05">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand05">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1599,7 +1599,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-06">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand06">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1671,7 +1671,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-07">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand07">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1743,7 +1743,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-08">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand08">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>
@@ -1815,7 +1815,7 @@
 							<div class="custom-expand-button-container">
 								<div class="custom-expand-button-container-09">
 									<button type="action" class="buttonExpand" name="act_maneuverExpand09">
-										<div class=custom-button-triangle>
+										<div class=custom-button-triangle-alt>
 										</div>
 									</button>
 								</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -6087,6 +6087,14 @@
 			
 			<div class="item-options-row">
 				<label class="container-checkbox">
+					<input type="checkbox" name="attr_optionTakesNoSTUN">
+					<span class="checkmark" title="@{optionTakesNoSTUN}"></span>
+				</label>
+				<h1>Takes No STUN</h1>
+			</div>
+			
+			<div class="item-options-row">
+				<label class="container-checkbox">
 					<input type="checkbox" checked="checked" name="attr_optionAutoSubtractEND">
 					<span class="checkmark" title="@{optionAutoSubtractEND}"></span>
 				</label>
@@ -6111,10 +6119,10 @@
 			
 			<div class="item-options-row">
 				<label class="container-checkbox">
-					<input type="checkbox" name="attr_optionTakesNoSTUN">
-					<span class="checkmark" title="@{optionTakesNoSTUN}"></span>
+					<input type="checkbox" checked="checked" name="attr_optionResetTargeting">
+					<span class="checkmark" title="@{optionResetTargeting}"></span>
 				</label>
-				<h1>Takes No STUN</h1>
+				<h1>Health Reset Buttons Also Reset Hit Location and Range</h1>
 			</div>
 			
 			<div class="item-options-row">
@@ -6123,14 +6131,6 @@
 					<span class="checkmark" title="@{displayDegreeOfSuccess}"></span>
 				</label>
 				<h1>Display Degree of Success</h1>
-			</div>
-			
-			<div class="item-options-row">
-				<label class="container-checkbox">
-					<input type="checkbox" checked="checked" name="attr_optionResetTargeting">
-					<span class="checkmark" title="@{optionResetTargeting}"></span>
-				</label>
-				<h1>Health reset buttons also reset target and range</h1>
 			</div>
 			
 			<div class="item-options-row">
@@ -6180,6 +6180,9 @@
 	  	<span><input class="tally" type="number" value="0" min="0" name=attr_totalCharacterCost title="@{totalCharacterCost}" readonly="true" tabindex="-1"/></span>
 	</div>
 </div>
+
+<!-- Hidden sheet identifier -->
+<input type="hidden" name="attr_sheet_name" value="HeroSystem6eHeroic"/>
 
 <!-- Hidden variables for combat rolls -->
 <input type="hidden" name="attr_targetOCVpenalty" value="0"/>
@@ -6536,10 +6539,22 @@
 		}
 		
 		if (version < 2.3) {
+			values = await _getAttrs(["martialManeuverOCV01", "martialManeuverOCV02", "martialManeuverOCV03", "martialManeuverOCV04", "martialManeuverOCV05", "martialManeuverOCV06", "martialManeuverOCV07", "martialManeuverOCV08", "martialManeuverOCV09", "martialManeuverDCV01", "martialManeuverDCV02", "martialManeuverDCV03", "martialManeuverDCV04", "martialManeuverDCV05", "martialManeuverDCV06", "martialManeuverDCV07", "martialManeuverDCV08", "martialManeuverDCV09", "strength", "intelligence", "useCharacteristicMaximums", "enhancedPerceptionModifier", "perceptionModifierVision", "perceptionModifierHearing", "perceptionModifierSmell"]);
+			
+			// Ensure hiddenBasicDamage is available.
+			let statValue = parseInt(values.strength)||0;
+			let theNumberOfD6 = (parseInt((statValue - (statValue%5))/5)||0).toString();
+			
+			let theNumberOfD3 = 0;
+			if (statValue%5 > 2) {
+				theNumberOfD3 = 1;
+			}
+			
+			var hiddenDamage = theNumberOfD6.concat("d6+",theNumberOfD3.toString(),"d3");
+			
+			attributes.hiddenBasicDamage = hiddenDamage;
+			
 			// Update martial maneuver text CVs to integers.
-			
-			values = await _getAttrs(["martialManeuverOCV01", "martialManeuverOCV02", "martialManeuverOCV03", "martialManeuverOCV04", "martialManeuverOCV05", "martialManeuverOCV06", "martialManeuverOCV07", "martialManeuverOCV08", "martialManeuverOCV09", "martialManeuverDCV01", "martialManeuverDCV02", "martialManeuverDCV03", "martialManeuverDCV04", "martialManeuverDCV05", "martialManeuverDCV06", "martialManeuverDCV07", "martialManeuverDCV08", "martialManeuverDCV09"]);
-			
 			attributes.martialManeuverOCV01 = parseInt(values.martialManeuverOCV01)||0;
 			attributes.martialManeuverDCV01 = parseInt(values.martialManeuverDCV01)||0;
 			
@@ -6565,7 +6580,22 @@
 			attributes.martialManeuverDCV08 = parseInt(values.martialManeuverDCV08)||0;
 			
 			attributes.martialManeuverOCV09 = parseInt(values.martialManeuverOCV09)||0;
-			attributes.martialManeuverDCV09 = parseInt(values.martialManeuverDCV09)||0;
+			attributes.martialManeuverDCV09 = parseInt(values.martialManeuverDCV09)||0
+			attributes.martialManeuverDamage09 = hiddenDamage;
+			
+			// Update perception roll chances.
+			statValue = parseInt(values.intelligence)||10;
+			enhancedPerceptionMod = parseInt(values.enhancedPerceptionModifier)||0;
+			perceptionModVision = parseInt(values.perceptionModifierVision)||0;
+			perceptionModHearing = parseInt(values.perceptionModifierHearing)||0;
+			perceptionModSmell = parseInt(values.perceptionModifierSmell)||0;
+			
+			attributes.perceptionVision = calculateRoll(statValue) + enhancedPerceptionMod + perceptionModVision;
+			attributes.perceptionHearing = calculateRoll(statValue) + enhancedPerceptionMod + perceptionModHearing;
+			attributes.perceptionSmell = calculateRoll(statValue) + enhancedPerceptionMod + perceptionModSmell;
+			
+			// Add sheet_name identifier.
+			attributes.sheet_name = "HeroSystem6eHeroic";
 			
 			version = 2.3;
 		}
@@ -9007,7 +9037,6 @@
 				
 				if (currentEffect.includes(keywordPhrase) && isNormalDamage) {
 					// The effect includes the keyword phrase and the maneuver is still a normal damage attack.
-					attributes["treasures"] = "invoked";
 					theEndurance = parseInt(values.hiddenBasicEndurance)||0;
 					theDamage = values.hiddenBasicDamage;
 					theHiddenDamage = values.hiddenBasicDamage;
@@ -9498,12 +9527,12 @@
 			
 			
 			// Calculate basic strength damage dice and create a roll20 dice string of d6s and d3s.
-			let theStrength=parseInt(values.strength)||0;
-			let theNumberOfD6=(parseInt((theStrength-(theStrength%5))/5)||0).toString();
+			let theStrength = parseInt(values.strength)||0;
+			let theNumberOfD6 = (parseInt((theStrength - (theStrength%5))/5)||0).toString();
 			
-			let theNumberOfD3=0;
-			if (theStrength%5>2) {
-				theNumberOfD3=1;
+			let theNumberOfD3 = 0;
+			if (theStrength%5 > 2) {
+				theNumberOfD3 = 1;
 			}
 			
 			var theStrengthDamage=theNumberOfD6.concat("d6+",theNumberOfD3.toString(),"d3");

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -8400,7 +8400,9 @@
 					});
 				});
 					
+	/* ----------------------------------------------------- */
 	/* Martial Skills, which are entered in the Gear Section */
+	/* ----------------------------------------------------- */
 
 	/* Expanders for Maneuvers */
 	arrayOf(maxManeuverNum).forEach(num => {
@@ -8645,6 +8647,7 @@
 	/* --- Maneuver Functions --- */
 	/* -------------------------- */
 
+	/* Show Maneuver XX */
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');	
 		on(`clicked:showMartialRoll${maneuverId}`, (info) => {
@@ -8664,6 +8667,123 @@
 			});
 		});
 	});
+	
+	// /* Activate Maneuver XX */
+	arrayOf(maxManeuverNum).forEach(num => {
+		var maneuverId = String(num).padStart(2,'0');
+		on(`clicked:martialAttackRoll${maneuverId}`, (info)  => {
+			// Roll attack and damage dice for Martial Maneuver XX.
+			
+			getAttrs(["hiddenMartialDamage"+maneuverId, "martialNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "hiddenBasicEndurance",
+					"optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
+				var theRoll = values.whisperToGM||"";
+				let useHitLocations = values.optionHitLocationSystem != 0;
+				let isNormalDamage = values["martialNormalDamage"+maneuverId] != 0;
+			
+				let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
+			
+				let dmgType = isNormalDamage ? "STUN" : "BODY";
+				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
+				
+				// If isNormalDamage is TRUE, use the Normal Damage template.
+				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
+						+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{martialManeuverName"+maneuverId+"}}} ";
+				if (values.displayDegreeOfSuccess != 0) {
+					// theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
+					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
+				} else {
+					// theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
+					// + "{{Result=[[3d6cf6cs1]]}}";
+					theRoll += "{{OCV=[[@{ocv}[OCV]-@{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
+					+ "{{Result=[[3d6cf6cs1]]}}";
+				}
+				theRoll	+= (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
+						+ "{{"+dmgType+"=[[@{hiddenMartialDamage"+maneuverId+"}]]}} "
+						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
+				if (useHitLocations)
+					theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
+			
+				startRoll(theRoll, (results) => {
+					let computed = parseInt(results.results[dmgType].result)||0;
+					let theSTUNMultiplier = Math.floor(Math.random()*3+1);
+			
+			// 		// Get hit location message if system used.
+			// 		if (useHitLocations) {
+			// 			let theHitLocation = hitLocationDetails(results.results.HITLOC.result);
+			// 			theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
+			// 			theSTUNMultiplier = theHitLocation.STUNx;
+			// 		}
+			// 
+			// 		if (isNormalDamage) {
+			// 			// Convert dice roll to equivalent BODY damage.
+			// 			computed = convertStunToBody(results.results.STUN.rolls);
+			// 		} else {
+			// 			theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
+			// 			computed *= theSTUNMultiplier;
+			// 
+			// 			computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
+			// 		}
+			// 
+			// 		let theResult = new Object();
+			// 		theResult[otherDmgType] = computed;
+			// 		theResult.HITLOC = theMessage;
+			// 			
+			// 		// Subtract END cost if option checked.
+			// 		if (values.optionAutoSubtractEND != 0) {
+			// 			subtractEndurance(subtractENDAmt);
+			// 		}
+			
+					finishRoll(results.rollId, theResult);
+				});
+			});
+		});
+	});
+	
+	
+	/* Clean Maneuver Damage Dice */
+	on("change:martialDamage01 change:martialDamage02 change:martialDamage03 change:martialDamage04 change:martialDamage05 change:martialDamage06 change:martialDamage07 change:martialDamage08", function () {
+		// This function attempts to clean damage text input into text more likely to be rollable dice.
+		// Only characters 0-9, d, D, +, and - are passed to martial attack rolls.
+		
+		getAttrs(["martialDamage01","martialDamage02","martialDamage03","martialDamage04","martialDamage05","martialDamage06","martialDamage07", "martialDamage08"], function(values) {
+			
+			var martialDamage01=values.martialDamage01;
+			martialDamage01=martialDamage01.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var martialDamage02=values.martialDamage02;
+			martialDamage02=martialDamage02.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var martialDamage03=values.martialDamage03;
+			martialDamage03=martialDamage03.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var martialDamage04=values.martialDamage04;
+			martialDamage04=martialDamage04.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var martialDamage05=values.martialDamage05;
+			martialDamage05=martialDamage05.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var martialDamage06=values.martialDamage06;
+			martialDamage06=martialDamage06.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var martialDamage07=values.martialDamage07;
+			martialDamage07=martialDamage07.replace(/[^\ddD\\+\\-]/g,"");
+			
+			var martialDamage08=values.martialDamage08;
+			martialDamage08=martialDamage08.replace(/[^\ddD\\+\\-]/g,"");
+			
+			setAttrs({
+				hiddenMartialDamage01:martialDamage01,
+				hiddenMartialDamage02:martialDamage02,
+				hiddenMartialDamage03:martialDamage03,
+				hiddenMartialDamage04:martialDamage04,
+				hiddenMartialDamage05:martialDamage05,
+				hiddenMartialDamage06:martialDamage06,
+				hiddenMartialDamage07:martialDamage07,
+				hiddenMartialDamage08:martialDamage08
+			});
+		});
+	});
+
 
 	/* ------------------------------------------------ */
 	/* --- Weapon Attacks and Hit Location Helpers  --- */

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1255,8 +1255,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" value="1/2" tabindex="171"/>
-							<input type="number" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" value="0" min="0" step="1" tabindex="172"/>
+							<input type="text" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" value="1/2" tabindex="181"/>
+							<input type="number" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" value="0" min="0" step="1" tabindex="182"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack01" title="%{maneuverAttack01}">Roll</button>
 						</div>
 						
@@ -1265,19 +1265,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="" maxlength="100" tabindex="173"/>
-										<input type="number" value="" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="174"/>
+										<input type="text" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" value="" maxlength="100" tabindex="183"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx01" title="@{martialManeuverSTUNx01}" value="0" min="0" max="9" step="1" tabindex="184"/>
+										<input type="number" value="" step="1" min="0" name="attr_maneuverEndurance01" title="@{maneuverEndurance01}" tabindex="185"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" value="0" step="1" tabindex="175"/>
+										<input type="number" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" value="0" step="1" tabindex="186"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" value="0" step="1" tabindex="176"/>
+										<input type="number" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" value="0" step="1" tabindex="187"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="" maxlength="12" tabindex="177"/>
+										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="" maxlength="12" tabindex="188"/>
 										
 										<h1>N:</h1>
 										
@@ -1314,7 +1316,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName02" title="@{martialManeuverName02}" value="" maxlength="34" tabindex="180"/>
+							<input type="text" name="attr_martialManeuverName02" title="@{martialManeuverName02}" value="" maxlength="34" tabindex="190"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp02">
@@ -1325,8 +1327,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" value="1/2" tabindex="181"/>
-							<input type="number" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}"  value="0" min="0" step="1" tabindex="182"/>
+							<input type="text" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" value="1/2" tabindex="191"/>
+							<input type="number" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}"  value="0" min="0" step="1" tabindex="192"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack02" title="%{maneuverAttack02}">Roll</button>
 						</div>
 						
@@ -1335,19 +1337,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" value="" maxlength="100" tabindex="183"/>
-										<input type="number" name="attr_maneuverEndurance02" title="@{maneuverEndurance02}" value="0" step="1" min="0" tabindex="184"/>
+										<input type="text" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" value="" maxlength="100" tabindex="193"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx02" title="@{martialManeuverSTUNx02}" value="0" min="0" max="9" step="1" tabindex="194"/>
+										<input type="number" name="attr_maneuverEndurance02" title="@{maneuverEndurance02}" value="0" step="1" min="0" tabindex="195"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" value="0" step="1" tabindex="185"/>
+										<input type="number" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" value="0" step="1" tabindex="196"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" value="0" step="1" tabindex="186"/>
+										<input type="number" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" value="0" step="1" tabindex="197"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage02" title="@{maneuverDamage02}" value="0" maxlength="12" tabindex="187"/>
+										<input type="text" name="attr_maneuverDamage02" title="@{maneuverDamage02}" value="0" maxlength="12" tabindex="198"/>
 										
 										<h1>N:</h1>
 										
@@ -1384,7 +1388,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName03" title="@{martialManeuverName03}" value="" maxlength="34" tabindex="190"/>
+							<input type="text" name="attr_martialManeuverName03" title="@{martialManeuverName03}" value="" maxlength="34" tabindex="200"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp03">
@@ -1395,8 +1399,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" value="1/2" tabindex="191"/>
-							<input type="number" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}"  value="0" min="0" step="1" tabindex="192"/>
+							<input type="text" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" value="1/2" tabindex="201"/>
+							<input type="number" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}"  value="0" min="0" step="1" tabindex="202"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack03" title="%{maneuverAttack03}">Roll</button>
 						</div>
 						
@@ -1405,19 +1409,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" value="" maxlength="100" tabindex="193"/>
-										<input type="number" name="attr_maneuverEndurance03" title="@{maneuverEndurance03}" value="0" step="1" min="0" tabindex="194"/>
+										<input type="text" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" value="" maxlength="100" tabindex="203"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx03" title="@{martialManeuverSTUNx03}" value="0" min="0" max="9" step="1" tabindex="204"/>
+										<input type="number" name="attr_maneuverEndurance03" title="@{maneuverEndurance03}" value="0" step="1" min="0" tabindex="205"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" value="0" step="1" tabindex="195"/>
+										<input type="number" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" value="0" step="1" tabindex="206"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" value="0" step="1" tabindex="196"/>
+										<input type="number" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" value="0" step="1" tabindex="207"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage03" title="@{maneuverDamage03}" value="0" maxlength="12" tabindex="197"/>
+										<input type="text" name="attr_maneuverDamage03" title="@{maneuverDamage03}" value="0" maxlength="12" tabindex="208"/>
 										
 										<h1>N:</h1>
 										
@@ -1454,7 +1460,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName04" title="@{martialManeuverName04}" value="" maxlength="34" tabindex="200"/>
+							<input type="text" name="attr_martialManeuverName04" title="@{martialManeuverName04}" value="" maxlength="34" tabindex="210"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp04">
@@ -1465,8 +1471,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" value="1/2" tabindex="201"/>
-							<input type="number" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}"  value="0" min="0" step="1" tabindex="202"/>
+							<input type="text" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" value="1/2" tabindex="211"/>
+							<input type="number" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}"  value="0" min="0" step="1" tabindex="212"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack04" title="%{maneuverAttack04}">Roll</button>
 						</div>
 						
@@ -1475,19 +1481,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" value="" maxlength="100" tabindex="203"/>
-										<input type="number" name="attr_maneuverEndurance04" title="@{maneuverEndurance04}" value="0" step="1" min="0" tabindex="204"/>
+										<input type="text" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" value="" maxlength="100" tabindex="213"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx04" title="@{martialManeuverSTUNx04}" value="0" min="0" max="9" step="1" tabindex="214"/>
+										<input type="number" name="attr_maneuverEndurance04" title="@{maneuverEndurance04}" value="0" step="1" min="0" tabindex="215"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" value="0" step="1" tabindex="205"/>
+										<input type="number" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" value="0" step="1" tabindex="216"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" value="0" step="1" tabindex="206"/>
+										<input type="number" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" value="0" step="1" tabindex="217"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage04" title="@{maneuverDamage04}" value="0" maxlength="12" tabindex="207"/>
+										<input type="text" name="attr_maneuverDamage04" title="@{maneuverDamage04}" value="0" maxlength="12" tabindex="218"/>
 										
 										<h1>N:</h1>
 										
@@ -1524,7 +1532,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName05" title="@{martialManeuverName05}" value="" maxlength="34" tabindex="210"/>
+							<input type="text" name="attr_martialManeuverName05" title="@{martialManeuverName05}" value="" maxlength="34" tabindex="220"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp05">
@@ -1535,8 +1543,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" value="1/2" tabindex="211"/>
-							<input type="number" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}"  value="0" min="0" step="1" tabindex="212"/>
+							<input type="text" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" value="1/2" tabindex="221"/>
+							<input type="number" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}"  value="0" min="0" step="1" tabindex="222"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack05" title="%{maneuverAttack05}">Roll</button>
 						</div>
 						
@@ -1545,19 +1553,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" value="" maxlength="100" tabindex="213"/>
-										<input type="number" name="attr_maneuverEndurance05" title="@{maneuverEndurance05}" value="0" step="1" min="0" tabindex="214"/>
+										<input type="text" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" value="" maxlength="100" tabindex="223"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx05" title="@{martialManeuverSTUNx05}" value="0" min="0" max="9" step="1" tabindex="224"/>
+										<input type="number" name="attr_maneuverEndurance05" title="@{maneuverEndurance05}" value="0" step="1" min="0" tabindex="225"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" value="0" step="1" tabindex="215"/>
+										<input type="number" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" value="0" step="1" tabindex="226"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" value="0" step="1" tabindex="216"/>
+										<input type="number" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" value="0" step="1" tabindex="227"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage05" title="@{maneuverDamage05}" value="0" maxlength="12" tabindex="217"/>
+										<input type="text" name="attr_maneuverDamage05" title="@{maneuverDamage05}" value="0" maxlength="12" tabindex="228"/>
 										
 										<h1>N:</h1>
 										
@@ -1594,7 +1604,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName06" title="@{martialManeuverName06}" value="" maxlength="34" tabindex="220"/>
+							<input type="text" name="attr_martialManeuverName06" title="@{martialManeuverName06}" value="" maxlength="34" tabindex="230"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp06">
@@ -1605,8 +1615,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" value="1/2" tabindex="221"/>
-							<input type="number" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}"  value="0" min="0" step="1" tabindex="222"/>
+							<input type="text" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" value="1/2" tabindex="231"/>
+							<input type="number" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}"  value="0" min="0" step="1" tabindex="232"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack06" title="%{maneuverAttack06}">Roll</button>
 						</div>
 						
@@ -1615,19 +1625,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" value="" maxlength="100" tabindex="223"/>
-										<input type="number" name="attr_maneuverEndurance06" title="@{maneuverEndurance06}" value="0" step="1" min="0" tabindex="224"/>
+										<input type="text" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" value="" maxlength="100" tabindex="233"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx06" title="@{martialManeuverSTUNx06}" value="0" min="0" max="9" step="1" tabindex="234"/>
+										<input type="number" name="attr_maneuverEndurance06" title="@{maneuverEndurance06}" value="0" step="1" min="0" tabindex="235"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" value="0" step="1" tabindex="225"/>
+										<input type="number" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" value="0" step="1" tabindex="236"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" value="0" step="1" tabindex="226"/>
+										<input type="number" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" value="0" step="1" tabindex="237"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage06" title="@{maneuverDamage06}" value="0" maxlength="12" tabindex="227"/>
+										<input type="text" name="attr_maneuverDamage06" title="@{maneuverDamage06}" value="0" maxlength="12" tabindex="238"/>
 										
 										<h1>N:</h1>
 										
@@ -1664,7 +1676,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName07" title="@{martialManeuverName07}" value="" maxlength="34" tabindex="230"/>
+							<input type="text" name="attr_martialManeuverName07" title="@{martialManeuverName07}" value="" maxlength="34" tabindex="240"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp07">
@@ -1675,8 +1687,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" value="1/2" tabindex="231"/>
-							<input type="number" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}"  value="0" min="0" step="1" tabindex="232"/>
+							<input type="text" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" value="1/2" tabindex="241"/>
+							<input type="number" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}"  value="0" min="0" step="1" tabindex="242"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack07" title="%{maneuverAttack07}">Roll</button>
 						</div>
 						
@@ -1685,19 +1697,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" value="" maxlength="100" tabindex="233"/>
-										<input type="number" name="attr_maneuverEndurance07" title="@{maneuverEndurance07}" value="0" step="1" min="0" tabindex="234"/>
+										<input type="text" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" value="" maxlength="100" tabindex="243"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx07" title="@{martialManeuverSTUNx07}" value="0" min="0" max="9" step="1" tabindex="244"/>
+										<input type="number" name="attr_maneuverEndurance07" title="@{maneuverEndurance07}" value="0" step="1" min="0" tabindex="245"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" value="0" step="1" tabindex="235"/>
+										<input type="number" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" value="0" step="1" tabindex="246"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" value="0" step="1" tabindex="236"/>
+										<input type="number" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" value="0" step="1" tabindex="247"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage07" title="@{maneuverDamage07}" value="0" maxlength="12" tabindex="237"/>
+										<input type="text" name="attr_maneuverDamage07" title="@{maneuverDamage07}" value="0" maxlength="12" tabindex="248"/>
 										
 										<h1>N:</h1>
 										
@@ -1722,7 +1736,7 @@
 							</div>
 						</div>
 					</div>
-
+					
 					<!-- Maneuver 08 -->
 					<div class="item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
@@ -1734,7 +1748,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName08" title="@{martialManeuverName08}" value="" maxlength="34" tabindex="240"/>
+							<input type="text" name="attr_martialManeuverName08" title="@{martialManeuverName08}" value="" maxlength="34" tabindex="250"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp08">
@@ -1745,8 +1759,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" value="1/2" tabindex="241"/>
-							<input type="number" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}"  value="0" min="0" step="1" tabindex="242"/>
+							<input type="text" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" value="1/2" tabindex="251"/>
+							<input type="number" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}"  value="0" min="0" step="1" tabindex="252"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack08" title="%{maneuverAttack08}">Roll</button>
 						</div>
 						
@@ -1755,19 +1769,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" value="" maxlength="100" tabindex="243"/>
-										<input type="number" name="attr_maneuverEndurance08" title="@{maneuverEndurance08}" value="0" step="1" min="0" tabindex="244"/>
+										<input type="text" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" value="" maxlength="100" tabindex="253"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx08" title="@{martialManeuverSTUNx08}" value="0" min="0" max="9" step="1" tabindex="254"/>
+										<input type="number" name="attr_maneuverEndurance08" title="@{maneuverEndurance08}" value="0" step="1" min="0" tabindex="255"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" value="0" step="1" tabindex="245"/>
+										<input type="number" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" value="0" step="1" tabindex="256"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" value="0" step="1" tabindex="246"/>
+										<input type="number" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" value="0" step="1" tabindex="257"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage08" title="@{maneuverDamage08}" value="0" maxlength="12" tabindex="247"/>
+										<input type="text" name="attr_maneuverDamage08" title="@{maneuverDamage08}" value="0" maxlength="12" tabindex="258"/>
 										
 										<h1>N:</h1>
 										
@@ -1804,7 +1820,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverName09" title="@{martialManeuverName09}" value="Basic HTH Strike" maxlength="34" tabindex="250"/>
+							<input type="text" name="attr_martialManeuverName09" title="@{martialManeuverName09}" value="Basic HTH Strike" maxlength="34" tabindex="260"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp09">
@@ -1815,8 +1831,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" name="attr_martialManeuverPhase09" title="@{martialManeuverPhase09}" value="1/2" tabindex="251"/>
-							<input type="number" name="attr_martialManeuverCP09" title="@{martialManeuverCP09}"  value="0" min="0" step="1" tabindex="252"/>
+							<input type="text" name="attr_martialManeuverPhase09" title="@{martialManeuverPhase09}" value="1/2" tabindex="261"/>
+							<input type="number" name="attr_martialManeuverCP09" title="@{martialManeuverCP09}"  value="0" min="0" step="1" tabindex="262"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack09" title="%{maneuverAttack09}">Roll</button>
 						</div>
 						
@@ -1825,19 +1841,21 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="Damage by STR" maxlength="100" tabindex="253"/>
-										<input type="number" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" value="2" step="1" min="0" tabindex="254"/>
+										<input type="text" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" value="Damage by STR" maxlength="100" tabindex="263"/>
+										<h1>Sx:</h1>
+										<input type="number" name="attr_martialManeuverSTUNx09" title="@{martialManeuverSTUNx09}" value="0" min="0" max="9" step="1" tabindex="264"/>
+										<input type="number" name="attr_maneuverEndurance09" title="@{maneuverEndurance09}" value="2" step="1" min="0" tabindex="265"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" name="attr_martialManeuverOCV09" title="@{martialManeuverOCV09}" value="0" step="1" tabindex="255"/>
+										<input type="number" name="attr_martialManeuverOCV09" title="@{martialManeuverOCV09}" value="0" step="1" tabindex="266"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" value="0" step="1" tabindex="256"/>
+										<input type="number" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" value="0" step="1" tabindex="267"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="2d6" maxlength="12" tabindex="257"/>
+										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="2d6" maxlength="12" tabindex="268"/>
 										
 										<h1>N:</h1>
 										
@@ -9110,6 +9128,17 @@
 	});
 	
 	
+	/* Use Maneuver XX Endurance */
+	arrayOf(maxManeuverNum).forEach(num => {
+		var maneuverId = String(num).padStart(2,'0');
+		on("clicked:buttonManeuverEND"+maneuverId, function() {
+			getAttrs(["maneuverEndurance"+maneuverId], function(values) {
+				subtractEndurance(parseInt(values["maneuverEndurance"+maneuverId]));
+			});
+		});
+	});
+	
+	
 	/* Update range penalty */
 	on("change:rangeSelection", function () {
 		getAttrs(["rangeSelection"], function(values) {
@@ -9120,17 +9149,6 @@
 			setAttrs({
 				"rangeOCVpenalty":theOCVpenalty
 			})
-		});
-	});
-	
-	
-	/* Use Maneuver XX Endurance */
-	arrayOf(maxManeuverNum).forEach(num => {
-		var maneuverId = String(num).padStart(2,'0');
-		on("clicked:buttonManeuverEND"+maneuverId, function() {
-			getAttrs(["maneuverEndurance"+maneuverId], function(values) {
-				subtractEndurance(parseInt(values["maneuverEndurance"+maneuverId]));
-			});
 		});
 	});
 	

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1220,9 +1220,10 @@
 					<input type="hidden" class="maneuver-normal-damage06" name="attr_maneuverNormalDamage06">
 					<input type="hidden" class="maneuver-normal-damage07" name="attr_maneuverNormalDamage07">
 					<input type="hidden" class="maneuver-normal-damage08" name="attr_maneuverNormalDamage08">
+					<input type="hidden" class="maneuver-normal-damage09" name="attr_maneuverNormalDamage09">
 					
 					<!-- Standard Attack -->
-					<div class="item-flex-maneuver">
+					<!-- <div class="item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
 							<div class="subitem-tab-gear-slide-flex-container-standard-attack">
 								<h1>Basic Attack:</h1>
@@ -1231,7 +1232,7 @@
 								<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_standardAttackRoll" title="%{standardAttackRoll}">Roll</button>
 							</div>
 						</div>
-					</div>
+					</div> -->
 
 					<input type="hidden" class="sheet-maneuver-toggle" name="attr_maneuverToggle"  value="maneuverExpand01" />
 					
@@ -1762,7 +1763,73 @@
 								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll08" title="%{showMartialRoll08}">Show</button>
 							</div>
 						</div>
-					</div>	
+					</div>
+					
+					<!-- Maneuver 09 -->
+					<div class="item-flex-maneuver">
+						<div class="subitem-flex-container-martial-row">
+							<div class="custom-expand-button-container">
+								<div class="custom-expand-button-container-09">
+									<button type="action" class="buttonExpand" name="act_maneuverExpand09">
+										<div class=custom-button-triangle>
+										</div>
+									</button>
+								</div>
+							</div>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName09" title="@{martialManeuverName09}" tabindex="228"/>
+							<div class="maneuver-mover-plus-minus-enclosure">
+								<div class="maneuver-mover-plus-minus-button">
+									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp09">
+										<span>&#10095;</span>
+									</button>
+									<button type="action" class="button buttonMinus" tabindex="-1" name="act_martialManeuverDown09">
+										<span>&#10094;</span>
+									</button>
+								</div>
+							</div>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase09" title="@{martialManeuverPhase09}" tabindex="229"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP09" title="@{martialManeuverCP09}" tabindex="230"/>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack09" title="%{maneuverAttack09}">Roll</button>
+						</div>
+						
+						<div class="sheet-maneuver-expand-09">
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect08}" tabindex="231"/>
+									</div>
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
+										<h1>OCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverOCV09" title="@{martialManeuverOCV09}" tabindex="232"/>
+										
+										<h1>DCV:</h1>
+										<input type="number" value="0" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" tabindex="233"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="0" maxlength="12" tabindex="234"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage09">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage09}"></span>
+										</label>
+										
+										<h1>B:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_maneuverBlock09">
+											<span class="checkmark-small-gray" title="@{maneuverBlock09}"></span>
+										</label>
+									</div>
+								</div>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll09" title="%{showMartialRoll09}">Show</button>
+							</div>
+						</div>
+					</div>
 				</div>
 				
 				<!-- Range Modifier Table -->
@@ -6022,6 +6089,14 @@
 <input type="hidden" name="attr_hiddenWeaponDamage04"  value="0"/>
 <input type="hidden" name="attr_hiddenWeaponDamage05"  value="0"/>
 <input type="hidden" name="attr_hiddenManeuverDamage01"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage02"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage03"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage04"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage05"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage06"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage07"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage08"  value="2d6"/>
+<input type="hidden" name="attr_hiddenManeuverDamage09"  value="2d6"/>
 <input type="hidden" name="attr_hiddenBasicEndurance" value="2"/>
 
 <!-- Hidden variables for clean power dice strings -->
@@ -6318,7 +6393,7 @@
 		if (version < 2.3) {
 			// Update martial maneuver text CVs to integers.
 			
-			values = await _getAttrs(["martialManeuverOCV01", "martialManeuverOCV02", "martialManeuverOCV03", "martialManeuverOCV04", "martialManeuverOCV05", "martialManeuverOCV06", "martialManeuverOCV07", "martialManeuverOCV08", "martialManeuverDCV01", "martialManeuverDCV02", "martialManeuverDCV03", "martialManeuverDCV04", "martialManeuverDCV05", "martialManeuverDCV06", "martialManeuverDCV07", "martialManeuverDCV08"]);
+			values = await _getAttrs(["martialManeuverOCV01", "martialManeuverOCV02", "martialManeuverOCV03", "martialManeuverOCV04", "martialManeuverOCV05", "martialManeuverOCV06", "martialManeuverOCV07", "martialManeuverOCV08", "martialManeuverOCV09", "martialManeuverDCV01", "martialManeuverDCV02", "martialManeuverDCV03", "martialManeuverDCV04", "martialManeuverDCV05", "martialManeuverDCV06", "martialManeuverDCV07", "martialManeuverDCV08", "martialManeuverDCV09"]);
 			
 			attributes.martialManeuverOCV01 = parseInt(values.martialManeuverOCV01)||0;
 			attributes.martialManeuverDCV01 = parseInt(values.martialManeuverDCV01)||0;
@@ -6343,6 +6418,9 @@
 			
 			attributes.martialManeuverOCV08 = parseInt(values.martialManeuverOCV08)||0;
 			attributes.martialManeuverDCV08 = parseInt(values.martialManeuverDCV08)||0;
+			
+			attributes.martialManeuverOCV09 = parseInt(values.martialManeuverOCV09)||0;
+			attributes.martialManeuverDCV09 = parseInt(values.martialManeuverDCV09)||0;
 			
 			version = 2.3;
 		}
@@ -6374,7 +6452,7 @@
 	const maxArmorNum = 4;
 	const maxWeaponNum = 5;
 	const maxEquipmentNum = 16;
-	const maxManeuverNum = 8;
+	const maxManeuverNum = 9;
 	const maxSkillNum = 30;
 	const maxPowerNum = 17;
 	const maxTalentNum = 7;
@@ -8805,11 +8883,11 @@
 	
 	
 	/* Clean Maneuver Damage Dice */
-	on("change:maneuverDamage01 change:maneuverDamage02 change:maneuverDamage03 change:maneuverDamage04 change:maneuverDamage05 change:maneuverDamage06 change:maneuverDamage07 change:maneuverDamage08", function () {
+	on("change:maneuverDamage01 change:maneuverDamage02 change:maneuverDamage03 change:maneuverDamage04 change:maneuverDamage05 change:maneuverDamage06 change:maneuverDamage07 change:maneuverDamage08 change:maneuverDamage09", function () {
 		// This function attempts to clean damage text input into text more likely to be rollable dice.
 		// Only characters 0-9, d, D, +, and - are passed to martial attack rolls.
 		
-		getAttrs(["maneuverDamage01","maneuverDamage02","maneuverDamage03","maneuverDamage04","maneuverDamage05","maneuverDamage06","maneuverDamage07", "maneuverDamage08"], function(values) {
+		getAttrs(["maneuverDamage01","maneuverDamage02","maneuverDamage03","maneuverDamage04","maneuverDamage05","maneuverDamage06","maneuverDamage07", "maneuverDamage08", "maneuverDamage09"], function(values) {
 			
 			var maneuverDamage01=values.maneuverDamage01;
 			maneuverDamage01=maneuverDamage01.replace(/[^\ddD\\+\\-]/g,"");
@@ -8835,6 +8913,9 @@
 			var maneuverDamage08=values.maneuverDamage08;
 			maneuverDamage08=maneuverDamage08.replace(/[^\ddD\\+\\-]/g,"");
 			
+			var maneuverDamage09=values.maneuverDamage09;
+			maneuverDamage09=maneuverDamage09.replace(/[^\ddD\\+\\-]/g,"");
+			
 			setAttrs({
 				hiddenManeuverDamage01:maneuverDamage01,
 				hiddenManeuverDamage02:maneuverDamage02,
@@ -8843,7 +8924,8 @@
 				hiddenManeuverDamage05:maneuverDamage05,
 				hiddenManeuverDamage06:maneuverDamage06,
 				hiddenManeuverDamage07:maneuverDamage07,
-				hiddenManeuverDamage08:maneuverDamage08
+				hiddenManeuverDamage08:maneuverDamage08,
+				hiddenManeuverDamage09:maneuverDamage09
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1236,7 +1236,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="Strike" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="164"/>
+							<input type="text" value="Strike" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="170"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp01">
@@ -1247,8 +1247,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" tabindex="165"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" tabindex="166"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" tabindex="171"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" tabindex="172"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack01" title="%{maneuverAttack01}">Roll</button>
 						</div>
 						
@@ -1257,18 +1257,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="Damage by STR or weapon." maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="167"/>
+										<input type="text" value="Damage by STR or weapon." maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="173"/>
+										<input type="number" value="0" name="attr_maneuverEND01" title="@{maneuverEND01}" tabindex="174"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" tabindex="168"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" tabindex="175"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="169"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="176"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" value="2d6" name="attr_maneuverDamage01" title="@{maneuverDamage01}" maxlength="12" tabindex="170"/>
+										<input type="text" value="2d6" name="attr_maneuverDamage01" title="@{maneuverDamage01}" maxlength="12" tabindex="177"/>
 										
 										<h1>N:</h1>
 										
@@ -1286,7 +1287,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND01" title="%{buttonManueverEND01}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -1302,7 +1306,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="Block" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="172"/>
+							<input type="text" value="Block" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="180"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp02">
@@ -1313,8 +1317,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" tabindex="173"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}" tabindex="174"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" tabindex="181"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}" tabindex="182"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack02" title="%{maneuverAttack02}">Roll</button>
 						</div>
 						
@@ -1323,18 +1327,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" tabindex="175"/>
+										<input type="text" value="Block/Abort" maxlength="100" name="attr_martialManeuverEffect02" title="@{martialManeuverEffect02}" tabindex="183"/>
+										<input type="number" value="0" name="attr_maneuverEND02" title="@{maneuverEND02}" tabindex="184"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" tabindex="176"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV02" title="@{martialManeuverOCV02}" tabindex="185"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" tabindex="177"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" tabindex="186"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage02" title="@{maneuverDamage02}" value="0" maxlength="12" tabindex="178"/>
+										<input type="text" value="2d6" name="attr_maneuverDamage02" title="@{maneuverDamage02}" maxlength="12" tabindex="187"/>
 										
 										<h1>N:</h1>
 										
@@ -1352,7 +1357,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll02" title="%{showMartialRoll02}" >Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND02" title="%{buttonManueverEND02}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll02" title="%{showMartialRoll02}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -1368,7 +1376,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName03" title="@{martialManeuverName03}" tabindex="180"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName03" title="@{martialManeuverName03}" tabindex="190"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp03">
@@ -1379,8 +1387,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" tabindex="181"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}" tabindex="182"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" tabindex="191"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}" tabindex="192"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack03" title="%{maneuverAttack03}">Roll</button>
 						</div>
 						
@@ -1389,18 +1397,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" tabindex="183"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect03" title="@{martialManeuverEffect03}" tabindex="193"/>
+										<input type="number" value="0" name="attr_maneuverEND03" title="@{maneuverEND03}" tabindex="194"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" tabindex="184"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV03" title="@{martialManeuverOCV03}" tabindex="195"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" tabindex="185"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" tabindex="196"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage03" title="@{maneuverDamage03}" value="0" maxlength="12" tabindex="186"/>
+										<input type="text" value="" name="attr_maneuverDamage03" title="@{maneuverDamage03}" maxlength="12" tabindex="197"/>
 										
 										<h1>N:</h1>
 										
@@ -1418,7 +1427,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll03" title="%{showMartialRoll03}" >Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND03" title="%{buttonManueverEND03}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll03" title="%{showMartialRoll03}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -1434,7 +1446,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="188"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName04" title="@{martialManeuverName04}" tabindex="200"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp04">
@@ -1445,8 +1457,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" tabindex="189"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}" tabindex="190"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" tabindex="201"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}" tabindex="202"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack04" title="%{maneuverAttack04}">Roll</button>
 						</div>
 						
@@ -1455,18 +1467,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" tabindex="191"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect04" title="@{martialManeuverEffect04}" tabindex="203"/>
+										<input type="number" value="0" name="attr_maneuverEND04" title="@{maneuverEND04}" tabindex="204"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" tabindex="192"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV04" title="@{martialManeuverOCV04}" tabindex="205"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" tabindex="193"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" tabindex="206"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage04" title="@{maneuverDamage04}" value="0" maxlength="12" tabindex="194"/>
+										<input type="text" value="" name="attr_maneuverDamage04" title="@{maneuverDamage04}" maxlength="12" tabindex="207"/>
 										
 										<h1>N:</h1>
 										
@@ -1484,11 +1497,13 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll04" title="%{showMartialRoll04}" >Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND04" title="%{buttonManueverEND04}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll04" title="%{showMartialRoll04}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
-
 
 					<!-- Maneuver 05 -->
 					<div class="item-flex-maneuver">
@@ -1501,7 +1516,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="196"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName05" title="@{martialManeuverName05}" tabindex="210"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp05">
@@ -1512,8 +1527,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" tabindex="197"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}" tabindex="198"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" tabindex="211"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}" tabindex="212"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack05" title="%{maneuverAttack05}">Roll</button>
 						</div>
 						
@@ -1522,18 +1537,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" tabindex="199"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect05" title="@{martialManeuverEffect05}" tabindex="213"/>
+										<input type="number" value="0" name="attr_maneuverEND05" title="@{maneuverEND05}" tabindex="214"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" tabindex="200"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV05" title="@{martialManeuverOCV05}" tabindex="215"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" tabindex="201"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" tabindex="216"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage05" title="@{maneuverDamage05}" value="0" maxlength="12" tabindex="202"/>
+										<input type="text" value="" name="attr_maneuverDamage05" title="@{maneuverDamage05}" maxlength="12" tabindex="217"/>
 										
 										<h1>N:</h1>
 										
@@ -1551,7 +1567,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll05" title="%{showMartialRoll05}" >Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND05" title="%{buttonManueverEND05}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll05" title="%{showMartialRoll05}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -1567,7 +1586,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="204"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName06" title="@{martialManeuverName06}" tabindex="220"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp06">
@@ -1578,8 +1597,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" tabindex="205"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}" tabindex="206"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" tabindex="221"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}" tabindex="222"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack06" title="%{maneuverAttack06}">Roll</button>
 						</div>
 						
@@ -1588,18 +1607,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" tabindex="207"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect06" title="@{martialManeuverEffect06}" tabindex="223"/>
+										<input type="number" value="0" name="attr_maneuverEND06" title="@{maneuverEND06}" tabindex="224"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" tabindex="208"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV06" title="@{martialManeuverOCV06}" tabindex="225"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" tabindex="209"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" tabindex="226"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage06" title="@{maneuverDamage06}" value="0" maxlength="12" tabindex="210"/>
+										<input type="text" value="" name="attr_maneuverDamage06" title="@{maneuverDamage06}" maxlength="12" tabindex="227"/>
 										
 										<h1>N:</h1>
 										
@@ -1617,7 +1637,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll06" title="%{showMartialRoll06}" >Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND06" title="%{buttonManueverEND06}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll06" title="%{showMartialRoll06}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -1633,19 +1656,19 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="212"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName07" title="@{martialManeuverName07}" tabindex="230"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp07">
 										<span>&#10095;</span>
 									</button>
-									<button type="action" class="button buttonMinus" tabindex="-1" name="act_martialManeuverDown07">
+									<button type="action" class="button buttonMinus" tabindex="-1" name="act_martialManeuverDown076">
 										<span>&#10094;</span>
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" tabindex="213"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}" tabindex="214"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" tabindex="231"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}" tabindex="232"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack07" title="%{maneuverAttack07}">Roll</button>
 						</div>
 						
@@ -1654,18 +1677,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" tabindex="215"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect07" title="@{martialManeuverEffect07}" tabindex="233"/>
+										<input type="number" value="0" name="attr_maneuverEND07" title="@{maneuverEND07}" tabindex="234"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" tabindex="216"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV07" title="@{martialManeuverOCV07}" tabindex="235"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" tabindex="217"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" tabindex="236"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage07" title="@{maneuverDamage07}" value="0" maxlength="12" tabindex="218"/>
+										<input type="text" value="" name="attr_maneuverDamage07" title="@{maneuverDamage07}" maxlength="12" tabindex="237"/>
 										
 										<h1>N:</h1>
 										
@@ -1683,7 +1707,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll07" title="%{showMartialRoll07}">Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND07" title="%{buttonManueverEND07}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll07" title="%{showMartialRoll07}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -1699,7 +1726,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="220"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName08" title="@{martialManeuverName08}" tabindex="240"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp08">
@@ -1710,8 +1737,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" tabindex="221"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}" tabindex="222"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" tabindex="241"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}" tabindex="242"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack08" title="%{maneuverAttack08}">Roll</button>
 						</div>
 						
@@ -1720,18 +1747,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" tabindex="223"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect08" title="@{martialManeuverEffect08}" tabindex="243"/>
+										<input type="number" value="0" name="attr_maneuverEND08" title="@{maneuverEND08}" tabindex="244"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" tabindex="224"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV08" title="@{martialManeuverOCV08}" tabindex="245"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" tabindex="225"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" tabindex="246"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage08" title="@{maneuverDamage08}" value="0" maxlength="12" tabindex="226"/>
+										<input type="text" value="" name="attr_maneuverDamage08" title="@{maneuverDamage08}" maxlength="12" tabindex="247"/>
 										
 										<h1>N:</h1>
 										
@@ -1749,7 +1777,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll08" title="%{showMartialRoll08}">Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND08" title="%{buttonManueverEND08}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll08" title="%{showMartialRoll08}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -1765,7 +1796,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName09" title="@{martialManeuverName09}" tabindex="228"/>
+							<input type="text" value="" maxlength="34" name="attr_martialManeuverName09" title="@{martialManeuverName09}" tabindex="250"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp09">
@@ -1776,8 +1807,8 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="1/2" name="attr_martialManeuverPhase09" title="@{martialManeuverPhase09}" tabindex="229"/>
-							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP09" title="@{martialManeuverCP09}" tabindex="230"/>
+							<input type="text" value="1/2" name="attr_martialManeuverPhase09" title="@{martialManeuverPhase09}" tabindex="251"/>
+							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP09" title="@{martialManeuverCP09}" tabindex="252"/>
 							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack09" title="%{maneuverAttack09}">Roll</button>
 						</div>
 						
@@ -1786,18 +1817,19 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect08}" tabindex="231"/>
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect09" title="@{martialManeuverEffect09}" tabindex="253"/>
+										<input type="number" value="0" name="attr_maneuverEND09" title="@{maneuverEND09}" tabindex="254"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverOCV09" title="@{martialManeuverOCV09}" tabindex="232"/>
+										<input type="number" value="0" name="attr_martialManeuverOCV09" title="@{martialManeuverOCV09}" tabindex="255"/>
 										
 										<h1>DCV:</h1>
-										<input type="number" value="0" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" tabindex="233"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV09" title="@{martialManeuverDCV09}" tabindex="256"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage09" title="@{maneuverDamage09}" value="0" maxlength="12" tabindex="234"/>
+										<input type="text" value="" name="attr_maneuverDamage09" title="@{maneuverDamage09}" maxlength="12" tabindex="257"/>
 										
 										<h1>N:</h1>
 										
@@ -1815,7 +1847,10 @@
 									</div>
 								</div>
 								
-								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll09" title="%{showMartialRoll09}">Show</button>
+								<div class="subitem-flex-container-martial-buttons-column">
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND09" title="%{buttonManueverEND09}">END</button>
+									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll09" title="%{showMartialRoll09}" >Show</button>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -7954,7 +7954,7 @@
 			case "str":
 			theSkillRollChance=standardSkillChance( strengthChance,skillCP,bonusLevels);
 			break;
-	
+			
 			case "dex":
 			theSkillRollChance=standardSkillChance( dexterityChance,skillCP,agilitySkillLevels+bonusLevels);
 			break;
@@ -7986,7 +7986,7 @@
 			case "dexPS":
 			theSkillRollChance=knowledgeIntSkillChance( dexterityChance, enhancerJack,skillCP,bonusLevels);
 			break;
-	
+			
 			case "ks":
 			theSkillRollChance=knowledgeSkillChance( enhancerSch,skillCP,bonusLevels);
 			break;
@@ -8002,7 +8002,7 @@
 			case "intSS":
 			theSkillRollChance=knowledgeIntSkillChance( intelligenceChance, enhancerSci, skillCP,bonusLevels);
 			break;
-	
+			
 			case "ak":
 			theSkillRollChance=knowledgeSkillChance( enhancerTrav,skillCP,bonusLevels);;
 			break;
@@ -8059,7 +8059,7 @@
 			getAttrs(["displayDegreeOfSuccess", "whisperToGM"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				var displayName = characteristic.charAt(0).toUpperCase() + characteristic.slice(1);
-	
+				
 				if (values.displayDegreeOfSuccess != 0) {
 					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses "+displayName+" }} ";
 					if (characteristic == 'dexterity') {
@@ -8090,7 +8090,7 @@
 		on (`clicked:perceptionRoll${percType}`, (info) => {
 			getAttrs(["displayDegreeOfSuccess", "whisperToGM"], function(values) {
 				var theRoll = values.whisperToGM||"";
-
+				
 				if (values.displayDegreeOfSuccess != 0) {
 					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title}}} {{subtitle= Uses Perception"+subtitleExt+" }} "
 						+ "{{SUCCESS= [[@{intelligenceChance}[Intelligence Chance]+@{enhancedPerceptionModifier}[Perception Modifier]-3d6cf6cs1[Roll]";
@@ -8119,7 +8119,7 @@
 		on(`clicked:testSkill${skillId}`, (info) => {
 			getAttrs(["displayDegreeOfSuccess", "whisperToGM"], function(values) {
 				var theRoll = values.whisperToGM||"";
-
+				
 				if (values.displayDegreeOfSuccess != 0) {
 					theRoll += "&{template:custom-success-roll} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
 						+ "{{SUCCESS=[[@{skillRollChance"+skillId+"}[Skill Chance]-3d6cf6cs1[Roll]+?{Modifiers|0}[Modifiers]]] }}"
@@ -8890,9 +8890,11 @@
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
+				// let stunMod = parseInt(values["weaponStunMod"+weaponId])||0;
+				let stunMod = 0; // Reserved for later use.
 				let isBlocking = values["maneuverBlock"+maneuverId] != 0;
 				
-				// Martial maneuvers by default cost no endurance. Come back to this.
+				// Martial maneuvers by default cost no endurance. Endurance costs used for flexibility.
 				let subtractENDAmt =  parseInt(values["maneuverEndurance"+maneuverId])||0;
 				
 				let dmgType = isNormalDamage ? "STUN" : "BODY";
@@ -8940,6 +8942,7 @@
 				if (!isBlocking) {
 					startRoll(theRoll, (results) => {
 						let computed = parseInt(results.results[dmgType].result)||0;
+						let theMessage = "";
 						let theSTUNMultiplier = Math.floor(Math.random()*3+1);
 						
 						// Get hit location message if system used.
@@ -8953,6 +8956,7 @@
 							// Convert dice roll to equivalent BODY damage.
 							computed = convertStunToBody(results.results.STUN.rolls);
 						else {
+							theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
 							computed *= theSTUNMultiplier;
 											
 							computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
@@ -9331,9 +9335,9 @@
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["weaponNormalDamage"+weaponId] != 0;
 				let stunMod = parseInt(values["weaponStunMod"+weaponId])||0;
-
+				
 				let subtractENDAmt = parseInt(values["weaponEndurance"+weaponId])||0;
-
+				
 				let dmgType = isNormalDamage ? "STUN" : "BODY";
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 				
@@ -9357,30 +9361,30 @@
 						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 				if (useHitLocations)
 					theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
-	
+					
 				startRoll(theRoll, (results) => {
 					let computed = parseInt(results.results[dmgType].result)||0;
 					let theMessage = "AOE";
 					let theSTUNMultiplier = Math.floor(Math.random()*3+1);
-
-
+					
+					
 					// Get hit location message if system used.
 					if (useHitLocations && !areaOfEffect) {
 						let theHitLocation = hitLocationDetails(results.results.HITLOC.result);
 						theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
 						theSTUNMultiplier = theHitLocation.STUNx;
 					}
-
+					
 					if (isNormalDamage) {
 						// Convert dice roll to equivalent BODY damage.
 						computed = convertStunToBody(results.results.STUN.rolls);
 					} else {
 						theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
 						computed *= theSTUNMultiplier;
-
+						
 						computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
 					}
-
+					
 					let theResult = new Object();
 					theResult[otherDmgType] = computed;
 					theResult.HITLOC = theMessage;
@@ -9389,7 +9393,7 @@
 					if (values.optionAutoSubtractEND != 0) {
 						subtractEndurance(subtractENDAmt);
 					}
-
+					
 					finishRoll(results.rollId, theResult);
 				});
 			});
@@ -9398,22 +9402,22 @@
 	
 	on('clicked:attackShield', (info) => {
 		// Roll attack and damage dice for the shield.
-						
+			
 		getAttrs(["shieldNormalDamage", "shieldStunMod", "shieldEndurance", "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 			var theRoll = values.whisperToGM||"";
 			let useHitLocations = values.optionHitLocationSystem != 0;
 			let isNormalDamage = values.shieldNormalDamage != 0;
 			let stunMod = parseInt(values.shieldStunMod)||0;
 			let dispDoS = values.displayDegreeOfSuccess != 0;
-
+			
 			let subtractENDAmt = parseInt(values.shieldEndurance)||0;
-
+			
 			let dmgType = isNormalDamage ? "STUN" : "BODY";
 			let otherDmgType = isNormalDamage ? "BODY" : "STUN";
-
+			
 			theRoll += "?{Blocking|Yes,";
 			// This a nested query so we need to use &rbrace; for } and &#124; for |
-
+			
 			// Blocking Roll
 			theRoll += "&{template:custom-defense&rbrace; {{title=@{character_name} - @{character_title}&rbrace;&rbrace; "
 					+ "{{subtitle=Blocks with @{shieldName}&rbrace;&rbrace; ";
@@ -9423,10 +9427,10 @@
 				theRoll += "{{OCV=[[@{ocv}[OCV]+@{shieldOCV}[Shield OCV]+@{shieldDCV}[ShieldDCV]+?{Modifiers&#124;0&rbrace;[Modifier]]]&rbrace;&rbrace; "
 					+ "{{Result=[[3d6cf6cs1]]&rbrace;&rbrace; ";
 			}
-
+			
 			// The second option in the nested query
 			theRoll += "|No,";
-
+			
 			// Attacking Roll
 			theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack&rbrace; {{title=@{character_name} - @{character_title}&rbrace;&rbrace; "
 					+ "{{subtitle= Makes a " + (isNormalDamage ? "normal" : "killing") + " attack with @{shieldName}&rbrace;&rbrace; ";
@@ -9441,38 +9445,38 @@
 					+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]&rbrace;&rbrace;";
 			if (useHitLocations)
 				theRoll += " {{HITLOC=[[@{targetHitRoll}]]&rbrace;&rbrace;";
-
+				
 			// End Nested Query
 			theRoll += "}";
-
+			
 			startRoll(theRoll, (results) => {
 				let theMessage = "AOE";
 				let theSTUNMultiplier = Math.floor(Math.random()*3+1);
 				let computed = parseInt(results.results[dmgType]?.result)||0;
-
+				
 				// No Damage Sections for Blocking
 				let isBlocking = results.results.STUN == undefined;
-
+				
 				// Get hit location message if system used.
 				if (useHitLocations && !isBlocking) {
 					var theHitLocation = hitLocationDetails(results.results.HITLOC.result);
 					theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
 					theSTUNMultiplier = theHitLocation.STUNx;
 				}
-
+				
 				if (isNormalDamage && !isBlocking) {
 					// Convert dice roll to equivalent BODY damage.
 					computed = convertStunToBody(results.results.STUN.rolls);
 				} else {
 					theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
 					computed *= theSTUNMultiplier;
-
+					
 					if (theSTUNMultiplier != 1)
 						computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
 				}
-
+				
 				let theResult = new Object();
-
+				
 				if (!isBlocking) {
 					theResult[otherDmgType] = computed;
 					theResult.HITLOC = theMessage;
@@ -9482,7 +9486,7 @@
 				if (!isBlocking && values.optionAutoSubtractEND != 0) {
 					subtractEndurance(subtractENDAmt);
 				}
-
+				
 				finishRoll(results.rollId, theResult);
 			});				
 		});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1288,7 +1288,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND01" title="%{buttonManueverEND01}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND01" title="%{buttonManeuverEND01}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
 								</div>
 							</div>
@@ -1358,7 +1358,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND02" title="%{buttonManueverEND02}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND02" title="%{buttonManeuverEND02}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll02" title="%{showMartialRoll02}" >Show</button>
 								</div>
 							</div>
@@ -1428,7 +1428,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND03" title="%{buttonManueverEND03}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND03" title="%{buttonManeuverEND03}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll03" title="%{showMartialRoll03}" >Show</button>
 								</div>
 							</div>
@@ -1498,7 +1498,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND04" title="%{buttonManueverEND04}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND04" title="%{buttonManeuverEND04}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll04" title="%{showMartialRoll04}" >Show</button>
 								</div>
 							</div>
@@ -1568,7 +1568,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND05" title="%{buttonManueverEND05}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND05" title="%{buttonManeuverEND05}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll05" title="%{showMartialRoll05}" >Show</button>
 								</div>
 							</div>
@@ -1638,7 +1638,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND06" title="%{buttonManueverEND06}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND06" title="%{buttonManeuverEND06}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll06" title="%{showMartialRoll06}" >Show</button>
 								</div>
 							</div>
@@ -1708,7 +1708,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND07" title="%{buttonManueverEND07}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND07" title="%{buttonManeuverEND07}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll07" title="%{showMartialRoll07}" >Show</button>
 								</div>
 							</div>
@@ -1778,7 +1778,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND08" title="%{buttonManueverEND08}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND08" title="%{buttonManeuverEND08}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll08" title="%{showMartialRoll08}" >Show</button>
 								</div>
 							</div>
@@ -1848,7 +1848,7 @@
 								</div>
 								
 								<div class="subitem-flex-container-martial-buttons-column">
-									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManueverEND09" title="%{buttonManueverEND09}">END</button>
+									<button type="action" class="button buttonManeuverEND" tabindex="-1" name="act_buttonManeuverEND09" title="%{buttonManeuverEND09}">END</button>
 									<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll09" title="%{showMartialRoll09}" >Show</button>
 								</div>
 							</div>
@@ -7569,7 +7569,7 @@
 	
 	
 	/* -------------------------------------- */
-	/* Functions used for tally bar           */
+	/* Functions used for Tally Bar           */
 	/* -------------------------------------- */
 	
 	function addPoints() {
@@ -7800,7 +7800,7 @@
 			});
 		});
 	});
-			
+	
 	/* Activate Power XX */
 	arrayOf(maxPowerNum).forEach(num => {
 		var powerId = String(num).padStart(2,'0');
@@ -7922,7 +7922,7 @@
 			}
 		return languageCP;
 	}
-			
+	
 	function standardSkillChance(theBaseSkillRoll,skillCP,additionalLevels) {
 		var skillCost=3;
 		var skillLevelCost=2;
@@ -7941,7 +7941,7 @@
 		} 
 		return theSkillRollChance;
 	}
-			
+	
 	function knowledgeSkillChance(enhancer,skillCP,additionalLevels) {
 		// Calculate KS, PS, or AK-type skill roll chance.
 		var skillCost=2;
@@ -7964,7 +7964,7 @@
 		}
 		return theSkillRollChance;
 	}
-			
+	
 	function knowledgeIntSkillChance(theBaseSkillRoll, enhancer, skillCP, additionalLevels) {
 		// Knowledge, Professional, and Science Skills can be purchased as Intelligence-based skills. In such a case 
 		// this function replaces the more general knowledgeSkillChance(...) function.
@@ -7993,7 +7993,7 @@
 		}
 		return theSkillRollChance;
 	}
-				
+	
 	function calculateSkillChance(skillType,skillCP,enhancerJack,enhancerSch,enhancerSci,enhancerTrav,strengthChance,dexterityChance,constitutionChance,intelligenceChance,egoChance,presenceChance,interactionSkillLevels,intellectSkillLevels,agilitySkillLevels,bonusLevels) {
 		// Calculates the skill roll chance for a general skill.
 		//
@@ -8126,6 +8126,7 @@
 					}
 					theRoll += "{{Roll=[[3d6cf6cs1]]}}";
 				}
+				
 				startRoll(theRoll, (results) => {
 					finishRoll(results.rollId,{});
 				});	
@@ -8155,6 +8156,7 @@
 					}
 					theRoll += "+?{Modifiers|0}[Modifier]]] }} {{Roll=[[3d6cf6cs1]]}}"
 				}
+				
 				startRoll(theRoll, (results) => {
 					finishRoll(results.rollId,{});
 				});
@@ -8175,6 +8177,7 @@
 					theRoll += "&{template:custom} {{title=@{character_name} - @{character_title} }} {{subtitle= Uses @{skillName"+skillId+"}}} "
 						+ "{{Base Chance = [[@{skillRollChance"+skillId+"}[Skill Chance]+?{Modifiers|0}[Modifiers]]] }} {{Roll=[[3d6cf6cs1]]}}"
 				}
+				
 				startRoll(theRoll, (results) => {
 					finishRoll(results.rollId,{});
 				});	
@@ -9001,6 +9004,18 @@
 						
 					finishRoll(results.rollId, theResult);
 				});
+			});
+		});
+	});
+	
+	
+	/* Use Maneuver XX Endurance */
+	arrayOf(maxManeuverNum).forEach(num => {
+		var maneuverId = String(num).padStart(2,'0');
+		on("clicked:buttonManeuverEND"+maneuverId, function() {
+			getAttrs(["maneuverEND"+maneuverId], function(values) {
+				// subtractEndurance(parseInt(values["maneuverEND"+maneuverId]));
+				subtractEndurance(parseInt(values["maneuverEND"+maneuverId]));
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1204,7 +1204,7 @@
 			<div class="item-tab-gear-slide-flex-container-martial-maneuvers">
 				<!-- Slide showing special martial arts maneuvers. Entries need to be supplied by the user. -->
 				<div class="subitem-tab-gear-slide-flex-container-martial-maneuvers-heading">
-					<h1>Martial Maneuvers</h1>
+					<h1>Martial and Combat Maneuvers</h1>
 					<h1>Phase</h1>
 					<h1>CP</h1>
 				</div>
@@ -1302,7 +1302,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="172"/>
+							<input type="text" value="Block" maxlength="34" name="attr_martialManeuverName02" title="@{martialManeuverName02}" tabindex="172"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp02">
@@ -6104,6 +6104,7 @@
 <input type="hidden" name="attr_currentDCV" value="0"/>
 
 <!-- Jackob's Roll Template -->
+<!-- Basic checks -->
 <rolltemplate class="sheet-rolltemplate-custom">
 	<div class="template-wrapper">
 	  <div class="sheet-container sheet-color-{{color}}">
@@ -6149,6 +6150,27 @@
 		</div>
 	</div>
 </rolltemplate>
+
+
+<!-- Jackob's Roll Template for defensive actions (blocks)-->
+<rolltemplate class="sheet-rolltemplate-custom-defense">
+	<div class="template-wrapper">
+	  <div class="sheet-container sheet-color-{{color}}">
+		<div class="sheet-header">
+		  {{#title}}<div class="sheet-title">{{title}}</div>{{/title}}
+		  {{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
+		</div>
+		<div class="sheet-content">
+		  {{#allprops() title subtitle desc color}}
+		  <div class="sheet-key">{{key}}</div>
+		  <div class="sheet-value">{{value}}</div>
+		  {{/allprops() title subtitle desc color}}
+		  {{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+		</div>
+	  </div>
+	</div>
+</rolltemplate>
+
 
 <!-- Jackob's Roll Template for normal damage attacks -->
 <!-- Includes row for computed BODY damage using July, 2021 Roll Parsing feature -->
@@ -6216,7 +6238,71 @@
 	</div>
 </rolltemplate>
 
-<!-- Jackob's Roll Template -->
+<!-- Jackob's Roll Template for killing damage maneuvers -->
+<rolltemplate class="sheet-rolltemplate-custom-maneuver">
+	<div class="sheet-template-wrapper">
+		<div class="sheet-container sheet-color-{{color}}">
+			<div class="sheet-header">
+				{{#title}}<div class="sheet-title">{{title}}</div>{{/title}}
+				{{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
+			</div>
+			<div class="sheet-content">
+				{{#allprops() title subtitle desc color HITLOC STUN BODY}}
+				<div class="sheet-key">{{key}}</div>
+				<div class="sheet-value">{{value}}</div>
+				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
+				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+				<!-- Stun, Body, and Hit Location go at the end -->
+				{{#STUN}}
+				<div class="sheet-key">STUN</div>
+				<div class="sheet-value">{{computed::STUN}}</div>
+				{{/STUN}}
+				{{#BODY}}
+				<div class="sheet-key">BODY</div>
+				<div class="sheet-value">{{computed::BODY}}</div>
+				{{/BODY}}
+				{{#HITLOC}}
+				<div class="sheet-key">Hit Location</div>
+				<div class="sheet-value">{{computed::HITLOC}}</div>
+				{{/HITLOC}}
+			</div>
+		</div>
+	</div>
+</rolltemplate>
+
+<!-- Jackob's Roll Template for normal damage maneuvers -->
+<rolltemplate class="sheet-rolltemplate-custom-normal-maneuver">
+	<div class="sheet-template-wrapper">
+		<div class="sheet-container sheet-color-{{color}}">
+			<div class="sheet-header">
+				{{#title}}<div class="sheet-title">{{title}}</div>{{/title}}
+				{{#subtitle}}<div class="sheet-subtitle">{{subtitle}}</div>{{/subtitle}}
+			</div>
+			<div class="sheet-content">
+				{{#allprops() title subtitle desc color HITLOC STUN BODY}}
+				<div class="sheet-key">{{key}}</div>
+				<div class="sheet-value">{{value}}</div>
+				{{/allprops() title subtitle desc color HITLOC STUN BODY}}
+				{{#desc}}<div class="sheet-desc">{{desc}}</div>{{/desc}}
+				<!-- Stun, Body, and Hit Location go at the end -->
+					{{#STUN}}
+					<div class="sheet-key">STUN</div>
+					<div class="sheet-value">{{computed::STUN}}</div>
+					{{/STUN}}
+					{{#BODY}}
+					<div class="sheet-key">BODY</div>
+					<div class="sheet-value">{{computed::BODY}}</div>
+					{{/BODY}}
+					{{#HITLOC}}
+					<div class="sheet-key">Hit Location</div>
+					<div class="sheet-value">{{computed::HITLOC}}</div>
+					{{/HITLOC}}
+			</div>
+		</div>
+	</div>
+</rolltemplate>
+
+<!-- Jackob's Roll Template for armor activation-->
 <rolltemplate class="sheet-rolltemplate-custom-activate">
 	<div class="sheet-template-wrapper">
 	  <div class="sheet-container sheet-color-{{color}}">
@@ -8807,63 +8893,82 @@
 		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "hiddenBasicEndurance",
-					"optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
+			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "hiddenBasicEndurance", "maneuverBlock"+maneuverId, "optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
 				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
-			
+				let isBlocking = values["maneuverBlock"+maneuverId] != 0;
+				
+				// Martial maneuvers by default cost no endurance. Come back to this.
 				let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
-			
+				
 				let dmgType = isNormalDamage ? "STUN" : "BODY";
 				let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 				
-				// If isNormalDamage is TRUE, use the Normal Damage template.
-				theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-attack} {{title=@{character_name} - @{character_title}}} "
-						+ "{{subtitle= Uses @{martialManeuverName"+maneuverId+"} to make a " + (isNormalDamage ? "normal" : "killing") + " attack.}} ";
-				if (values.displayDegreeOfSuccess != 0) {
-					theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
+				if (isBlocking) {
+					// Use the Blocking template.
+					theRoll += "&{template:custom-defense} {{title=@{character_name} - @{character_title}}} "
+						+ "{{subtitle=Blocks with @{martialManeuverName"+maneuverId+"}}} ";
+					if (values.displayDegreeOfSuccess != 0) {
+						theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]+?{Modifiers|0}[Modifier]]]}} ";
+					} else {
+						theRoll += "{{OCV=[[@{ocv}[OCV] + @{martialManeuverOCV"+maneuverId+"}[ManeuverOCV]+?{Modifiers|0}[Modifier]]]}} " + "{{Result=[[3d6cf6cs1]]}} ";
+					}
 				} else {
-					theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
-					+ "{{Result=[[3d6cf6cs1]]}}";
-				}
-				theRoll	+= (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
+					// If isNormalDamage is TRUE, use the Normal Damage template.
+					theRoll += "&{template:custom"+(isNormalDamage ? "-normal" : "")+"-maneuver} {{title=@{character_name} - @{character_title}}} "
+						+ "{{subtitle= Uses @{martialManeuverName"+maneuverId+"} to make a " + (isNormalDamage ? "normal" : "killing") + " attack.}} ";
+					if (values.displayDegreeOfSuccess != 0) {
+						theRoll	+= "{{Hit DCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} ";
+					} else {
+						theRoll += "{{OCV=[[@{ocv}[OCV]+@{martialManeuverOCV"+maneuverId+"}[ManeuverOCV] - @{targetOCVPenalty}[TargetOCV]+?{Modifier|0}[Modifier]]]}} "
+						+ "{{Result=[[3d6cf6cs1]]}}";
+					}
+					theRoll	+= (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
 						+ "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}} "
 						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
-				if (useHitLocations)
-					theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
-			
+					if (useHitLocations)
+						theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
+				}
+				
 				startRoll(theRoll, (results) => {
-					let computed = parseInt(results.results[dmgType].result)||0;
-					let theSTUNMultiplier = Math.floor(Math.random()*3+1);
-			
+					if (!isBlocking) {
+						let computed = parseInt(results.results[dmgType].result)||0;
+						let theSTUNMultiplier = Math.floor(Math.random()*3+1);
+					}
+					
 					// Get hit location message if system used.
-					if (useHitLocations) {
-						let theHitLocation = hitLocationDetails(results.results.HITLOC.result);
+					if (useHitLocations && !isBlocking) {
+						var theHitLocation = hitLocationDetails(results.results.HITLOC.result);
 						theMessage = isNormalDamage ? theHitLocation.normalMessage : theHitLocation.killMessage;
 						theSTUNMultiplier = theHitLocation.STUNx;
 					}
-			
-					if (isNormalDamage) {
-						// Convert dice roll to equivalent BODY damage.
-						computed = convertStunToBody(results.results.STUN.rolls);
-					} else {
-						// theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
-						theSTUNMultiplier = Math.max(1,theSTUNMultiplier);
-						computed *= theSTUNMultiplier;
-			
-						computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
+					
+					if (!isBlocking) {
+						if (isNormalDamage)
+							// Convert dice roll to equivalent BODY damage.
+							computed = convertStunToBody(results.results.STUN.rolls);
+						else {
+							// theSTUNMultiplier = Math.max(1,theSTUNMultiplier + stunMod);
+							theSTUNMultiplier = Math.max(1,theSTUNMultiplier);
+							computed *= theSTUNMultiplier;
+							
+							computed = String(computed) + " (BODY x" + theSTUNMultiplier + ")";
+						}
 					}
-			
+					
 					let theResult = new Object();
-					theResult[otherDmgType] = computed;
-					theResult.HITLOC = theMessage;
+					
+					if (!isBlocking) {
+						theResult[otherDmgType] = computed;
+						theResult.HITLOC = theMessage;
+					}
 						
 					// Subtract END cost if option checked.
 					if (values.optionAutoSubtractEND != 0) {
 						subtractEndurance(subtractENDAmt);
 					}
-			
+						
 					finishRoll(results.rollId, theResult);
 				});
 			});
@@ -9278,13 +9383,13 @@
 			let otherDmgType = isNormalDamage ? "BODY" : "STUN";
 
 			theRoll += "?{Blocking|Yes,";
-			// This is nested queries so we need to use &rbrace; for } and &#124; for |
+			// This a nested query so we need to use &rbrace; for } and &#124; for |
 
 			// Blocking Roll
-			theRoll += "&{template:custom&rbrace; {{title=@{character_name} - @{character_title}&rbrace;&rbrace; "
+			theRoll += "&{template:custom-defense&rbrace; {{title=@{character_name} - @{character_title}&rbrace;&rbrace; "
 					+ "{{subtitle=Blocks with @{shieldName}&rbrace;&rbrace; ";
 			if (dispDoS) {
-				theRoll	+= "{{vs OCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{shieldOCV}[Shield OCV]+@{shieldDCV}[ShieldDCV]+?{Modifiers&#124;0&rbrace;[Modifier]]]&rbrace;&rbrace; ";
+				theRoll	+= "{{versus OCV=[[11-3d6cf6cs1[Roll]+@{ocv}[OCV]+@{shieldOCV}[Shield OCV]+@{shieldDCV}[ShieldDCV]+?{Modifiers&#124;0&rbrace;[Modifier]]]&rbrace;&rbrace; ";
 			} else {
 				theRoll += "{{OCV=[[@{ocv}[OCV]+@{shieldOCV}[Shield OCV]+@{shieldDCV}[ShieldDCV]+?{Modifiers&#124;0&rbrace;[Modifier]]]&rbrace;&rbrace; "
 					+ "{{Result=[[3d6cf6cs1]]&rbrace;&rbrace; ";

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1211,6 +1211,16 @@
 					
 				<div class="item-tab-gear-slide-flex-container-martial-maneuvers-block">
 					
+					<!-- These are needed here for Maneuver Roll button Normal/Killing coloring -->
+					<input type="hidden" class="maneuver-normal-damage01" name="attr_maneuverNormalDamage01">
+					<input type="hidden" class="maneuver-normal-damage02" name="attr_maneuverNormalDamage02">
+					<input type="hidden" class="maneuver-normal-damage03" name="attr_maneuverNormalDamage03">
+					<input type="hidden" class="maneuver-normal-damage04" name="attr_maneuverNormalDamage04">
+					<input type="hidden" class="maneuver-normal-damage05" name="attr_maneuverNormalDamage05">
+					<input type="hidden" class="maneuver-normal-damage06" name="attr_maneuverNormalDamage06">
+					<input type="hidden" class="maneuver-normal-damage07" name="attr_maneuverNormalDamage07">
+					<input type="hidden" class="maneuver-normal-damage08" name="attr_maneuverNormalDamage08">
+					
 					<!-- Standard Attack -->
 					<div class="item-flex-maneuver">
 						<div class="subitem-flex-container-martial-row">
@@ -1249,7 +1259,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" tabindex="165"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" tabindex="166"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll01" title="%{martialAttackRoll01}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack01" title="%{maneuverAttack01}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-01">
@@ -1268,20 +1278,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="169"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage01" title="@{martialDamage01}" value="0" maxlength="12" tabindex="170"/>
+										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="0" maxlength="12" tabindex="170"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage01">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage01}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage01">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage01}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck01">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck01}"></span>
+											<input type="checkbox" name="attr_maneuverBlock01">
+											<span class="checkmark-small-gray" title="@{maneuverBlock01}"></span>
 										</label>
 									</div>
 								</div>
@@ -1315,7 +1325,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase02" title="@{martialManeuverPhase02}" tabindex="173"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP02" title="@{martialManeuverCP02}" tabindex="174"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll02" title="%{martialAttackRoll02}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack02" title="%{maneuverAttack02}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-02">
@@ -1334,20 +1344,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV02" title="@{martialManeuverDCV02}" tabindex="177"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage02" title="@{martialDamage02}" value="0" maxlength="12" tabindex="178"/>
+										<input type="text" name="attr_maneuverDamage02" title="@{maneuverDamage02}" value="0" maxlength="12" tabindex="178"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage02">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage02}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage02">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage02}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck02">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck02}"></span>
+											<input type="checkbox" name="attr_maneuverBlock02">
+											<span class="checkmark-small-gray" title="@{maneuverBlock02}"></span>
 										</label>
 									</div>
 								</div>
@@ -1381,7 +1391,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase03" title="@{martialManeuverPhase03}" tabindex="181"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP03" title="@{martialManeuverCP03}" tabindex="182"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll03" title="%{martialAttackRoll03}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack03" title="%{maneuverAttack03}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-03">
@@ -1400,20 +1410,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV03" title="@{martialManeuverDCV03}" tabindex="185"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage03" title="@{martialDamage03}" value="0" maxlength="12" tabindex="186"/>
+										<input type="text" name="attr_maneuverDamage03" title="@{maneuverDamage03}" value="0" maxlength="12" tabindex="186"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage03">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage03}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage03">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage03}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck03">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck03}"></span>
+											<input type="checkbox" name="attr_maneuverBlock03">
+											<span class="checkmark-small-gray" title="@{maneuverBlock03}"></span>
 										</label>
 									</div>
 								</div>
@@ -1447,7 +1457,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase04" title="@{martialManeuverPhase04}" tabindex="189"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP04" title="@{martialManeuverCP04}" tabindex="190"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll04" title="%{martialAttackRoll04}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack04" title="%{maneuverAttack04}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-04">
@@ -1466,20 +1476,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV04" title="@{martialManeuverDCV04}" tabindex="193"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage04" title="@{martialDamage04}" value="0" maxlength="12" tabindex="194"/>
+										<input type="text" name="attr_maneuverDamage04" title="@{maneuverDamage04}" value="0" maxlength="12" tabindex="194"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage04">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage04}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage04">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage04}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck04">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck04}"></span>
+											<input type="checkbox" name="attr_maneuverBlock04">
+											<span class="checkmark-small-gray" title="@{maneuverBlock04}"></span>
 										</label>
 									</div>
 								</div>
@@ -1514,7 +1524,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase05" title="@{martialManeuverPhase05}" tabindex="197"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP05" title="@{martialManeuverCP05}" tabindex="198"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll05" title="%{martialAttackRoll05}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack05" title="%{maneuverAttack05}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-05">
@@ -1533,20 +1543,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV05" title="@{martialManeuverDCV05}" tabindex="201"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage05" title="@{martialDamage05}" value="0" maxlength="12" tabindex="202"/>
+										<input type="text" name="attr_maneuverDamage05" title="@{maneuverDamage05}" value="0" maxlength="12" tabindex="202"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage05">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage05}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage05">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage05}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck05">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck05}"></span>
+											<input type="checkbox" name="attr_maneuverBlock05">
+											<span class="checkmark-small-gray" title="@{maneuverBlock05}"></span>
 										</label>
 									</div>
 								</div>
@@ -1580,7 +1590,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase06" title="@{martialManeuverPhase06}" tabindex="205"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP06" title="@{martialManeuverCP06}" tabindex="206"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll06" title="%{martialAttackRoll06}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack06" title="%{maneuverAttack06}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-06">
@@ -1599,20 +1609,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV06" title="@{martialManeuverDCV06}" tabindex="209"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage06" title="@{martialDamage06}" value="0" maxlength="12" tabindex="210"/>
+										<input type="text" name="attr_maneuverDamage06" title="@{maneuverDamage06}" value="0" maxlength="12" tabindex="210"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage06">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage06}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage06">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage06}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck06">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck06}"></span>
+											<input type="checkbox" name="attr_maneuverBlock06">
+											<span class="checkmark-small-gray" title="@{maneuverBlock06}"></span>
 										</label>
 									</div>
 								</div>
@@ -1646,7 +1656,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase07" title="@{martialManeuverPhase07}" tabindex="213"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP07" title="@{martialManeuverCP07}" tabindex="214"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll07" title="%{martialAttackRoll07}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack07" title="%{maneuverAttack07}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-07">
@@ -1665,20 +1675,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV07" title="@{martialManeuverDCV07}" tabindex="217"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage07" title="@{martialDamage07}" value="0" maxlength="12" tabindex="218"/>
+										<input type="text" name="attr_maneuverDamage07" title="@{maneuverDamage07}" value="0" maxlength="12" tabindex="218"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage07">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage07}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage07">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage07}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck07">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck07}"></span>
+											<input type="checkbox" name="attr_maneuverBlock07">
+											<span class="checkmark-small-gray" title="@{maneuverBlock07}"></span>
 										</label>
 									</div>
 								</div>
@@ -1712,7 +1722,7 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase08" title="@{martialManeuverPhase08}" tabindex="221"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP08" title="@{martialManeuverCP08}" tabindex="222"/>
-							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll08" title="%{martialAttackRoll08}">Roll</button>
+							<button type="action" class="button buttonRollAttack" tabindex="-1" name="act_maneuverAttack08" title="%{maneuverAttack08}">Roll</button>
 						</div>
 						
 						<div class="sheet-maneuver-expand-08">
@@ -1731,20 +1741,20 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV08" title="@{martialManeuverDCV08}" tabindex="225"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_martialDamage08" title="@{martialDamage08}" value="0" maxlength="12" tabindex="226"/>
+										<input type="text" name="attr_maneuverDamage08" title="@{maneuverDamage08}" value="0" maxlength="12" tabindex="226"/>
 										
 										<h1>N:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" checked="checked" name="attr_martialNormalDamage08">
-											<span class="checkmark-small-gray" title="@{martialNormalDamage08}"></span>
+											<input type="checkbox" checked="checked" name="attr_maneuverNormalDamage08">
+											<span class="checkmark-small-gray" title="@{maneuverNormalDamage08}"></span>
 										</label>
 										
 										<h1>B:</h1>
 										
 										<label class="container-checkbox-small-gray">
-											<input type="checkbox" name="attr_martialBlockCheck08">
-											<span class="checkmark-small-gray" title="@{martialBlockCheck08}"></span>
+											<input type="checkbox" name="attr_maneuverBlock08">
+											<span class="checkmark-small-gray" title="@{maneuverBlock08}"></span>
 										</label>
 									</div>
 								</div>
@@ -8727,14 +8737,14 @@
 	// /* Activate Maneuver XX */
 	arrayOf(maxManeuverNum).forEach(num => {
 		var maneuverId = String(num).padStart(2,'0');
-		on(`clicked:martialAttackRoll${maneuverId}`, (info)  => {
+		on(`clicked:maneuverAttack${maneuverId}`, (info)  => {
 			// Roll attack and damage dice for Martial Maneuver XX.
 			
-			getAttrs(["hiddenMartialDamage"+maneuverId, "martialNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "hiddenBasicEndurance",
+			getAttrs(["hiddenManeuverDamage"+maneuverId, "maneuverNormalDamage"+maneuverId,"martialManeuverPhase"+maneuverId, "martialManeuverEffect"+maneuverId, "martialManeuverOCV"+maneuverId, "martialManeuverDCV"+maneuverId, "martialManeuverName"+maneuverId, "hiddenBasicEndurance",
 					"optionAutoSubtractEND", "optionHitLocationSystem", "whisperToGM", "displayDegreeOfSuccess"], function(values) {
 				var theRoll = values.whisperToGM||"";
 				let useHitLocations = values.optionHitLocationSystem != 0;
-				let isNormalDamage = values["martialNormalDamage"+maneuverId] != 0;
+				let isNormalDamage = values["maneuverNormalDamage"+maneuverId] != 0;
 			
 				let subtractENDAmt = parseInt(values.hiddenBasicEndurance)||0;
 			
@@ -8751,7 +8761,7 @@
 					+ "{{Result=[[3d6cf6cs1]]}}";
 				}
 				theRoll	+= (subtractENDAmt ? "{{END=[[@{hiddenBasicEndurance}]] (@{currentEND})}} " : "")
-						+ "{{"+dmgType+"=[[@{hiddenMartialDamage"+maneuverId+"}]]}} "
+						+ "{{"+dmgType+"=[[@{hiddenManeuverDamage"+maneuverId+"}]]}} "
 						+ "{{"+otherDmgType+"=[[0[See "+dmgType+"]]]}}";
 				if (useHitLocations)
 					theRoll += " {{HITLOC=[[@{targetHitRoll}]]}}";
@@ -8795,45 +8805,45 @@
 	
 	
 	/* Clean Maneuver Damage Dice */
-	on("change:martialDamage01 change:martialDamage02 change:martialDamage03 change:martialDamage04 change:martialDamage05 change:martialDamage06 change:martialDamage07 change:martialDamage08", function () {
+	on("change:maneuverDamage01 change:maneuverDamage02 change:maneuverDamage03 change:maneuverDamage04 change:maneuverDamage05 change:maneuverDamage06 change:maneuverDamage07 change:maneuverDamage08", function () {
 		// This function attempts to clean damage text input into text more likely to be rollable dice.
 		// Only characters 0-9, d, D, +, and - are passed to martial attack rolls.
 		
-		getAttrs(["martialDamage01","martialDamage02","martialDamage03","martialDamage04","martialDamage05","martialDamage06","martialDamage07", "martialDamage08"], function(values) {
+		getAttrs(["maneuverDamage01","maneuverDamage02","maneuverDamage03","maneuverDamage04","maneuverDamage05","maneuverDamage06","maneuverDamage07", "maneuverDamage08"], function(values) {
 			
-			var martialDamage01=values.martialDamage01;
-			martialDamage01=martialDamage01.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage01=values.maneuverDamage01;
+			maneuverDamage01=maneuverDamage01.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var martialDamage02=values.martialDamage02;
-			martialDamage02=martialDamage02.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage02=values.maneuverDamage02;
+			maneuverDamage02=maneuverDamage02.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var martialDamage03=values.martialDamage03;
-			martialDamage03=martialDamage03.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage03=values.maneuverDamage03;
+			maneuverDamage03=maneuverDamage03.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var martialDamage04=values.martialDamage04;
-			martialDamage04=martialDamage04.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage04=values.maneuverDamage04;
+			maneuverDamage04=maneuverDamage04.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var martialDamage05=values.martialDamage05;
-			martialDamage05=martialDamage05.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage05=values.maneuverDamage05;
+			maneuverDamage05=maneuverDamage05.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var martialDamage06=values.martialDamage06;
-			martialDamage06=martialDamage06.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage06=values.maneuverDamage06;
+			maneuverDamage06=maneuverDamage06.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var martialDamage07=values.martialDamage07;
-			martialDamage07=martialDamage07.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage07=values.maneuverDamage07;
+			maneuverDamage07=maneuverDamage07.replace(/[^\ddD\\+\\-]/g,"");
 			
-			var martialDamage08=values.martialDamage08;
-			martialDamage08=martialDamage08.replace(/[^\ddD\\+\\-]/g,"");
+			var maneuverDamage08=values.maneuverDamage08;
+			maneuverDamage08=maneuverDamage08.replace(/[^\ddD\\+\\-]/g,"");
 			
 			setAttrs({
-				hiddenMartialDamage01:martialDamage01,
-				hiddenMartialDamage02:martialDamage02,
-				hiddenMartialDamage03:martialDamage03,
-				hiddenMartialDamage04:martialDamage04,
-				hiddenMartialDamage05:martialDamage05,
-				hiddenMartialDamage06:martialDamage06,
-				hiddenMartialDamage07:martialDamage07,
-				hiddenMartialDamage08:martialDamage08
+				hiddenManeuverDamage01:maneuverDamage01,
+				hiddenManeuverDamage02:maneuverDamage02,
+				hiddenManeuverDamage03:maneuverDamage03,
+				hiddenManeuverDamage04:maneuverDamage04,
+				hiddenManeuverDamage05:maneuverDamage05,
+				hiddenManeuverDamage06:maneuverDamage06,
+				hiddenManeuverDamage07:maneuverDamage07,
+				hiddenManeuverDamage08:maneuverDamage08
 			});
 		});
 	});

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1249,21 +1249,39 @@
 							</div>
 							<input type="text" value="1/2" name="attr_martialManeuverPhase01" title="@{martialManeuverPhase01}" tabindex="165"/>
 							<input type="number" value="0" min="0" step="1" name="attr_martialManeuverCP01" title="@{martialManeuverCP01}" tabindex="166"/>
-							<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
+							<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_martialAttackRoll01" title="%{martialAttackRoll01}">Roll</button>
 						</div>
+						
 						<div class="sheet-maneuver-expand-01">
-							<div class="subitem-tab-gear-slide-flex-container-martial-details-row">
-								<div class="subitem-flex-container-martial-ocv-dcv">
-									<div class="subitem-flex-container-martial-cv-row">
+							<div class="subitem-flex-container-martial-details-row">
+								<div class="subitem-flex-container-martial-details-column">
+									
+									<div class="subitem-martial-description-row">
+										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="169"/>
+										
+									</div>
+										
+									<div class="subitem-flex-container-martial-cv-damage-row">
 										<h1>OCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" tabindex="167"/>
-									</div>
-									<div class="subitem-flex-container-martial-cv-row">
+										<input type="number" value="0" name="attr_martialManeuverOCV01" title="@{martialManeuverOCV01}" tabindex="167"/>
+										
 										<h1>DCV:</h1>
-										<input type="text" value="+0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="168"/>
+										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="168"/>
+										
+										<h1>DMG:</h1>
+										<input type="text" name="attr_martialDamage01" title="@{martialDamage01}" value="0" maxlength="16" tabindex="169"/>
+										
+										<h1>N:</h1>
+										
+										<label class="container-checkbox-small-gray">
+											<input type="checkbox" name="attr_martialNormalDamage01">
+											<span class="checkmark-small-gray" title="@{martialNormalDamage01}"></span>
+										</label>	
 									</div>
+									
 								</div>
-								<textarea value="" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" placeholder="Effect" tabindex="169"/>
+								
+								<button type="action" class="button buttonRollShow" tabindex="-1" name="act_showMartialRoll01" title="%{showMartialRoll01}" >Show</button>
 							</div>
 						</div>
 					</div>

--- a/HeroSystem6eHeroic/HeroSystem6eHeroic.html
+++ b/HeroSystem6eHeroic/HeroSystem6eHeroic.html
@@ -1211,29 +1211,18 @@
 					
 				<div class="item-tab-gear-slide-flex-container-martial-maneuvers-block">
 					
-					<!-- These are needed here for Maneuver Roll button Normal/Killing coloring -->
-					<input type="hidden" class="maneuver-normal-damage01" name="attr_maneuverNormalDamage01">
-					<input type="hidden" class="maneuver-normal-damage02" name="attr_maneuverNormalDamage02">
-					<input type="hidden" class="maneuver-normal-damage03" name="attr_maneuverNormalDamage03">
-					<input type="hidden" class="maneuver-normal-damage04" name="attr_maneuverNormalDamage04">
-					<input type="hidden" class="maneuver-normal-damage05" name="attr_maneuverNormalDamage05">
-					<input type="hidden" class="maneuver-normal-damage06" name="attr_maneuverNormalDamage06">
-					<input type="hidden" class="maneuver-normal-damage07" name="attr_maneuverNormalDamage07">
-					<input type="hidden" class="maneuver-normal-damage08" name="attr_maneuverNormalDamage08">
-					<input type="hidden" class="maneuver-normal-damage09" name="attr_maneuverNormalDamage09">
+					<!-- These are needed here for Maneuver Roll button Normal/Killing coloring. -->
+					<input type="hidden" class="maneuver-normal-damage01" name="attr_maneuverNormalDamage01" value="on">
+					<input type="hidden" class="maneuver-normal-damage02" name="attr_maneuverNormalDamage02" value="on">
+					<input type="hidden" class="maneuver-normal-damage03" name="attr_maneuverNormalDamage03" value="on">
+					<input type="hidden" class="maneuver-normal-damage04" name="attr_maneuverNormalDamage04" value="on">
+					<input type="hidden" class="maneuver-normal-damage05" name="attr_maneuverNormalDamage05" value="on">
+					<input type="hidden" class="maneuver-normal-damage06" name="attr_maneuverNormalDamage06" value="on">
+					<input type="hidden" class="maneuver-normal-damage07" name="attr_maneuverNormalDamage07" value="on">
+					<input type="hidden" class="maneuver-normal-damage08" name="attr_maneuverNormalDamage08" value="on">
+					<input type="hidden" class="maneuver-normal-damage09" name="attr_maneuverNormalDamage09" value="on">
 					
-					<!-- Standard Attack -->
-					<!-- <div class="item-flex-maneuver">
-						<div class="subitem-flex-container-martial-row">
-							<div class="subitem-tab-gear-slide-flex-container-standard-attack">
-								<h1>Basic Attack:</h1>
-								<h2 title="@{hiddenManeuverDamage01}">HA STR/5</h2>
-								<input type="text" value="1/2" name="attr_normalPhase01" title="@{normalPhase01}" tabindex="-1" readonly="">
-								<button type="action" class="button buttonRollNormalAttack" tabindex="-1" name="act_standardAttackRoll" title="%{standardAttackRoll}">Roll</button>
-							</div>
-						</div>
-					</div> -->
-
+					<!-- Set first maneuver to expanded state as default. -->
 					<input type="hidden" class="sheet-maneuver-toggle" name="attr_maneuverToggle"  value="maneuverExpand01" />
 					
 					<!-- Maneuver 01 -->
@@ -1247,7 +1236,7 @@
 									</button>
 								</div>
 							</div>
-							<input type="text" value="" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="164"/>
+							<input type="text" value="Strike" maxlength="34" name="attr_martialManeuverName01" title="@{martialManeuverName01}" tabindex="164"/>
 							<div class="maneuver-mover-plus-minus-enclosure">
 								<div class="maneuver-mover-plus-minus-button">
 									<button type="action" class="button buttonPlus" tabindex="-1" name="act_martialManeuverUp01">
@@ -1268,7 +1257,7 @@
 								<div class="subitem-flex-container-martial-details-column">
 									
 									<div class="subitem-martial-description-row">
-										<input type="text" value="" maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="167"/>
+										<input type="text" value="Damage by STR or weapon." maxlength="100" name="attr_martialManeuverEffect01" title="@{martialManeuverEffect01}" tabindex="167"/>
 									</div>
 										
 									<div class="subitem-flex-container-martial-cv-damage-row">
@@ -1279,7 +1268,7 @@
 										<input type="number" value="0" name="attr_martialManeuverDCV01" title="@{martialManeuverDCV01}" tabindex="169"/>
 										
 										<h1>DMG:</h1>
-										<input type="text" name="attr_maneuverDamage01" title="@{maneuverDamage01}" value="0" maxlength="12" tabindex="170"/>
+										<input type="text" value="2d6" name="attr_maneuverDamage01" title="@{maneuverDamage01}" maxlength="12" tabindex="170"/>
 										
 										<h1>N:</h1>
 										


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Change log:

Features:
Expanded functionality of martial maneuvers: Roll Buttons for normal and killing attacks and blocks, END costs with buttons for non-martial or advanced maneuvers, and STUNx.
Removed the "Basic Attack" maneuver and added a ninth martial maneuver with the name "Basic HTH Strike." 
To keep the default strike functionality, "Damage by STR" is a keyword phrase for maneuver effects. Any maneuver effect that includes this keyword will use and update normal damage and END values according to STR.
Maneuver rolls display updated DCV.
Added OCV range penalties chosen by radio buttons in the existing range penalty table.
Changed perception roll boxes to display success chances for each type (general, vision/sight, hearing, and smell).
Added the hidden variable "sheet_name," which might by used in the future for mod compatibility (e.g., Hero Roller).

Accessibility:
Changed color palette of buttons and matching roll messages to the Okaba and Ito palette for better color vision accessibility.
Sheet styling changed to be a majority of tints and shades of the Okabe and Ito palette.

Fixes:
Added sheet version update for maneuvers, perception rolls, and sheet_name.
Increased text limit for martial maneuver names (24 to 34).
Added floating text labels for power variables.
Fixed super heroic campaign endurance, which had the opposite of the intended effect.
Fixed double precision math error causing END calculations to be sometimes rounded incorrectly.
Fixed tab index order issue in the powers tab.
Fixed issue where Safari offered to autofill some text fields.
Fixed focus outline clipping due to adjacent equipment items.