### PR TITLE
[Paladin] Automating ideals calculation + squire skills default value

### DIFF
--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -149,7 +149,8 @@
 <div class="row 2autocolumn woman">
 <h2 data-i18n="Gentle Woman Bonus[*](total=80+)"></h2>
 <label data-i18n-title="enter gentle woman bonus" title="enter gentle woman bonus">
-<span class="text-center display" name="attr_gentle_woman_bonus"></span>
+<input data-i18n-placeholder="gentle woman bonus" name="attr_gentle_woman_bonus" placeholder="gentle woman bonus" title="@{gentle_woman_bonus}" type="text" value=""/>
+</label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="Religious Bonus(total=90+, Love (God) 16+)"></h2>

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -144,27 +144,20 @@
 </div>
 <div class="row 2autocolumn knight">
 <h2 data-i18n="Chivalry Bonus[*](total=90+, Honor 16+)"></h2>
-<label data-i18n-title="enter chivalry bonus" title="enter chivalry bonus">
-<input data-i18n-placeholder="chivalry bonus" name="attr_chivalry_bonus" placeholder="chivalry bonus" title="@{chivalry_bonus}" type="text" value=""/>
-</label>
+<span class="text-center display" name="attr_chivalry_bonus"></span>
 </div>
 <div class="row 2autocolumn woman">
 <h2 data-i18n="Gentle Woman Bonus[*](total=80+)"></h2>
 <label data-i18n-title="enter gentle woman bonus" title="enter gentle woman bonus">
-<input data-i18n-placeholder="gentle woman bonus" name="attr_gentle_woman_bonus" placeholder="gentle woman bonus" title="@{gentle_woman_bonus}" type="text" value=""/>
-</label>
+<span class="text-center display" name="attr_gentle_woman_bonus"></span>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="Religious Bonus(total=90+, Love (God) 16+)"></h2>
-<label data-i18n-title="enter religious bonus" title="enter religious bonus">
-<input data-i18n-placeholder="religious bonus" name="attr_religious_bonus" placeholder="religious bonus" title="@{religious_bonus}" type="text" value=""/>
-</label>
+<span class="text-center display" name="attr_religious_bonus"></span>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="Romance Bonus(total=90+, Amor 16+)"></h2>
-<label data-i18n-title="enter romance bonus" title="enter romance bonus">
-<input data-i18n-placeholder="romance bonus" name="attr_romance_bonus" placeholder="romance bonus" title="@{romance_bonus}" type="text" value=""/>
-</label>
+<span class="text-center display" name="attr_romance_bonus"></span>
 </div>
 <div class="row traits">
 <div class="font-weight-bold"><span class="woman">*</span></div>
@@ -2367,7 +2360,10 @@ data-i18n="courtesy" name="roll_courtesy" type="roll" value="&{template:rolls} {
 	hp: ['size', 'constitution'],
 	unconcious: ['total_hit_points'],
 	knights: ['old_knights', 'middle_aged_knights', 'young_knights'],
-	annualglory: ['annual_glory_rewards_traits', 'annual_glory_rewards_passions', 'annual_glory_rewards_skills', 'annual_glory_rewards_attributes', 'annual_glory_rewards_attitudes', 'annual_glory_rewards_chivalry', 'annual_glory_rewards_romance', 'annual_glory_rewards_religion', 'annual_glory_rewards_maintenance', 'annual_glory_rewards_luxury_spendings', 'annual_glory_rewards_holdings', 'annual_glory_rewards_enchanted_items']
+	annualglory: ['annual_glory_rewards_traits', 'annual_glory_rewards_passions', 'annual_glory_rewards_skills', 'annual_glory_rewards_attributes', 'annual_glory_rewards_attitudes', 'annual_glory_rewards_chivalry', 'annual_glory_rewards_romance', 'annual_glory_rewards_religion', 'annual_glory_rewards_maintenance', 'annual_glory_rewards_luxury_spendings', 'annual_glory_rewards_holdings', 'annual_glory_rewards_enchanted_items'],
+	chivalry: ['energetic', 'generous', 'just', 'merciful', 'modest', 'valorous'],
+	religious: ['chaste', 'forgiving', 'merciful', 'modest', 'temperate', 'trusting'],
+	romantic: ['chaste', 'forgiving', 'generous', 'honest', 'prudent', 'trusting']
 }
 
 
@@ -2410,6 +2406,24 @@ attributes.knights.forEach(attr => {
 attributes.annualglory.forEach(attr => {
 	on(`change:${attr}`, (eventinfo) => {
 		sumOfCalculator(attributes.annualglory, 'annual_glory_rewards_total');
+	});
+})
+
+attributes.chivalry.forEach(attr => {
+	on(`change:${attr}`, (eventinfo) => {
+		sumOfCalculator(attributes.chivalry, 'chivalry_bonus');
+	});
+})
+
+attributes.religious.forEach(attr => {
+	on(`change:${attr}`, (eventinfo) => {
+		sumOfCalculator(attributes.religious, 'religious_bonus');
+	});
+})
+
+attributes.romantic.forEach(attr => {
+	on(`change:${attr}`, (eventinfo) => {
+		sumOfCalculator(attributes.romantic, 'romance_bonus');
 	});
 })
 

--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1056,13 +1056,13 @@
 <div class="row 3autocolumn knight">
 <button class="text-capitalize" data-i18n="age" name="roll_age" type="roll" value="&{template:rolls} {{header=Squire's ^{age}}} {{dice=[[{1d20+({@{squire_age}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_age}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_age}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter age" title="enter age">
-<input name="attr_squire_age" placeholder="#" title="@{squire_age}" type="number" value=""/>
+<input name="attr_squire_age" placeholder="#" title="@{squire_age}" type="number" value="0"/>
 </label>
 </div>
 <div class="row 3autocolumn knight">
 <button class="text-capitalize" data-i18n="first aid" name="roll_first-aid" type="roll" value="&{template:rolls} {{header=Squire's ^{first aid}}} {{dice=[[{1d20+({@{squire_first_aid}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_first_aid}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_first_aid}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter first aid" title="enter first aid">
-<input name="attr_squire_first_aid" placeholder="#" title="@{squire_first_aid}" type="number" value=""/>
+<input name="attr_squire_first_aid" placeholder="#" title="@{squire_first_aid}" type="number" value="0"/>
 </label>
 <label class="styled-checkbox grid" data-i18n-title="squire first aid check" title="squire first aid check">
 <input name="attr_squire_first_aid_check" title="@{squire_first_aid_check}" type="checkbox" value="squire first aid check"/>
@@ -1072,7 +1072,7 @@
 <div class="row 3autocolumn knight">
 <button class="text-capitalize" data-i18n="battle" name="roll_battle" type="roll" value="&{template:rolls} {{header=Squire's ^{battle}}} {{dice=[[{1d20+({@{squire_battle}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_battle}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_battle}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter battle" title="enter battle">
-<input name="attr_squire_battle" placeholder="#" title="@{squire_battle}" type="number" value=""/>
+<input name="attr_squire_battle" placeholder="#" title="@{squire_battle}" type="number" value="0"/>
 </label>
 <label class="styled-checkbox grid" data-i18n-title="squire battle check" title="squire battle check">
 <input name="attr_squire_battle_check" title="@{squire_battle_check}" type="checkbox" value="squire battle check"/>
@@ -1082,7 +1082,7 @@
 <div class="row 3autocolumn knight">
 <button class="text-capitalize" data-i18n="horsemanship" name="roll_horsemanship" type="roll" value="&{template:rolls} {{header=Squire's ^{horsemanship}}} {{dice=[[{1d20+({@{squire_horsemanship}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_horsemanship}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_horsemanship}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter horsemanship" title="enter horsemanship">
-<input name="attr_squire_horsemanship" placeholder="#" title="@{squire_horsemanship}" type="number" value=""/>
+<input name="attr_squire_horsemanship" placeholder="#" title="@{squire_horsemanship}" type="number" value="0"/>
 </label>
 <label class="styled-checkbox grid" data-i18n-title="squire horsemanship check" title="squire horsemanship check">
 <input name="attr_squire_horsemanship_check" title="@{squire_horsemanship_check}" type="checkbox" value="squire horsemanship check"/>


### PR DESCRIPTION
All three ideals for knights (Romance, chivalry, religion) consist in adding up the values of six relevant personality traits.

Rather than doing it manually, I propose this change to automate the calculations and thus making it easier/faster for players.

**Current version (in French)**

<img width="293" alt="image" src="https://github.com/Roll20/roll20-character-sheets/assets/72399500/82528d6d-0ea1-4546-a7b1-269b4c4c8e86">


**Proposed change**

<img width="293" alt="image" src="https://github.com/Roll20/roll20-character-sheets/assets/72399500/0b31859e-8846-4a79-b06c-4d42a63a5954">

Also, adding 0 as default value to all 4 squire basic skills