### PR TITLE
Update Shadowdark-Unofficial.html: Fix monster parser, options, and initiative

### DIFF
--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.css
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.css
@@ -315,6 +315,10 @@ span.sd-text {
   color: #666;
 }
 
+label.sheet-form-checkbox {
+  display: inline-block;
+}
+
 .sheet-form-group .trait-name,
 .sheet-form-group .trait-desc {
   width: 100%;
@@ -471,6 +475,16 @@ span.sd-text {
   background-color: #eee;
   border-color: #fff;
   color: #666;
+}
+
+/* don't color initiative (for roll20 bug that adds fullcrit/fullfail class even when using kl1/kh1) */
+.sheet-rolltemplate-simple .sheet-roll-initiative .inlinerollresult,
+.sheet-rolltemplate-simple .sheet-roll-initiative .inlinerollresult.fullcrit,
+.sheet-rolltemplate-simple .sheet-roll-initiative .inlinerollresult.importantroll,
+.sheet-rolltemplate-simple .sheet-roll-initiative .inlinerollresult.fullfail {
+  background-color: #111;
+  border: 4px solid #111;
+  color: #fff;
 }
 
 /* PC sheets */

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.css
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.css
@@ -317,6 +317,7 @@ span.sd-text {
 
 label.sheet-form-checkbox {
   display: inline-block;
+  white-space: normal;
 }
 
 .sheet-form-group .trait-name,

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -983,6 +983,7 @@
 
 		// convert string to title case
 		let titleCase = function(str) {
+			if(!str) return '';
 			return str.replace(/\w\S*/g, function (txt) {
 				return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
 			});
@@ -1041,7 +1042,7 @@
 							monster.description += line;
 					}
 				}
-
+		
 				// push monster only if found the stats block
 				if (acIndex > 0)
 				{
@@ -1051,34 +1052,40 @@
 					console.log(`Unable to parse stats for ${monster.name}`);
 					return; // parse next monster, skip forEach iteration
 				}
-
+		
 				// stats come before actions - first stat is "AC" (armor class) and final stat is "LV" (level)
 				// attacks are included in the stats block using "ATK"
 				const statsAndActionsLines = lines.slice(acIndex);
-
+		
 				// find beginning of actions text
-				const actionsIndex = statsAndActionsLines.findIndex(o=>/[Ll][Vv]\s(\d+|\*)$/.test(o)) + 1;
+				const actionsIndex = statsAndActionsLines.findIndex(o=>/[Ll][Vv]\s(\d+|\*)(\/\d+)?$/.test(o)) + 1;
 				const actionsLines = statsAndActionsLines.slice(actionsIndex);
 				monster.actions = parseActions(actionsLines);
-
+		
 				// slice out and parse stats from between monster description and actions
 				const statsLines = statsAndActionsLines.slice(0, actionsIndex).map(o=>o.trim()).join(" ").split(/,/);
 				for (let i = 0; i < statsLines.length; i++) {
-					const statsLine = statsLines[i].trim(); // Trim leading and trailing whitespace for copy-paste issues	
+					let statsLine = statsLines[i].trim(); // Trim leading and trailing whitespace for copy-paste issues	
 					if (!statsLine?.length) continue; // skip empty lines
 					try {
 						if (!monster.armorClass && statsLine.startsWith('AC ')) {
 							const [, AC, armor] = statsLine.match(/AC (\d+)(?: \(([\w\s]+)\))?/);
 							monster.armorClass = +AC;
 							monster.armor = armor || "";
-						} else if (!monster.maxHitPoints && statsLine.startsWith('HP ')) {
-							const [, HP] = statsLine.match(/HP (\d+)/);
-							monster.maxHitPoints = parseInt(HP, 10) || monster.name==="Hydra" ? 55 : 0; // hydra heads special case (5 heads)
+						} else if (!monster.maxHitPoints && /^[Hh][Pp]\s(\*|\d+)(\/\d+)?$/.test(statsLine)) {
+							// if there is a rare case of multi-value like 4/5 grab the first number (ex: elementals don't have separate lesser/greater stats in the book)
+							const hp = /^[Hh][Pp]\s(?<hp>\*|\d+)(\/\d+)?$/.exec(statsLine).groups?.hp || "";
+							monster.maxHitPoints = parseInt(hp, 10) || (monster.name==="Hydra" ? 55 : 0); // hydra heads special case (5 heads)
 						} else if (!monster.attacks && statsLine.startsWith('ATK ')) {
+									// hacky fix for Azer (and other stat blocks that have comma in the ATK section)
+							if(/^\s+[^A-Z]/.test(statsLines[i+1]))
+							{
+								statsLine += ' + ' + statsLines[i+1]; // restore comma
+							}
 							const [, attackText] = statsLine.match(/ATK (.+)/);
 							const attackStrings = attackText.split(/\bor\b|\band\b/).map(s => s.trim());
 							const attacks = attackStrings.map(s => 
-								/^(?<qty>\d+(d\d+)?)\s*(?<name>(\+\d+)?[\w\s]*)\b(\s*)?(\((?<rng>([\w\s/]+))\)\s*)?(?<mod>[\+|\-]\d+)?(\s*)?[\(]?(?<dmg>\d+d\d+(\s\+\s\d+)?)?(\s*)?[\+,]?(\s)?(?<effect>[^\)][\w\s\+]*)?\)?/g
+								/^(?<qty>\d+(d\d+)?)\s*(?<name>(\+\d+)?[\w\s]*)\b(\s*)?(\((?<rng>([\w\s/]+))\)\s*)?(?<mod>[\+|\-]\d+)?(\s*)?[\(]?(?<dmg>(\d+[Dd]\d+|\d+)(\s\+\s\d+)?)?(\/\d+[Dd]\d+)?(\s*)?[\+,]?(\s+)?(?<effect>[^\)][\w\s\+]*)?\)?/g
 								.exec(s)?.groups).filter(s=>s!==undefined);
 							monster.attackText = attackText;
 							monster.attacks = attacks.map(attack => {
@@ -1113,8 +1120,10 @@
 							monster.stats.CHA = Math.max(1, 10 + 2 * monster.stats.cha_mod); // derive core stat
 						} else if (!monster.alignment && /^[Aa][Ll]\s+[\(\w\s]*[\w\)]$/.test(statsLine)) {
 							monster.alignment = alignments[statsLine.substring(3)];
-						} else if (!monster.level && /^[Ll][Vv]\s(\*|\d+)$/.test(statsLine)) {
-							monster.level = parseInt(statsLine.substring(3), 10) || monster.name==="Hydra" ? 10 : 0; // hydra heads special case (5 heads)
+						} else if (!monster.level && /^[Ll][Vv]\s(\*|\d+)(\/\d+)?$/.test(statsLine)) {
+							// if there is a rare case of multi-value like 4/5 grab the first number (ex: elementals don't have separate lesser/greater stats in the book)
+							const levelText = /^[Ll][Vv]\s(?<level>\*|\d+)(\/\d+)?$/.exec(statsLine).groups?.level || "";
+							monster.level = parseInt(levelText, 10) || (monster.name==="Hydra" ? 10 : 0); // hydra heads special case (5 heads)
 							break; // done getting stats - get attack text next loop
 						}
 					}
@@ -1126,7 +1135,7 @@
 			});
 			return monsters;
 		}
-		
+
 		let parseActions = function(inputArray) {
 			const result = [];
 		
@@ -1137,7 +1146,7 @@
 				};
 		
 				// action name
-				const actionNameRegex = /^[A-Z][^.]*/;
+				const actionNameRegex = /^[A-Z][^A-Z][^.]*/;
 				const actionNameMatch = inputArray[i].match(actionNameRegex);
 				if (actionNameMatch) {
 					actionObject.name = actionNameMatch[0].trim();
@@ -1684,7 +1693,7 @@
 			update[`${prefix}_atkmod`] = action.mod === undefined ? "0" : action.mod.toString();
 			update[`${prefix}_duration`] = action.duration || "";
 			update[`${prefix}_castdc`] = action.dc || "";
-			update[`${prefix}_atkrange`] = action.rng || "";
+			update[`${prefix}_atkrange`] = action.range || "";
 			update[`${prefix}_equipped`] = "1"; // default to usable state
 			update[`${prefix}_atkmagic`] = action.magBonus || "";
 			update[`${prefix}_atkcritrange`] = action.critRange || "20";
@@ -1696,7 +1705,7 @@
 			update[`${prefix}_dmg2base`] = action.damage2 || "";
 			update[`${prefix}_dmg2mmod`] = action.damage2Mod || "";
 			update[`${prefix}_dmg2custcrit`] = action.damage2CustomCrit || "";
-			update[`${prefix}_atk_desc`] = action.effect || "";
+			update[`${prefix}_atk_desc`] = action.effect ? "Effect: " + action.effect : "";
 			setAttrs(update, {
 				silent: true
 			}, () => update_attacks(attackId));

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -553,16 +553,16 @@
 				</div>
 				<label class="sheet-form-checkbox" title="@{sheetwipe_confirm_flag}">
 					<input type="checkbox" name="attr_sheetwipe_confirm_flag" value="1">
-					<span>"By checking this box, I officially swear that I want to replace my stats"</span>
+					<span>Confirm Import: "By checking this box, I officially swear that I want to replace my stats"</span>
 				</label>
 			</div>
 			<div class="sheet-form-group">
-				<label>JSON or Monster Text</label>
+				<label>JSON (Shadowdarklings format) or Monster Text (Core rules PDF format)</label>
 				<textarea name="attr_json" title="@{json}"></textarea>
 			</div>
 			<div class="sheet-form-group">
 				<label>Version:</label>
-				<input type="text" name="attr_version" value="2024.1.25.1" hidden disabled>
+				<input type="text" name="attr_version" value="2024.1.26.0" hidden disabled>
 				<span name="attr_version"></span>
 			</div>
 			<div>
@@ -942,26 +942,12 @@
 					return;
 				}
 				try {
-					const monsterSheet = parseMonsters(v.json);
+					const monster = parseMonster(v.json);
 					const isNpc = true;
-					if (monsterSheet?.length) {
-						monster = monsterSheet[0];
+					if (monster) {
 						import_sheet(monster, isNpc);
-						if (monster.attacks?.length) {
-							// help GMs: add attackText as a Multiattack feature if has multiple possible attacks or > 1 qty of single attack
-							if (monster.attackText?.length &&
-									(monster.attacks?.length > 1 || monster.attacks.filter(o=>o.qty > 1).length)) {
-								create_trait_from_feature({name: "Multiattack", description: monster.attackText});
-							}
-							monster.attacks.filter(o=>o.damage || o.damage2).forEach(o=> {
-								try { create_attack_from_action(o); }
-								catch(ex) { console.log(`Failed to add attack ${o}\n${ex}`); }
-							});
-						}
-						monster.actions.forEach(o=> {
-							try { create_trait_from_feature(o); }
-							catch(ex) { console.log(`Failed to add attack ${o}\n${ex}`); }
-						});
+					} else {
+						throw new Error("No data returned from parseMonster()");
 					}
 				}
 				catch(ex)
@@ -1002,96 +988,84 @@
 		}
 
 		// parse monster from copy-and-paste book format to shadowdarklings-style format
-		let parseMonsters = function(text) {
+		let parseMonster = function(text) {
 			const entries = [];
 			let entry = [];
-			let lines = text.split(/\n/);
-			for (let l = 0; l < lines.length; ++l) {
-				let line = lines[l];
-				if (!line?.length) continue; // skip empty lines
-		
-				// Find the first line containing the monster name
-				let isName = /^[A-Z][A-Z\s,]*[A-Z]$/.test(line);
-				if (isName) {
-					if (entry?.length) entries.push(entry.join("\n"));
-					entry = [];
-				}
-				entry.push(line);
+			let lines = text.split(/\n/)
+				.map(o=>o.trim())
+				.filter(o=>o.length);
+			if (lines.length < 3) {
+				throw new Error(
+					`This doesn't look like valid monster text. Expected format is:\n` +
+					`NAME\n` +
+					`Description text.\n` +
+					`AC 1 (armor type), HP 1, ATK 1 hammer +1 (1d4), MV near,\n` +
+					`S +1, D +0, C +0, I -1, W +0, Ch -1, AL C, LV 1\n` + 
+					`Action 1. Action 1 description.\n` +
+					`Action N. Action N description.`
+				);
 			}
-			if (entry?.length) entries.push(entry.join("\n"));
-		
-			const monsters = [];
-			let monster;
+
+			// Assume first line is the monster name
 			let acIndex = 0;
+			let monster = {
+				name: titleCase(lines[0]),
+				description: "",
+				actions: [],
+				stats: {}
+			};
 		
-			entries.forEach(entry => {
-				lines = entry.split(/\n/);
-				for (let l = 0; l < lines.length; ++l) {
-					let line = lines[l].trim();
-					if (!line?.length) continue; // skip empty lines
-		
-					// Find the first line containing the monster name
-					let isName = /^[A-Z][A-Z\s,]*[A-Z]$/.test(line);
-					if (isName) {
-						// create new monster item and add to list
-						monster = {
-							name: titleCase(line),
-							description: "",
-							actions: [],
-							stats: {}
-						};
-						acIndex = 0;
-						continue;
-					}
-		
-					// Assume AC is first stat. Everything between name and AC is Description text.
-					// Hopefully there is no monster with "AC " in the description... shrug..
-					if (/^AC \d+/.test(line)) {
-						acIndex = l;
-						break; // found start of stat block; exit loop
-					} else {
-							if (monster.description.length) monster.description += " ";
-							monster.description += line;
-					}
+			for (let l = 0; l < lines.length; ++l) {
+				let line = lines[l];	
+				// Assume AC is first stat. Everything between name and AC is Description text.
+				// Hopefully there is no monster with "AC " in the description... shrug..
+				if (monster.description.length && /^(A[Cc]\s+\d+|AC$)/.test(line)) {
+					acIndex = l;
+					break; // found start of stat block; exit loop
+				} else {
+						if (monster.description.length) monster.description += " ";
+						monster.description += line;
 				}
-		
-				// push monster only if found the stats block
-				if (acIndex > 0)
-				{
-					monsters.push(monster);
-				}
-				else {
-					console.log(`Unable to parse stats for ${monster.name}`);
-					return; // parse next monster, skip forEach iteration
-				}
-		
-				// stats come before actions - first stat is "AC" (armor class) and final stat is "LV" (level)
-				// attacks are included in the stats block using "ATK"
-				const statsAndActionsLines = lines.slice(acIndex);
-		
-				// find beginning of actions text
-				const actionsIndex = statsAndActionsLines.findIndex(o=>/(^\d+|[Ll][Vv]\s(\d+|\*)(\/\d+)?)$/.test(o)) + 1;
-				const actionsLines = statsAndActionsLines.slice(actionsIndex);
+			}
+
+			// push monster only if found the stats block
+			if (acIndex === 0) {
+				console.log(`Unable to parse stats for ${monster.name}`);
+				return monster;
+			}
+	
+			// stats come before actions - first stat is "AC" (armor class) and final stat is "LV" (level)
+			// attacks are included in the stats block using "ATK"
+			const statsAndActionsLines = lines.slice(acIndex);
+	
+			// find beginning of actions text
+			const actionsIndex = statsAndActionsLines.findIndex(o=>/(^\d+|[Ll][Vv]\s(\d+|\*)(\/\d+)?)$/.test(o)) + 1;
+			const actionsLines = statsAndActionsLines.slice(actionsIndex);
+			try {
 				monster.actions = parseActions(actionsLines);
-		
-				// slice out and parse stats from between monster description and actions
-				const statsLines = statsAndActionsLines.slice(0, actionsIndex).map(o=>o.trim()).join(" ").split(/,/);
-				for (let i = 0; i < statsLines.length; i++) {
-					let statsLine = statsLines[i].trim(); // Trim leading and trailing whitespace for copy-paste issues	
-					if (!statsLine?.length) continue; // skip empty lines
-					try {
-						if (!monster.armorClass && statsLine.startsWith('AC ')) {
-							const [, AC, armor] = statsLine.match(/AC (\d+)(?: \(([\w\s]+)\))?/);
-							monster.armorClass = +AC;
-							monster.armor = armor || "";
-						} else if (!monster.maxHitPoints && /^[Hh][Pp]\s(\*|\d+)(\/\d+)?$/.test(statsLine)) {
-							// if there is a rare case of multi-value like 4/5 grab the first number (ex: elementals don't have separate lesser/greater stats in the book)
-							const hp = /^[Hh][Pp]\s(?<hp>\*|\d+)(\/\d+)?$/.exec(statsLine).groups?.hp || "";
-							monster.maxHitPoints = parseInt(hp, 10) || (monster.name==="Hydra" ? 55 : 0); // hydra heads special case (5 heads)
-						} else if (!monster.attacks && statsLine.startsWith('ATK ')) {
-									// hacky fix for Azer (and other stat blocks that have comma in the ATK section)
-							if(/^\s+[^A-Z]/.test(statsLines[i+1]))
-							{
+			} catch (ex) {
+				console.log(`Failed to parse actions for ${monster.name}`);
+				console.log(ex);
+			}
+	
+			// slice out and parse stats from between monster description and actions
+			const statsLines = statsAndActionsLines.slice(0, actionsIndex).map(o=>o.trim()).join(" ").split(/,/);
+			for (let i = 0; i < statsLines.length; i++) {
+				let statsLine = statsLines[i].trim(); // Trim leading and trailing whitespace for copy-paste issues	
+				if (!statsLine?.length) continue; // skip empty lines
+				try {
+					if (!monster.armorClass && statsLine.startsWith('AC ')) {
+						const [, AC, armor] = statsLine.match(/AC (\d+)(?: \(([\w\s]+)\))?/);
+						monster.armorClass = +AC;
+						monster.armor = armor || "";
+					} else if (!monster.maxHitPoints && /^[Hh][Pp]\s(\*|\d+)(\/\d+)?$/.test(statsLine)) {
+						// if there is a rare case of multi-value like 4/5 grab the first number (ex: elementals don't have separate lesser/greater stats in the book)
+						const hp = /^[Hh][Pp]\s(?<hp>\*|\d+)(\/\d+)?$/.exec(statsLine).groups?.hp || "";
+						monster.maxHitPoints = parseInt(hp, 10) || (monster.name==="Hydra" ? 55 : 0); // hydra heads special case (5 heads)
+					} else if (!monster.attacks && statsLine.startsWith('ATK ')) {
+						try {
+							// hacky fix for Azer (and other stat blocks that have comma in the ATK section)
+							if(/^\s+[^A-Z]/.test(statsLines[i+1])) {
 								statsLine += ' + ' + statsLines[i+1]; // restore comma
 							}
 							const [, attackText] = statsLine.match(/ATK (.+)/);
@@ -1110,42 +1084,45 @@
 									effect: attack.effect || ""
 								};
 							});
-						} else if (!monster.movement && /^[Mm][Vv]\s[\(\s\w/]*[\w\)]$/.test(statsLine)) {
-							monster.movement = statsLine.substring(3);
-						} else if (!monster.stats.str_mod && /^[Ss]\s[\+\-]+[\d]+$/.test(statsLine)) {
-							monster.stats.str_mod = parseInt(statsLine.substring(2), 10) || 0;
-							monster.stats.STR = Math.max(1, 10 + 2 * monster.stats.str_mod); // derive core stat
-						} else if (!monster.stats.dex_mod && /^[Dd]\s[\+\-]+[\d]+$/.test(statsLine)) {
-							monster.stats.dex_mod = parseInt(statsLine.substring(2), 10) || 0;
-							monster.stats.DEX = Math.max(1, 10 + 2 * monster.stats.dex_mod); // derive core stat
-						} else if (!monster.stats.con_mod && /^[Cc]\s[\+\-]+[\d]+$/.test(statsLine)) {
-							monster.stats.con_mod = parseInt(statsLine.substring(2), 10) || 0;
-							monster.stats.CON = Math.max(1, 10 + 2 * monster.stats.con_mod); // derive core stat
-						} else if (!monster.stats.int_mod && /^[Ii]\s[\+\-]+[\d]+$/.test(statsLine)) {
-							monster.stats.int_mod = parseInt(statsLine.substring(2), 10) || 0;
-							monster.stats.INT = Math.max(1, 10 + 2 * monster.stats.int_mod); // derive core stat
-						} else if (!monster.stats.wis_mod && /^[Ww]\s[\+\-]+[\d]+$/.test(statsLine)) {
-							monster.stats.wis_mod = parseInt(statsLine.substring(2), 10) || 0;
-							monster.stats.WIS = Math.max(1, 10 + 2 * monster.stats.wis_mod); // derive core stat
-						} else if (!monster.stats.cha_mod && /^[Cc][Hh]\s[\+\-]+[\d]+$/.test(statsLine)) {
-							monster.stats.cha_mod = parseInt(statsLine.substring(3), 10) || 0;
-							monster.stats.CHA = Math.max(1, 10 + 2 * monster.stats.cha_mod); // derive core stat
-						} else if (!monster.alignment && /^[Aa][Ll]\s+[\(\w\s]*[\w\)]$/.test(statsLine)) {
-							monster.alignment = alignments[statsLine.substring(3)];
-						} else if (!monster.level && /^[Ll][Vv]\s(\*|\d+)(\/\d+)?$/.test(statsLine)) {
-							// if there is a rare case of multi-value like 4/5 grab the first number (ex: elementals don't have separate lesser/greater stats in the book)
-							const levelText = /^[Ll][Vv]\s(?<level>\*|\d+)(\/\d+)?$/.exec(statsLine).groups?.level || "";
-							monster.level = parseInt(levelText, 10) || (monster.name==="Hydra" ? 10 : 0); // hydra heads special case (5 heads)
-							break; // done getting stats - get attack text next loop
+						} catch (ex) {
+							console.log(`Failed to parse attacks for ${monster.name}`);
+							console.log(ex);
 						}
-					}
-					catch (ex) { 
-						console.log(ex);
-						console.log(monster); 
+					} else if (!monster.movement && /^[Mm][Vv]\s[\(\s\w/]*[\w\)]$/.test(statsLine)) {
+						monster.movement = statsLine.substring(3);
+					} else if (!monster.stats.str_mod && /^[Ss]\s[\+\-]+[\d]+$/.test(statsLine)) {
+						monster.stats.str_mod = parseInt(statsLine.substring(2), 10) || 0;
+						monster.stats.STR = Math.max(1, 10 + 2 * monster.stats.str_mod); // derive core stat
+					} else if (!monster.stats.dex_mod && /^[Dd]\s[\+\-]+[\d]+$/.test(statsLine)) {
+						monster.stats.dex_mod = parseInt(statsLine.substring(2), 10) || 0;
+						monster.stats.DEX = Math.max(1, 10 + 2 * monster.stats.dex_mod); // derive core stat
+					} else if (!monster.stats.con_mod && /^[Cc]\s[\+\-]+[\d]+$/.test(statsLine)) {
+						monster.stats.con_mod = parseInt(statsLine.substring(2), 10) || 0;
+						monster.stats.CON = Math.max(1, 10 + 2 * monster.stats.con_mod); // derive core stat
+					} else if (!monster.stats.int_mod && /^[Ii]\s[\+\-]+[\d]+$/.test(statsLine)) {
+						monster.stats.int_mod = parseInt(statsLine.substring(2), 10) || 0;
+						monster.stats.INT = Math.max(1, 10 + 2 * monster.stats.int_mod); // derive core stat
+					} else if (!monster.stats.wis_mod && /^[Ww]\s[\+\-]+[\d]+$/.test(statsLine)) {
+						monster.stats.wis_mod = parseInt(statsLine.substring(2), 10) || 0;
+						monster.stats.WIS = Math.max(1, 10 + 2 * monster.stats.wis_mod); // derive core stat
+					} else if (!monster.stats.cha_mod && /^[Cc][Hh]\s[\+\-]+[\d]+$/.test(statsLine)) {
+						monster.stats.cha_mod = parseInt(statsLine.substring(3), 10) || 0;
+						monster.stats.CHA = Math.max(1, 10 + 2 * monster.stats.cha_mod); // derive core stat
+					} else if (!monster.alignment && /^[Aa][Ll]\s+[\(\w\s]*[\w\)]$/.test(statsLine)) {
+						monster.alignment = alignments[statsLine.substring(3)];
+					} else if (!monster.level && /^[Ll][Vv]\s(\*|\d+)(\/\d+)?$/.test(statsLine)) {
+						// if there is a rare case of multi-value like 4/5 grab the first number (ex: elementals don't have separate lesser/greater stats in the book)
+						const levelText = /^[Ll][Vv]\s(?<level>\*|\d+)(\/\d+)?$/.exec(statsLine).groups?.level || "";
+						monster.level = parseInt(levelText, 10) || (monster.name==="Hydra" ? 10 : 0); // hydra heads special case (5 heads)
+						break; // done getting stats - get attack text next loop
 					}
 				}
-			});
-			return monsters;
+				catch (ex) { 
+					console.log(ex);
+					console.log(monster); 
+				}
+			}
+			return monster;
 		}
 		
 		let parseActions = function(inputArray) {
@@ -1387,6 +1364,29 @@
 			});
 			update_slots(sheet.gearSlotsTotal);
 			console.log("Finished importing custom sheet");
+
+			if (isNpc) {
+				importMonsterActions(sheet);
+			}
+		}
+
+		let importMonsterActions = function(monster)
+		{
+			if (monster.attacks?.length) {
+				// help GMs: add attackText as a Multiattack feature if has multiple possible attacks or > 1 qty of single attack
+				if (monster.attackText?.length &&
+						(monster.attacks?.length > 1 || monster.attacks.filter(o=>o.qty > 1).length)) {
+					create_trait_from_feature({name: "Multiattack", description: monster.attackText});
+				}
+				monster.attacks.filter(o=>o.damage || o.damage2).forEach(o=> {
+					try { create_attack_from_action(o); }
+					catch(ex) { console.log(`Failed to add attack ${o}\n${ex}`); }
+				});
+			}
+			monster.actions.forEach(o=> {
+				try { create_trait_from_feature(o); }
+				catch(ex) { console.log(`Failed to add attack ${o}\n${ex}`); }
+			});
 		}
 
 		let addSpaces = function(str) {
@@ -1778,14 +1778,12 @@
 			var attrs_to_get = ["dexterity", "dexterity_mod", "init_tiebreaker", "advantagetoggle"];
 			getAttrs(attrs_to_get, function(v) {
 				var update = {};
-				debugger;
 				var final_init = parseInt(v["dexterity_mod"], 10);				
 				if (v["init_tiebreaker"] != "0") {
 					final_init = (final_init + parseFloat(Math.abs(parseInt(v["dexterity"], 10) / 100))).toFixed(2);
 				}
 
-				switch (v["advantagetoggle"])
-				{
+				switch (v["advantagetoggle"]) {
 					// advantage
 				 	case "{{query=1}} {{advantage=1}} {{r2=[[@{d20}":
 						update["initiative_style"] = "{@{d20},@{d20}}kh1";

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -33,7 +33,7 @@
 		<div class="sd-row">
 			<div class="sd-col sd-core-stat">
 				<button type="roll" name="roll_initiative" title="Roll initiative; click token first"
-				value="@{wtype}&{template:simple} {{rname=Initiative}} {{mod=@{initiative_bonus}}} {{r1=[[@{initiative_style}+@{initiative_bonus}[INIT] &{tracker}]]}} {{isinit=1}} @{charname_output}">Name</button>
+				value="@{wtype}&{template:simple} {{rname=Initiative}} {{mod=@{dexterity_mod}}} {{r1=[[@{initiative_style}+@{initiative_bonus}[INIT] &{tracker}]]}} {{isinit=1}} @{charname_output}">Name</button>
 				<input type="text" class="sd-text" name="attr_character_name" title="@{character_name}" placeholder="Name">
 			</div>
 			<div class="sd-col">
@@ -69,7 +69,7 @@
 		<div class="sd-row">
 			<div class="sd-col sd-core-stat">
 				<button type="roll" name="roll_initiative" title="Roll initiative; click token first"
-				value="@{wtype}&{template:simple} {{rname=Initiative}} {{mod=@{initiative_bonus}}} {{r1=[[@{initiative_style}+@{initiative_bonus}[INIT] &{tracker}]]}} {{isinit=1}} @{charname_output}">Name</button>
+				value="@{wtype}&{template:simple} {{rname=Initiative}} {{mod=@{dexterity_mod}}} {{r1=[[@{initiative_style}+@{initiative_bonus}[INIT] &{tracker}]]}} {{isinit=1}} @{charname_output}">Name</button>
 				<input type="text" class="sd-text" name="attr_character_name" title="@{character_name}" placeholder="Name">
 			</div>
 			<div class="sd-col">
@@ -538,7 +538,7 @@
 			</div>
 			<div class="sheet-form-group">
 				<label class="sheet-form-checkbox">
-					<input type="checkbox" name="attr_init_tiebreaker" value="@{dexterity}/100">
+					<input type="checkbox" name="attr_init_tiebreaker" value="1">
 					<span>Add Dex Tiebreaker to Initiative</span>
 				</label>
 			</div>
@@ -610,6 +610,7 @@
 		<input type="hidden" name="attr_initiative_style" value="@{d20}">
 		<input type="hidden" name="attr_wtype" value="@{whispertoggle}">
 		<input type="hidden" name="attr_rtype" value="@{advantagetoggle}">
+		<input type="hidden" name="attr_init_tiebreaker" value="0">
 	</div>
 	<div class="sheet-section sheet-section-templates">
 		<div class="sheet-rolltemplates">
@@ -1777,9 +1778,10 @@
 			var attrs_to_get = ["dexterity", "dexterity_mod", "init_tiebreaker", "advantagetoggle"];
 			getAttrs(attrs_to_get, function(v) {
 				var update = {};
-				var final_init = parseInt(v["dexterity_mod"], 10);
-				if (v["init_tiebreaker"] && v["init_tiebreaker"] != 0) {
-					final_init = final_init + parseFloat((parseInt(v["dexterity"], 10) / 100).toFixed(2));
+				debugger;
+				var final_init = parseInt(v["dexterity_mod"], 10);				
+				if (v["init_tiebreaker"] != "0") {
+					final_init = (final_init + parseFloat(Math.abs(parseInt(v["dexterity"], 10) / 100))).toFixed(2);
 				}
 
 				switch (v["advantagetoggle"])

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -33,7 +33,7 @@
 		<div class="sd-row">
 			<div class="sd-col sd-core-stat">
 				<button type="roll" name="roll_initiative" title="Roll initiative; click token first"
-				value="@{wtype}&{template:simple} {{rname=Initiative}} {{r1=[[@{d20}+@{dexterity_mod}[INIT] &{tracker}]]}} @{rtype}+@{dexterity_mod}]]}} @{charname_output}">Name</button>
+				value="@{wtype}&{template:simple} {{rname=Initiative}} {{mod=@{initiative_bonus}}} {{r1=[[@{initiative_style}+@{initiative_bonus}[INIT] &{tracker}]]}} {{isinit=1}} @{charname_output}">Name</button>
 				<input type="text" class="sd-text" name="attr_character_name" title="@{character_name}" placeholder="Name">
 			</div>
 			<div class="sd-col">
@@ -69,7 +69,7 @@
 		<div class="sd-row">
 			<div class="sd-col sd-core-stat">
 				<button type="roll" name="roll_initiative" title="Roll initiative; click token first"
-				value="@{wtype}&{template:simple} {{rname=Initiative}} {{r1=[[@{d20}+@{dexterity_mod}[INIT] &{tracker}]]}} @{rtype}+@{dexterity_mod}]]}} @{charname_output}">Name</button>
+				value="@{wtype}&{template:simple} {{rname=Initiative}} {{mod=@{initiative_bonus}}} {{r1=[[@{initiative_style}+@{initiative_bonus}[INIT] &{tracker}]]}} {{isinit=1}} @{charname_output}">Name</button>
 				<input type="text" class="sd-text" name="attr_character_name" title="@{character_name}" placeholder="Name">
 			</div>
 			<div class="sd-col">
@@ -537,6 +537,16 @@
 				</label>
 			</div>
 			<div class="sheet-form-group">
+				<label class="sheet-form-checkbox">
+					<input type="checkbox" name="attr_init_tiebreaker" value="@{dexterity}/100">
+					<span>Add Dex Tiebreaker to Initiative</span>
+				</label>
+			</div>
+			<div class="sheet-form-group">
+				<label>Core Die Roll:</label>
+				<input type="text" name="attr_core_die" value="1d20" placeholder="1d20" title="@{core_die}">
+			</div>
+			<div class="sheet-form-group">
 				<div>
 					<button type="action" name="act_importjson">Import Shadowdarklings JSON</button>
 					<button type="action" name="act_importmonster">Import Monster Text from Book</button>
@@ -552,7 +562,7 @@
 			</div>
 			<div class="sheet-form-group">
 				<label>Version:</label>
-				<input type="text" name="attr_version" value="2024.1.17.1" hidden disabled>
+				<input type="text" name="attr_version" value="2024.1.25.1" hidden disabled>
 				<span name="attr_version"></span>
 			</div>
 			<div>
@@ -597,6 +607,7 @@
 		<input type="hidden" name="attr_intelligence_mod" value="0">
 		<input type="hidden" name="attr_wisdom_mod" value="0">
 		<input type="hidden" name="attr_charisma_mod" value="0">
+		<input type="hidden" name="attr_initiative_style" value="@{d20}">
 		<input type="hidden" name="attr_wtype" value="@{whispertoggle}">
 		<input type="hidden" name="attr_rtype" value="@{advantagetoggle}">
 	</div>
@@ -775,11 +786,6 @@
 							<span>Duration: {{duration}}</span>
 						</div>
 						{{/duration}}
-						{{#range}}
-						<div class="info">
-							<span>Range: {{range}}</span>
-						</div>
-						{{/range}}
 						{{#desc}}
 						<div class="info">
 							<span>
@@ -800,12 +806,17 @@
 						<span>{{rname}}{{#mod}} <span>({{mod}})</span>{{/mod}}</span>
 					</div>
 					<div class="result">
+						{{#isinit}}
+						<div>
+							<span class="roll-initiative">{{r1}}</span>
+						</div>
+						{{/isinit}}
 						{{#normal}}
 						<div class="solo">
 							<span class="roll-used">{{r1}}</span>
 						</div>
-						{{#rollWasCrit() r1}}<div class="crit-success">CRIT SUCCESS!</div>{{/rollWasCrit() r1}}
-						{{#rollWasFumble() r1}}<div class="crit-fail">CRIT FAIL!</div>{{/rollWasFumble() r1}}
+						{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
+						{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
 						{{/normal}}
 						{{#advantage}}
 						{{#rollLess() r1 r2}}
@@ -816,7 +827,7 @@
 						<div class="adv">
 							<span class="roll-used">{{r2}}</span>
 						</div>
-						{{#rollWasCrit() r2}}<div class="crit-success">CRIT SUCCESS!</div>{{/rollWasCrit() r2}}
+						{{#rollWasCrit() r2}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r2}}
 						{{/rollLess() r1 r2}}
 						{{#rollTotal() r1 r2}}
 						<div class="adv">
@@ -826,8 +837,8 @@
 						<div class="adv">
 							<span class="roll-used">{{r2}}</span>
 						</div>
-						{{#rollWasCrit() r1}}<div class="crit-success">CRIT SUCCESS!</div>{{/rollWasCrit() r1}}
-						{{#rollWasFumble() r1}}<div class="crit-fail">CRIT FAIL!</div>{{/rollWasFumble() r1}}
+						{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
+						{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
 						{{/rollTotal() r1 r2}}
 						{{#rollGreater() r1 r2}}
 						<div class="adv">
@@ -837,7 +848,7 @@
 						<div class="adv">
 							<span class="roll-unused">{{r2}}</span>
 						</div>
-						{{#rollWasCrit() r1}}<div class="crit-success">CRIT SUCCESS!</div>{{/rollWasCrit() r1}}
+						{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
 						{{/rollGreater() r1 r2}}
 						{{/advantage}}
 						{{#disadvantage}}
@@ -849,7 +860,7 @@
 						<div class="adv">
 							<span class="roll-unused">{{r2}}</span>
 						</div>
-						{{#rollWasFumble() r1}}<div class="crit-fail">CRIT FAIL!</div>{{/rollWasFumble() r1}}
+						{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
 						{{/rollLess() r1 r2}}
 						{{#rollTotal() r1 r2}}
 						<div class="adv">
@@ -859,8 +870,8 @@
 						<div class="adv">
 							<span class="roll-used">{{r2}}</span>
 						</div>
-						{{#rollWasCrit() r1}}<div class="crit-success">CRIT SUCCESS!</div>{{/rollWasCrit() r1}}
-						{{#rollWasFumble() r1}}<div class="crit-fail">CRIT FAIL!</div>{{/rollWasFumble() r1}}
+						{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
+						{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
 						{{/rollTotal() r1 r2}}
 						{{#rollGreater() r1 r2}}
 						<div class="adv">
@@ -870,7 +881,7 @@
 						<div class="adv">
 							<span class="roll-used">{{r2}}</span>
 						</div>
-						{{#rollWasFumble() r2}}<div class="crit-fail">CRIT FAIL!</div>{{/rollWasFumble() r2}}
+						{{#rollWasFumble() r2}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r2}}
 						{{/rollGreater() r1 r2}}
 						{{/disadvantage}}
 					</div>
@@ -908,7 +919,7 @@
 		// Min slots = 10; Slots = STR score (which can exceed 18) + Fighter can use CON mod
 		// Stats can go higher than 18 so it is possible a PC could exceed 20 slots. if so, use the treasure box for overflow.
 		const maxSheetSlots = 20;
-		const minPcSlots = 0; // per core rules, min PC slots is 10, but making it 0 in case some debugg/curse/etc happens
+		const minPcSlots = 0; // per core rules, min PC slots is 10, but making it 0 in case some debuff/curse/etc happens
 
 		// SD core rules goes from levels 0-10 (class abilities start at level 1)
 		const minLevel = 0;
@@ -1412,6 +1423,24 @@
 			});
 		});
 
+		on("change:advantagetoggle", function(eventinfo) {
+			if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				return;
+			}
+			update_initiative();
+		});
+
+		on("change:core_die", function() {
+			getAttrs(["core_die"], function(v) {
+				let core = v.core_die && v.core_die != "" ? v.core_die : "1d20";
+				let update = { "d20": core };
+				if (!v.core_die || v.core_die === "") {
+					update["core_die"] = "1d20";
+				}
+				setAttrs(update);
+			});
+		});
+
 		on("change:repeating_attack:atkname change:repeating_attack:atkattr_base change:repeating_attack:atkmod change:repeating_attack:atkmagic change:repeating_attack:dmgflag change:repeating_attack:dmgbase change:repeating_attack:dmgmod change:repeating_attack:dmgtype change:repeating_attack:dmg2flag change:repeating_attack:dmg2base change:repeating_attack:dmg2mod change:repeating_attack:dmg2type change:repeating_attack:dmgcustcrit change:repeating_attack:dmg2custcrit change:repeating_attack:castdc change:repeating_attack:duration change:repeating_attack:atkrange", function(eventinfo) {
 			if (eventinfo.sourceType === "sheetworker") {
 				return;
@@ -1745,13 +1774,30 @@
 		};
 
 		var update_initiative = function() {
-			var attrs_to_get = ["dexterity", "dexterity_mod", "init_tiebreaker"];
+			var attrs_to_get = ["dexterity", "dexterity_mod", "init_tiebreaker", "advantagetoggle"];
 			getAttrs(attrs_to_get, function(v) {
 				var update = {};
 				var final_init = parseInt(v["dexterity_mod"], 10);
 				if (v["init_tiebreaker"] && v["init_tiebreaker"] != 0) {
 					final_init = final_init + parseFloat((parseInt(v["dexterity"], 10) / 100).toFixed(2));
 				}
+
+				switch (v["advantagetoggle"])
+				{
+					// advantage
+				 	case "{{query=1}} {{advantage=1}} {{r2=[[@{d20}":
+						update["initiative_style"] = "{@{d20},@{d20}}kh1";
+						break;
+					// disadvantage
+				 	case "{{query=1}} {{disadvantage=1}} {{r2=[[@{d20}":
+						update["initiative_style"] = "{@{d20},@{d20}}kl1";
+						break;
+					// normal
+					default:
+						update["initiative_style"] = "@{d20}";
+						break;
+				}
+
 				update["initiative_bonus"] = final_init;
 				setAttrs(update, {
 					silent: true

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -1000,7 +1000,7 @@
 				return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
 			});
 		}
-		
+
 		// parse monster from copy-and-paste book format to shadowdarklings-style format
 		let parseMonsters = function(text) {
 			const entries = [];
@@ -1070,7 +1070,7 @@
 				const statsAndActionsLines = lines.slice(acIndex);
 		
 				// find beginning of actions text
-				const actionsIndex = statsAndActionsLines.findIndex(o=>/[Ll][Vv]\s(\d+|\*)(\/\d+)?$/.test(o)) + 1;
+				const actionsIndex = statsAndActionsLines.findIndex(o=>/(^\d+|[Ll][Vv]\s(\d+|\*)(\/\d+)?)$/.test(o)) + 1;
 				const actionsLines = statsAndActionsLines.slice(actionsIndex);
 				monster.actions = parseActions(actionsLines);
 		
@@ -1147,7 +1147,7 @@
 			});
 			return monsters;
 		}
-
+		
 		let parseActions = function(inputArray) {
 			const result = [];
 		

--- a/Shadowdark-Unofficial/sheet.json
+++ b/Shadowdark-Unofficial/sheet.json
@@ -7,7 +7,7 @@
   "legacy": false,
   "printable": true,
   "compendium": "",
-  "instructions": "A tab-free 3rd-Party Shadowdark sheet for PCs (Crawlers) and NPCs (Monsters, etc.). Features: character info, stats, rollable traits/talents/abilities/notes, rollable attacks and spells, dark mode support, responsive design for smartphones, luck token tracking (normal and pulp mode), 20 gear slots and treasure tracking, import JSON from Shadowdarklings.net, import monsters by parsing copied text straight from the official PDF, level-up XP calculation, 3rd-party license compliant. No compendium support. This Unofficial Shadowdark sheet for Roll20 is an independent product published under the Shadowdark RPG Third-Party License and is not affiliated with The Arcane Library, LLC. Shadowdark RPG © 2023 The Arcane Library, LLC.",
+  "instructions": "A tab-free 3rd-Party Shadowdark sheet for PCs (Crawlers) and NPCs (Monsters, etc.). Features: character info, stats, tracking and sharing (to chat) traits/talents/abilities/notes, rollable attacks and spells, dark mode support, responsive design for smartphones, luck token tracking (normal and pulp mode), 20 gear slots and treasure tracking, import JSON from Shadowdarklings.net format, import monsters by parsing copied text straight from the official PDF, level-up XP calculation, 3rd-party license compliant. No compendium support. This Unofficial Shadowdark sheet for Roll20 is an independent product published under the Shadowdark RPG Third-Party License and is not affiliated with The Arcane Library, LLC. Shadowdark RPG © 2023 The Arcane Library, LLC.",
   "useroptions": [
     {
       "attribute": "npc",
@@ -15,32 +15,6 @@
       "type": "checkbox",
       "value": "1",
       "description": "Default sheet type to NPC (monster) instead of PC (Crawler). It is easy to toggle between these in the options section of the sheet."
-    },
-    {
-      "attribute": "rtype",
-      "displayname": "Roll Queries:",
-      "type": "select",
-      "options": [
-        "Always Roll Advantage|{{always=1}} {{r2=[[1d20",
-        "Advantage Toggle|@{advantagetoggle}",
-        "Query Advantage|{{query=1}} ?{Advantage?|Normal Roll,&#123&#123normal=1&#125&#125 &#123&#123r2=[[0d20|Advantage,&#123&#123advantage=1&#125&#125 &#123&#123r2=[[1d20|Disadvantage,&#123&#123disadvantage=1&#125&#125 &#123&#123r2=[[1d20}",
-        "Never Roll Advantage|{{normal=1}} {{r2=[[0d20"
-      ],
-      "default": "{{always=1}} {{r2=[[1d20",
-      "description": "D20 Rolls output according to this option. Always Roll Advantage is the default setting and will roll two D20 on every roll in case of advantage. The expectation is that if there is no advantage or disadvantage you use the left most result. The Advantage Toggle option adds three new buttons to the top of the sheet so that you can toggle advantage on a case by case basis. Query Advantage gives you a prompt every roll asking if the roll has advantage. Never Roll Advantage always rolls a single D20 on any given roll, expecting the player to roll a second time in case of advantage or disadvantage."
-    },
-    {
-      "attribute": "wtype",
-      "displayname": "Whisper Rolls to GM:",
-      "type": "select",
-      "options": [
-        "Never Whisper Rolls|",
-        "Whisper Toggle|@{whispertoggle}",
-        "Query Whisper|?{Whisper?|Public Roll,|Whisper Roll,/w gm }",
-        "Always Whisper Rolls|/w gm "
-      ],
-      "default": "",
-      "description": "All sheet rolls are sent to all players in chat by default. Whisper Toggle gives a set of buttons to quick select your preference on the fly. Query Whisper option gives you a prompt with each roll of whether or not the roll should be sent privately only to yourself and the GM. Always Whisper Rolls will send all rolls only to yourself and the GM."
     },
     {
       "attribute": "core_die",


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Fixed HP parsing (precedence issue, affected by previous Hydra fix attempt)
- Fixed Level parsing (precedence issue, affected by previous Hydra fix attempt)
- Fixed exception thrown by `titleCase()` when input is null / empty
- Improved regex for level, hp, and attack damage to account for weird slash `/` issue with elementals (picks the left hand side as default - for best results people shouldn't paste slash, or can edit after import)
- Fixed issue with splitting ATK with commas in the effect section, i.e.: the "Azer" stat block "2d8, ignites flammables" to properly parse the effect
- Effect output now shows "Effect: <effect>" in the description
- Fixed issue where range wasn't being imported due to using `.rng` instead of `.range`
- Fixed issue with parsing non-die damage (like spider, dealing 1 damage without roll)
- Removed unsupported options
- Added core die roll option
- Fixed issues with rolling initiative w/ adv and dis
- Added & Fixed initiative tie breaker option

Tested in my custom sheet sandbox, looks good now!



