### PR TITLE
Update Shadowdark-Unofficial.html: fix DEX typo for attack modifiers

### DIFF
--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -269,10 +269,10 @@
 									<select name="attr_atkattr_base">
 										<option value="@{strength_mod}" selected="selected">STR</option>
 										<option value="@{dexterity_mod}">DEX</option>
-										<option value="@{constitution_mod}">DEX</option>
+										<option value="@{constitution_mod}">CON</option>
 										<option value="@{intelligence_mod}">INT</option>
 										<option value="@{wisdom_mod}">WIS</option>
-										<option value="@{charisma_mod}">DEX</option>
+										<option value="@{charisma_mod}">CHA</option>
 										<option value="0">-</option>
 									</select>
 									<span>+</span>

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -577,7 +577,7 @@
 			</div>
 			<div class="sheet-form-group">
 				<label>Version:</label>
-				<input type="text" name="attr_version" value="2024.2.3.0" hidden disabled>
+				<input type="text" name="attr_version" value="2024.2.29.0" hidden disabled>
 				<span name="attr_version"></span>
 			</div>
 			<div>


### PR DESCRIPTION
**Shadowdark-Unofficial sheet - Version 2029.2.29.0**
Fixed 2 typos: Attack modifiers applied correct stat bonus but showed DEX instead of CON and CHA

# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

BUG FIXED: In Attacks & Spells, the labels for the drop down options CON and CHA were showing "DEX" instead.




