### PR TITLE
[Paladin] next small ovehauls

### DIFF
--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1154,21 +1154,21 @@
 <h2 data-i18n="wounds"></h2>
 <textarea data-i18n-placeholder="wounds" name="attr_wounds" placeholder="wounds"></textarea>
 </div>
-<div class="row three-quarter-hp">
+<div class="row chirurgery-needed">
 <label class="styled-checkbox grid" data-i18n-title="3/4 HP" title="3/4 HP">
 <input name="attr_three_quarter_hp" title="@{three_quarter_hp}" type="checkbox" value="3/4 HP"/>
 <span class="pictos">3</span>
 </label>
 <h2 data-i18n="3/4 HP = -5 to Actions"></h2>
 </div>
-<div class="row half-hp">
+<div class="row chirurgery-needed">
 <label class="styled-checkbox grid" data-i18n-title="1/2 HP" title="1/2 HP">
 <input name="attr_half_hp" title="@{half_hp}" type="checkbox" value="1/2 HP"/>
 <span class="pictos">3</span>
 </label>
 <h2 data-i18n="1/2 HP = -10 to Actions"></h2>
 </div>
-<div class="row one-quarter-hp">
+<div class="row chirurgery-needed">
 <label class="styled-checkbox grid" data-i18n-title="1/4 HP" title="1/4 HP">
 <input name="attr_one_quarter_hp" title="@{one_quarter_hp}" type="checkbox" value="1/4 HP"/>
 <span class="pictos">3</span>
@@ -2020,8 +2020,8 @@
 </div>
 <div class="row grid knight">
 <div class="col 2autocolumn">
-<h2 data-i18n="member of the round table"></h2>
-<label data-i18n-title="enter member of the round table" title="enter member of the round table"><input data-i18n-placeholder="member of the round table" name="attr_member_of_the_round_table" placeholder="member of the round table" title="@{member_of_the_round_table}" type="text" value=""/></label>
+<h2 data-i18n="paladin"></h2>
+<label data-i18n-title="enter paladin" title="enter paladin"><input data-i18n-placeholder="paladin" name="attr_paladin" placeholder="paladin" title="@{paladin}" type="text" value=""/></label>
 </div>
 </div>
 <div class="row grid col-4">


### PR DESCRIPTION
The checkboxes & text in the health section are all unaligned, causing unaesthetic alignment in the sheet. By changing the div class, the three lines & corresponding checkboxes realign properly.

The "member of the round table" attribute & box is useless - it is a holdover from the old King Arthur Pendragon character sheet on which the Paladin sheet is based. There are no round table knights in the Paladin universe :) However "Paladins" are indeed a thing (given the name of the game, what a surprise :) ), and this space is to keep track of the year in which the characters potentially receive this super rare honor. It makes sense to drop the old attribute and put the paladin one instead. Impact is extremely minor for users - its just there to track a year, and as I said, it is super rare even for really advanced characters.

**EXISTING SHEET**
![image](https://github.com/Roll20/roll20-character-sheets/assets/72399500/56736042-ad03-4293-a512-710363ae2380)

![image](https://github.com/Roll20/roll20-character-sheets/assets/72399500/1fd5b0ee-f7c2-4a5e-88b2-9f105299e898)

**PROPOSED CHANGES (with translation turned on)**
![image](https://github.com/Roll20/roll20-character-sheets/assets/72399500/77c16f4c-7ad9-4839-9ec5-8dab53efaeac)

![image](https://github.com/Roll20/roll20-character-sheets/assets/72399500/0ef76c84-9013-4813-9bb2-bc0edc324665)


