### PR TITLE
Shadowdark-Unofficial: Restore damage flag checkbox to fix non-damage spells

### DIFF
--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -315,7 +315,7 @@
 								</div>
 								<div class="sheet-form-group">
 									<label class="sheet-form-checkbox">
-										<input type="hidden" name="attr_dmgflag" value="{{damage=1}} {{dmg1flag=1}}">
+										<input type="checkbox" name="attr_dmgflag" value="{{damage=1}} {{dmg1flag=1}}" checked>
 										<span>Damage Type 1</span>
 									</label>
 								</div>

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -562,7 +562,7 @@
 			</div>
 			<div class="sheet-form-group">
 				<label>Version:</label>
-				<input type="text" name="attr_version" value="2024.1.26.0" hidden disabled>
+				<input type="text" name="attr_version" value="2024.1.29.0" hidden disabled>
 				<span name="attr_version"></span>
 			</div>
 			<div>


### PR DESCRIPTION
# Submission Checklist
## Required

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Version 2024.1.29.0
- Attacks and Spells: Damage 1 flag is once again a checkbox that user can control.
-- The Damage 1 flag is checked by default.
-- Spells or attack-like actions that don't deal damage can uncheck the box to avoid showing a "0" in the attack effect template (AKA damage template)
