### PR TITLE
Bug Fix Heroes Unlimted 2E wealth section macro correction

### DIFF
--- a/Heroes-Unlimited-2E/hu2.html
+++ b/Heroes-Unlimited-2E/hu2.html
@@ -2161,8 +2161,8 @@
                         <div class='space-holder'></div>
                         
                         <button class="skillroll dicefontd20" type="roll" name='roll_wealth' value="@{whispertoggle}&{template:custom} {{color=grey}} {{title=**@{character_name}'s**}} {{subtitle=**@{wealth_name}**}} {{desc=**Value:** @{wealth_worth} 
-                            **Weight:** @{consumables_weight}
-                            **Count:** @{consumables_count} 
+                            **Weight:** @{wealth_weight}
+                            **Count:** @{wealth_count} 
                             **Location:** @{wealth_location} 
                             **Description:** @{wealth_details}}}">0</button>
                         <input class='wealth-field parchment' type="text" value="" name="attr_wealth_name" placeholder="Salary, cash, valuable, etc" />


### PR DESCRIPTION
Bug fix for wealth inventory repeating section roll button macro

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)


# Changes / Description

The wealth section had retained some incorrectly copy/pasted attribute names in the roll button macro.  Must not be used much since it took over a year for someone to notice!
<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




