### PR TITLE
[Paladin] Overhaul continuation

### DIFF
--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -2366,7 +2366,7 @@ data-i18n="courtesy" name="roll_courtesy" type="roll" value="&{template:rolls} {
 	movement: ['strength', 'dexterity'],
 	hp: ['size', 'constitution'],
 	unconcious: ['total_hit_points'],
-	knights: ['old_knights', 'middle_aged_knights', 'young_knights']
+	knights: ['old_knights', 'middle_aged_knights', 'young_knights'],
 	annualglory: ['annual_glory_rewards_traits', 'annual_glory_rewards_passions', 'annual_glory_rewards_skills', 'annual_glory_rewards_attributes', 'annual_glory_rewards_attitudes', 'annual_glory_rewards_chivalry', 'annual_glory_rewards_romance', 'annual_glory_rewards_religion', 'annual_glory_rewards_maintenance', 'annual_glory_rewards_luxury_spendings', 'annual_glory_rewards_holdings', 'annual_glory_rewards_enchanted_items']
 }
 

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1056,8 +1056,8 @@
 </div>
 <div class="row 3autocolumn knight">
 <button class="text-capitalize" data-i18n="age" name="roll_age" type="roll" value="&{template:rolls} {{header=Squire's ^{age}}} {{dice=[[{1d20+({@{squire_age}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_age}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_age}+(?{Mod.|0}),0}kl1)]]}}"></button>
-<label data-i18n-title="squire age check" title="squire age check">
-<input name="attr_squire_age_check" placeholder="#" title="@{squire_age}" type="number" value=""/>
+<label data-i18n-title="enter age" title="enter age">
+<input name="attr_squire_age" placeholder="#" title="@{squire_age}" type="number" value=""/>
 </label>
 </div>
 <div class="row 3autocolumn knight">
@@ -1091,19 +1091,19 @@
 </label>
 </div>
 <div class="repeating-container">
-<fieldset class="repeating_squireskills">
+<fieldset class="repeating_squire-skills">
 <div class="row">
 <label data-i18n-title="enter name" title="enter name">
 <input data-i18n-placeholder="name" name="attr_name" placeholder="name" title="@{name}" type="text" value=""/>
 </label>
-<label data-i18n-title="enter squire skill" title="enter squire skill">
-<input name="attr_squire_skill" placeholder="#" title="@{squire_skill}" type="number" value="0"/>
+<label data-i18n-title="enter skill" title="enter skill">
+<input name="attr_skill" placeholder="#" title="@{skill}" type="number" value="0"/>
 </label>
 <label class="styled-checkbox grid" data-i18n-title="check" title="check">
 <input name="attr_check" title="@{check}" type="checkbox" value="check"/>
 <span class="pictos">3</span>
 </label>
-<button class="d20" name="roll_squire_skill" type="roll" value="&{template:rolls}{{header=@{name}}}{dice=[[{1d20+({@{squire_skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<button class="d20" name="roll_skill" type="roll" value="&{template:rolls}{{header=@{name}}}{{dice=[[{1d20+({@{skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
 </div>
 </fieldset>
 </div>

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -58,8 +58,8 @@
 <div class="header"><h1 data-i18n="personal data"></h1></div>
 <div class="row 2autocolumn">
 <h2 data-i18n="name"></h2>
-<label data-i18n-title="enter character name" title="enter character name">
-<input data-i18n-placeholder="name" name="attr_character_name" placeholder="name" title="@{character_name}" type="text" value=""/>
+<label data-i18n-title="enter name" title="enter name">
+<input data-i18n-placeholder="name" name="attr_name" placeholder="name" title="@{name}" type="text" value=""/>
 </label>
 </div>
 <div class="row 2column">
@@ -1102,14 +1102,14 @@
 <label data-i18n-title="enter name" title="enter name">
 <input data-i18n-placeholder="name" name="attr_name" placeholder="name" title="@{name}" type="text" value=""/>
 </label>
-<label data-i18n-title="enter skill" title="enter skill">
-<input name="attr_skill" placeholder="#" title="@{skill}" type="number" value="0"/>
+<label data-i18n-title="enter squire skill" title="enter squire skill">
+<input name="attr_squire_skill" placeholder="#" title="@{squire_skill}" type="number" value="0"/>
 </label>
 <label class="styled-checkbox grid" data-i18n-title="check" title="check">
 <input name="attr_check" title="@{check}" type="checkbox" value="check"/>
 <span class="pictos">3</span>
 </label>
-<button class="d20" name="roll_skill" type="roll" value="&{template:rolls}{{header=@{name}}}{{dice=[[{1d20+({@{skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<button class="d20" name="roll_squire_skill" type="roll" value="&{template:rolls}{{header=@{name}}}{{dice=[[{1d20+({@{squire_skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
 </div>
 </fieldset>
 </div>

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1077,7 +1077,7 @@
 </label>
 </div>
 <div class="row 3autocolumn knight">
-<button class="text-capitalize" data-i18n="battle" name="roll_battle" type="roll" value="&{template:rolls} {{header=Squire's ^{battle}}} {dice=[[{1d20+({@{squire_battle}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_battle}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_battle}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<button class="text-capitalize" data-i18n="battle" name="roll_battle" type="roll" value="&{template:rolls} {{header=Squire's ^{battle}}} {{dice=[[{1d20+({@{squire_battle}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_battle}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_battle}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter battle" title="enter battle">
 <input name="attr_squire_battle" placeholder="#" title="@{squire_battle}" type="number" value=""/>
 </label>
@@ -1087,12 +1087,12 @@
 </label>
 </div>
 <div class="row 3autocolumn knight">
-<button class="text-capitalize" data-i18n="horsemanship" name="roll_horsemanship" type="roll" value="&{template:rolls} {{header=Squire's ^{horsemanship}}} {dice=[[{1d20+({@{squire_horsemanship}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_horsemanship}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_horsemanship}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<button class="text-capitalize" data-i18n="horsemanship" name="roll_battle" type="roll" value="&{template:rolls} {{header=Squire's ^{horsemanship}}} {{dice=[[{1d20+({@{squire_horsemanship}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_horsemanship}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_horsemanship}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter horsemanship" title="enter horsemanship">
 <input name="attr_squire_horsemanship" placeholder="#" title="@{squire_horsemanship}" type="number" value=""/>
 </label>
-<label class="styled-checkbox grid" data-i18n-title="squire horsemanship check" title="squire horsemanship check">
-<input name="attr_squire_horsemanship_check" title="@{squire_horsemanship_check}" type="checkbox" value="squire horsemanship check"/>
+<label class="styled-checkbox grid" data-i18n-title="squire horsemanship" title="squire horsemanship">
+<input name="attr_squire_horsemanship" title="@{squire_horsemanship}" type="checkbox" value="squire horsemanship check"/>
 <span class="pictos">3</span>
 </label>
 </div>

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1,4 +1,4 @@
-<input name="attr_version" type="hidden" value="1"/>
+<input name="attr_version" type="hidden" value="2"/>
 <input name="attr_sheet_type" type="hidden" value="character"/>
 <input name="attr_character_type" type="hidden" value="knight"/>
 <input name="attr_feast_type" type="hidden" value="feast"/>
@@ -2336,7 +2336,7 @@ data-i18n="courtesy" name="roll_courtesy" type="roll" value="&{template:rolls} {
 <div class="row"><h2 data-i18n="notes"></h2><textarea name="attr_feast_record_notes"></textarea></div>
 </div>
 </div>
-<div class="footer"><span>©2016 Nocturnal Media. Permission granted to copy for personal use only.</span><span>v. </span><span name="attr_version"></span></div>
+<div class="footer"><span>©2016 Nocturnal Media. Permission granted to copy for personal use only. 2024 overhaul by Griselame </span><span>v. </span><span name="attr_version"></span></div>
 
 
 <!-- * * * PAGE BREAK * * * -->

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -143,7 +143,7 @@
 <h1 data-i18n="personality traits"></h1>
 </div>
 <div class="row 2autocolumn knight">
-<h2 data-i18n="Chivalry Bonus[*](total=80+)"></h2>
+<h2 data-i18n="Chivalry Bonus[*](total=90+, Honor 16+)"></h2>
 <label data-i18n-title="enter chivalry bonus" title="enter chivalry bonus">
 <input data-i18n-placeholder="chivalry bonus" name="attr_chivalry_bonus" placeholder="chivalry bonus" title="@{chivalry_bonus}" type="text" value=""/>
 </label>
@@ -155,9 +155,15 @@
 </label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="Religious Bonus(traits all 16+)"></h2>
+<h2 data-i18n="Religious Bonus(total=90+, Love (God) 16+)"></h2>
 <label data-i18n-title="enter religious bonus" title="enter religious bonus">
 <input data-i18n-placeholder="religious bonus" name="attr_religious_bonus" placeholder="religious bonus" title="@{religious_bonus}" type="text" value=""/>
+</label>
+</div>
+<div class="row 2autocolumn">
+<h2 data-i18n="Romance Bonus(total=90+, Amor 16+)"></h2>
+<label data-i18n-title="enter romance bonus" title="enter romance bonus">
+<input data-i18n-placeholder="romance bonus" name="attr_romance_bonus" placeholder="romance bonus" title="@{romance_bonus}" type="text" value=""/>
 </label>
 </div>
 <div class="row traits">

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -58,8 +58,8 @@
 <div class="header"><h1 data-i18n="personal data"></h1></div>
 <div class="row 2autocolumn">
 <h2 data-i18n="name"></h2>
-<label data-i18n-title="enter name" title="enter name">
-<input data-i18n-placeholder="name" name="attr_name" placeholder="name" title="@{name}" type="text" value=""/>
+<label data-i18n-title="enter character name" title="enter character name">
+<input data-i18n-placeholder="name" name="attr_character_name" placeholder="name" title="@{character_name}" type="text" value=""/>
 </label>
 </div>
 <div class="row 2column">

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -2418,7 +2418,7 @@ attributes.annualglory.forEach(attr => {
 //For example, a character with a Damage value of 4.43 would
 //have an effective value of 4, while a character with a Damage val-
 //ue of 4.5 would have a 5.
-const roundFraction = sum => sum >= 0.5 ? Math.ceil(sum) : Math.floor(sum)
+const roundFraction = sum => (sum % 1) >= 0.5 ? Math.ceil(sum) : Math.floor(sum)
 const divideBy = (sum, num) => sum/num;
 
 const totalAttributes = values => {

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1087,12 +1087,12 @@
 </label>
 </div>
 <div class="row 3autocolumn knight">
-<button class="text-capitalize" data-i18n="horsemanship" name="roll_battle" type="roll" value="&{template:rolls} {{header=Squire's ^{horsemanship}}} {{dice=[[{1d20+({@{squire_horsemanship}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_horsemanship}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_horsemanship}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<button class="text-capitalize" data-i18n="horsemanship" name="roll_horsemanship" type="roll" value="&{template:rolls} {{header=Squire's ^{horsemanship}}} {{dice=[[{1d20+({@{squire_horsemanship}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_horsemanship}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_horsemanship}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter horsemanship" title="enter horsemanship">
 <input name="attr_squire_horsemanship" placeholder="#" title="@{squire_horsemanship}" type="number" value=""/>
 </label>
-<label class="styled-checkbox grid" data-i18n-title="squire horsemanship" title="squire horsemanship">
-<input name="attr_squire_horsemanship" title="@{squire_horsemanship}" type="checkbox" value="squire horsemanship check"/>
+<label class="styled-checkbox grid" data-i18n-title="squire horsemanship check" title="squire horsemanship check">
+<input name="attr_squire_horsemanship_check" title="@{squire_horsemanship_check}" type="checkbox" value="squire horsemanship check"/>
 <span class="pictos">3</span>
 </label>
 </div>

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1949,6 +1949,10 @@
 <h2 data-i18n="enchanted items"></h2>
 <label data-i18n-title="enter annual glory rewards enchanted items" title="enter annual glory rewards enchanted items"><input data-i18n-placeholder="annual glory rewards enchanted items" name="attr_annual_glory_rewards_enchanted_items" placeholder="annual glory rewards enchanted items" title="@{annual_glory_rewards_enchanted_items}" type="text" value=""/></label>
 </div>
+<div class="row 2autocolumn">
+<h2 data-i18n="total"></h2>
+<span class="text-center display" name="attr_annual_glory_rewards_total"></span>
+</div>
 </div>
 <div class="holdings-row">
 <div class="header"><h1 data-i18n="holdings"></h1></div>
@@ -2403,7 +2407,7 @@ attributes.knights.forEach(attr => {
 	});
 })
 
-attributes.knights.forEach(attr => {
+attributes.annualglory.forEach(attr => {
 	on(`change:${attr}`, (eventinfo) => {
 		sumOfCalculator(attributes.annualglory, 'annual_glory_rewards_total');
 	});


### PR DESCRIPTION
Change list 03/12/24 - following pull request blocked due to attribute conflict: 

Corrected Age button
Fixing repeating container bug
Ideals - adding missing romance ideal field
Ideals - changed descriptions to reflect current rules
Squire section was wrongly pointing to the checkbox rather than the actual text field
Annual glory - added missing total, fixed sum calculator
"Knights" attribute (_attributes.knights.forEach(attr => {_)was doubled, changed for "annualglory" attribute that was missing
Fixed sum calculator syntax
Dropped change from attribute "name" to "character_name" - will use sheetworker at a later stage (thanks for the tip)
Modified calculator for derived attribute damage (rounding down as per rules, instead of rounding up)
Added my name as contributor, updated sheet version
