### PR TITLE
[Paladin] - Update of the Entourage tab

### DIFF
--- a/Paladin/paladin.html
+++ b/Paladin/paladin.html
@@ -1533,7 +1533,7 @@
    ============================= -->
 
 <div class="entourage grid">
-<div class="row bottom-border text-center"><h1 class="knight" data-i18n="knight's entourage"></h1><h1 class="woman" data-i18n="lady's entourage"></h1></div>
+<div class="row bottom-border text-center header"><h1 class="knight" data-i18n="knight's entourage"></h1><h1 class="woman" data-i18n="lady's entourage"></h1></div>
 <div class="row 2column">
 <div class="col">
 <div class="row knight"><h1 data-i18n="squire"></h1></div>
@@ -1560,34 +1560,34 @@
 </div>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_skill-1" type="roll" value="&{template:rolls} {{header=@{skill_1}}} {{dice=[[{1d20+({@{value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter skill 1" title="enter skill 1"><input data-i18n-placeholder="skill 1" name="attr_skill_1" placeholder="skill 1" title="@{skill_1}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_skill-2" type="roll" value="&{template:rolls} {{header=@{skill_2}}} {{dice=[[{1d20+({@{value_2}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_2}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_2}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter skill 2" title="enter skill 2"><input data-i18n-placeholder="skill 2" name="attr_skill_2" placeholder="skill 2" title="@{skill_2}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="loyalty lord"></h2>
+<button class="text-capitalize" data-i18n="loyalty lord" name="roll_loyalty-lord" type="roll" value="&{template:rolls} {{header=^{loyalty lord}}} {{dice=[[{1d20+({@{value_3}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_3}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_3}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter loyalty lord" title="enter loyalty lord"><input data-i18n-placeholder="loyalty lord" name="attr_loyalty_lord" placeholder="loyalty lord" title="@{loyalty_lord}" type="text" value=""/></label>
 </div>
 </div>
 <div class="col">
 <div class="row 2autocolumn">
-<h2 data-i18n="squire skill"></h2>
-<label data-i18n-title="enter squire skill" title="enter squire skill"><input data-i18n-placeholder="squire skill" name="attr_squire_skill" placeholder="squire skill" title="@{squire_skill}" type="text" value=""/></label>
+<button class="text-capitalize" data-i18n="squire skill" name="roll_squire-skill" type="roll" value="&{template:rolls} {{header=^{squire skill}}} {{dice=[[{1d20+({@{squire_skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{squire_skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{squire_skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<label data-i18n-title="enter squire skill" title="enter squire skill"><input data-i18n-placeholder="squire skill" name="attr_squire_skill" placeholder="squire skill" title="@{squire_skill}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 1" title="enter value 1"><input data-i18n-placeholder="value 1" name="attr_value_1" placeholder="value 1" title="@{value_1}" type="text" value=""/></label>
+<label data-i18n-title="enter value 1" title="enter value 1"><input data-i18n-placeholder="value 1" name="attr_value_1" placeholder="value 1" title="@{value_1}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 2" title="enter value 2"><input data-i18n-placeholder="value 2" name="attr_value_2" placeholder="value 2" title="@{value_2}" type="text" value=""/></label>
+<label data-i18n-title="enter value 2" title="enter value 2"><input data-i18n-placeholder="value 2" name="attr_value_2" placeholder="value 2" title="@{value_2}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 3" title="enter value 3"><input data-i18n-placeholder="value 3" name="attr_value_3" placeholder="value 3" title="@{value_3}" type="text" value=""/></label>
+<label data-i18n-title="enter value 3" title="enter value 3"><input data-i18n-placeholder="value 3" name="attr_value_3" placeholder="value 3" title="@{value_3}" type="number" value="0"/></label>
 </div>
 </div>
 </div>
@@ -1596,36 +1596,55 @@
 <div class="row woman"><h1 data-i18n="maid-in-waiting"></h1></div>
 <div class="repeating-container gold-bottom-border woman">
 <fieldset class="repeating_maid">
-<div class="row 2autocolumn"><h2 data-i18n="maid-in-waiting"></h2><label data-i18n-title="enter maid in waiting" title="enter maid in waiting"><input data-i18n-placeholder="maid in waiting" name="attr_maid_in_waiting" placeholder="maid in waiting" title="@{maid_in_waiting}" type="text" value=""/></label></div>
-<div class="row 3column"><div class="col 2autocolumn"><h2 data-i18n="born"></h2><label data-i18n-title="enter born" title="enter born"><input data-i18n-placeholder="born" name="attr_born" placeholder="born" title="@{born}" type="text" value=""/></label></div><div class="col 2autocolumn"><h2 data-i18n="age"></h2><label data-i18n-title="enter age" title="enter age"><input data-i18n-placeholder="age" name="attr_age" placeholder="age" title="@{age}" type="text" value=""/></label></div><div class="col 2autocolumn"><h2 data-i18n="mod"></h2><label data-i18n-title="enter mod" title="enter mod"><input data-i18n-placeholder="mod" name="attr_mod" placeholder="mod" title="@{mod}" type="text" value=""/></label></div></div>
-<div class="row 2autocolumn"><h2 data-i18n="hand maiden skill"></h2><label data-i18n-title="enter hand maiden skill" title="enter hand maiden skill"><input data-i18n-placeholder="hand maiden skill" name="attr_hand_maiden_skill" placeholder="hand maiden skill" title="@{hand_maiden_skill}" type="text" value=""/></label></div>
+<div class="row 2autocolumn">
+<h2 data-i18n="maid-in-waiting"></h2>
+<label data-i18n-title="enter maid in waiting" title="enter maid in waiting"><input data-i18n-placeholder="maid in waiting" name="attr_maid_in_waiting" placeholder="maid in waiting" title="@{maid_in_waiting}" type="text" value=""/></label>
+</div>
+<div class="row 3column">
+<div class="col 2autocolumn">
+<h2 data-i18n="born"></h2>
+<label data-i18n-title="enter born" title="enter born"><input data-i18n-placeholder="born" name="attr_born" placeholder="born" title="@{born}" type="text" value=""/></label>
+</div>
+<div class="col 2autocolumn">
+<h2 data-i18n="age"></h2>
+<label data-i18n-title="enter age" title="enter age"><input data-i18n-placeholder="age" name="attr_age" placeholder="age" title="@{age}" type="text" value=""/></label>
+</div>
+<div class="col 2autocolumn">
+<h2 data-i18n="mod"></h2>
+<label data-i18n-title="enter mod" title="enter mod"><input data-i18n-placeholder="mod" name="attr_mod" placeholder="mod" title="@{mod}" type="text" value=""/></label>
+</div>
+</div>
+<div class="row 2autocolumn">
+<button class="text-capitalize" data-i18n="hand maiden skill" name="roll_hand-maiden-skill" type="roll" value="&{template:rolls} {{header=^{hand maiden skill}}} {{dice=[[{1d20+({@{hand_maiden_skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{hand_maiden_skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{hand_maiden_skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<label data-i18n-title="enter hand maiden skill" title="enter hand maiden skill"><input data-i18n-placeholder="hand maiden skill" name="attr_hand_maiden_skill" placeholder="hand maiden skill" title="@{hand_maiden_skill}" type="number" value="0"/></label>
+</div>
 <div class="row col-2">
 <div class="col">
 <div class="row 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_skill" type="roll" value="&{template:rolls} {{header=@{skill}}} {{dice=[[{1d20+({@{value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter skill" title="enter skill"><input data-i18n-placeholder="skill" name="attr_skill" placeholder="skill" title="@{skill}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="skill industry"></h2>
+<button class="text-capitalize" data-i18n="skill industry" name="roll_skill-industry" type="roll" value="&{template:rolls} {{header=@{skill_industry}}} {{dice=[[{1d20+({@{value_2}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_2}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_2}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter skill industry" title="enter skill industry"><input data-i18n-placeholder="skill industry" name="attr_skill_industry" placeholder="skill industry" title="@{skill_industry}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="loyalty lady"></h2>
+<button class="text-capitalize" data-i18n="loyalty lady" name="roll_loyalty-lady" type="roll" value="&{template:rolls} {{header=@{loyalty_lady}}} {{dice=[[{1d20+({@{value_3}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_3}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_3}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter loyalty lady" title="enter loyalty lady"><input data-i18n-placeholder="loyalty lady" name="attr_loyalty_lady" placeholder="loyalty lady" title="@{loyalty_lady}" type="text" value=""/></label>
 </div>
 </div>
 <div class="col">
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 1" title="enter value 1"><input data-i18n-placeholder="value 1" name="attr_value_1" placeholder="value 1" title="@{value_1}" type="text" value=""/></label>
+<label data-i18n-title="enter value 1" title="enter value 1"><input data-i18n-placeholder="value 1" name="attr_value_1" placeholder="value 1" title="@{value_1}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 2" title="enter value 2"><input data-i18n-placeholder="value 2" name="attr_value_2" placeholder="value 2" title="@{value_2}" type="text" value=""/></label>
+<label data-i18n-title="enter value 2" title="enter value 2"><input data-i18n-placeholder="value 2" name="attr_value_2" placeholder="value 2" title="@{value_2}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 3" title="enter value 3"><input data-i18n-placeholder="value 3" name="attr_value_3" placeholder="value 3" title="@{value_3}" type="text" value=""/></label>
+<label data-i18n-title="enter value 3" title="enter value 3"><input data-i18n-placeholder="value 3" name="attr_value_3" placeholder="value 3" title="@{value_3}" type="number" value="0"/></label>
 </div>
 </div>
 </div>
@@ -1640,13 +1659,25 @@
 <h2 data-i18n="position"></h2>
 <label data-i18n-title="enter name" title="enter name"><input data-i18n-placeholder="name" name="attr_name" placeholder="name" title="@{name}" type="text" value=""/></label>
 </div>
+<div class="row 2column">
 <div class="row 2autocolumn">
-<h2 data-i18n="weapon"></h2>
+<button class="text-capitalize" data-i18n="weapon" name="roll_weapon-1" type="roll" value="&{template:rolls} {{header=@{weapon_1}}} {{dice=[[{1d20+({@{weapon_value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{weapon_value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{weapon_value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter weapon 1" title="enter weapon 1"><input data-i18n-placeholder="weapon 1" name="attr_weapon_1" placeholder="weapon 1" title="@{weapon_1}" type="text" value=""/></label>
 </div>
+<div class="col 2autocolumn">
+<h2 data-i18n="value"></h2>
+<label data-i18n-title="enter weapon value 1" title="enter weapon value 1"><input data-i18n-placeholder="weapon value 1" name="attr_weapon_value_1" placeholder="w1" title="@{weapon_value_1}" type="number" value="0"/></label>
+</div>
+</div>
+<div class="row 2column">
 <div class="row 2autocolumn">
-<h2 data-i18n="weapon"></h2>
+<button class="text-capitalize" data-i18n="weapon" name="roll_weapon-2" type="roll" value="&{template:rolls} {{header=@{weapon_2}}} {{dice=[[{1d20+({@{weapon_value_2}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{weapon_value_2}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{weapon_value_2}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter weapon 2" title="enter weapon 2"><input data-i18n-placeholder="weapon 2" name="attr_weapon_2" placeholder="weapon 2" title="@{weapon_2}" type="text" value=""/></label>
+</div>
+<div class="col 2autocolumn">
+<h2 data-i18n="value"></h2>
+<label data-i18n-title="enter weapon value 2" title="enter weapon value 2"><input data-i18n-placeholder="weapon value 2" name="attr_weapon_value_2" placeholder="w2" title="@{weapon_value_2}" type="number" value="0"/></label>
+</div>
 </div>
 <div class="row 2column">
 <div class="col 2autocolumn">
@@ -1663,9 +1694,10 @@
 <h2 data-i18n="horse"></h2>
 <label data-i18n-title="enter horse" title="enter horse"><input data-i18n-placeholder="horse" name="attr_horse" placeholder="horse" title="@{horse}" type="text" value=""/></label>
 </div>
-<div class="col 2autocolumn">
-<h2 data-i18n="damage"></h2>
-<label data-i18n-title="enter damage" title="enter damage"><input data-i18n-placeholder="damage" name="attr_damage" placeholder="damage" title="@{damage}" type="text" value=""/></label>
+<div class="row damage">
+<button class="text-capitalize" data-i18n="damage" name="roll_damage" type="roll" value="&{template:rolls} {{header=^{damage}}} {{damage=[[(@{damage}+(?{Mod.|0}))d6]]}}"></button>
+<label data-i18n-title="enter damage" title="enter damage"><input data-i18n-placeholder="damage" name="attr_damage" placeholder="damage" title="@{damage}" type="number" value="0"/></label>
+<span data-i18n="d6"></span>
 </div>
 </div>
 </div>
@@ -1675,13 +1707,13 @@
 <label data-i18n-title="enter cost" title="enter cost"><input data-i18n-placeholder="cost" name="attr_cost" placeholder="cost" title="@{cost}" type="text" value=""/></label>
 </div>
 <div class="row damage">
-<h2 data-i18n="damage"></h2>
-<label data-i18n-title="enter damage 1" title="enter damage 1"><input data-i18n-placeholder="damage 1" name="attr_damage_1" placeholder="damage 1" title="@{damage_1}" type="text" value=""/></label>
+<button class="text-capitalize" data-i18n="damage" name="roll_damage-1" type="roll" value="&{template:rolls} {{header=^{damage}}} {{damage=[[(@{damage_1}+(?{Mod.|0}))d6]]}}"></button>
+<label data-i18n-title="enter damage 1" title="enter damage 1"><input data-i18n-placeholder="damage 1" name="attr_damage_1" placeholder="damage 1" title="@{damage_1}" type="number" value="0"/></label>
 <span data-i18n="d6"></span>
 </div>
 <div class="row damage">
-<h2 data-i18n="damage"></h2>
-<label data-i18n-title="enter damage 2" title="enter damage 2"><input data-i18n-placeholder="damage 2" name="attr_damage_2" placeholder="damage 2" title="@{damage_2}" type="text" value=""/></label>
+<button class="text-capitalize" data-i18n="damage" name="roll_damage-2" type="roll" value="&{template:rolls} {{header=^{damage}}} {{damage=[[(@{damage_2}+(?{Mod.|0}))d6]]}}"></button>
+<label data-i18n-title="enter damage 2" title="enter damage 2"><input data-i18n-placeholder="damage 2" name="attr_damage_2" placeholder="damage 2" title="@{damage_2}" type="number" value="0"/></label>
 <span data-i18n="d6"></span>
 </div>
 <div class="row 2autocolumn">
@@ -1702,17 +1734,35 @@
 <h2 data-i18n="spouse"></h2>
 <label data-i18n-title="enter spouse name" title="enter spouse name"><input data-i18n-placeholder="spouse name" name="attr_spouse_name" placeholder="spouse name" title="@{spouse_name}" type="text" value=""/></label>
 </div>
-<div class="row 2autocolumn">
-<h2 data-i18n="improvable skill"></h2>
+<div class="row col-2">
+<div class="col">
+<div class="col 2autocolumn">
+<button class="text-capitalize" data-i18n="improvable skill" name="roll_spouse-improvable-skill-1" type="roll" value="&{template:rolls} {{header=@{spouse_improvable_skill_1}}} {{dice=[[{1d20+({@{spouse_improvable_skill_value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{spouse_improvable_skill_value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{spouse_improvable_skill_value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter spouse improvable skill 1" title="enter spouse improvable skill 1"><input data-i18n-placeholder="spouse improvable skill 1" name="attr_spouse_improvable_skill_1" placeholder="spouse improvable skill 1" title="@{spouse_improvable_skill_1}" type="text" value=""/></label>
 </div>
-<div class="row 2autocolumn">
-<h2 data-i18n="improvable skill"></h2>
+<div class="col 2autocolumn">
+<button class="text-capitalize" data-i18n="improvable skill" name="roll_spouse-improvable-skill-2" type="roll" value="&{template:rolls} {{header=@{spouse_improvable_skill_2}}} {{dice=[[{1d20+({@{spouse_improvable_skill_value_2}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{spouse_improvable_skill_value_2}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{spouse_improvable_skill_value_2}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter spouse improvable skill 2" title="enter spouse improvable skill 2"><input data-i18n-placeholder="spouse improvable skill 2" name="attr_spouse_improvable_skill_2" placeholder="spouse improvable skill 2" title="@{spouse_improvable_skill_2}" type="text" value=""/></label>
 </div>
-<div class="row 2autocolumn">
-<h2 data-i18n="improvable skill"></h2>
+<div class="col 2autocolumn">
+<button class="text-capitalize" data-i18n="improvable skill" name="roll_spouse-improvable-skill-3" type="roll" value="&{template:rolls} {{header=@{spouse_improvable_skill_3}}} {{dice=[[{1d20+({@{spouse_improvable_skill_value_3}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{spouse_improvable_skill_value_3}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{spouse_improvable_skill_value_3}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter spouse improvable skill 3" title="enter spouse improvable skill 3"><input data-i18n-placeholder="spouse improvable skill 3" name="attr_spouse_improvable_skill_3" placeholder="spouse improvable skill 3" title="@{spouse_improvable_skill_3}" type="text" value=""/></label>
+</div>
+</div>
+<div class="col">
+<div class="row 2autocolumn">
+<h2 data-i18n="value"></h2>
+<label data-i18n-title="enter spouse improvable skill value 1" title="enter spouse improvable skill value 1"><input data-i18n-placeholder="spouse improvable skill value 1" name="attr_spouse_improvable_skill_value_1" placeholder="spouse improvable skill value 1" title="@{spouse_improvable_skill_value_1}" type="number" value="0"/></label>
+</div>
+<div class="row 2autocolumn">
+<h2 data-i18n="value"></h2>
+<label data-i18n-title="enter spouse improvable skill value 2" title="enter spouse improvable skill value 2"><input data-i18n-placeholder="spouse improvable skill value 2" name="attr_spouse_improvable_skill_value_2" placeholder="spouse improvable skill value 2" title="@{spouse_improvable_skill_value_2}" type="number" value="0"/></label>
+</div>
+<div class="row 2autocolumn">
+<h2 data-i18n="value"></h2>
+<label data-i18n-title="enter spouse improvable skill value 3" title="enter spouse improvable skill value 3"><input data-i18n-placeholder="spouse improvable skill value 3" name="attr_spouse_improvable_skill_value_3" placeholder="spouse improvable skill value 3" title="@{spouse_improvable_skill_value_3}" type="number" value="0"/></label>
+</div>
+</div>
 </div>
 <div class="row 2column">
 <div class="col">
@@ -1725,15 +1775,15 @@
 <label data-i18n-title="enter spouse modifier" title="enter spouse modifier"><input data-i18n-placeholder="spouse modifier" name="attr_spouse_modifier" placeholder="spouse modifier" title="@{spouse_modifier}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_spouse-skill-1" type="roll" value="&{template:rolls} {{header=@{spouse_skill_1}}} {{dice=[[{1d20+({@{spouse_value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{spouse_value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{spouse_value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter spouse skill 1" title="enter spouse skill 1"><input data-i18n-placeholder="spouse skill 1" name="attr_spouse_skill_1" placeholder="spouse skill 1" title="@{spouse_skill_1}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_spouse-skill-1" type="roll" value="&{template:rolls} {{header=@{spouse_skill_1}}} {{dice=[[{1d20+({@{spouse_value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{spouse_value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{spouse_value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter spouse skill 2" title="enter spouse skill 2"><input data-i18n-placeholder="spouse skill 2" name="attr_spouse_skill_2" placeholder="spouse skill 2" title="@{spouse_skill_2}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="love (family)"></h2>
+<button class="text-capitalize" data-i18n="love family" name="roll_love-family" type="roll" value="&{template:rolls} {{header=^{love family}}} {{dice=[[{1d20+({@{spouse_value_3}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{spouse_value_3}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{spouse_value_3}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter spouse love" title="enter spouse love"><input data-i18n-placeholder="spouse love" name="attr_spouse_love" placeholder="spouse love" title="@{spouse_love}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
@@ -1747,20 +1797,20 @@
 <label data-i18n-title="enter spouse age" title="enter spouse age"><input data-i18n-placeholder="spouse age" name="attr_spouse_age" placeholder="spouse age" title="@{spouse_age}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="lady skill"></h2>
-<label data-i18n-title="enter spouse lady skill" title="enter spouse lady skill"><input data-i18n-placeholder="spouse lady skill" name="attr_spouse_lady_skill" placeholder="spouse lady skill" title="@{spouse_lady_skill}" type="text" value=""/></label>
+<button class="text-capitalize" data-i18n="lady skill" name="roll_lady-skill" type="roll" value="&{template:rolls} {{header=^{lady skill}}} {{dice=[[{1d20+({@{spouse_lady_skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{spouse_lady_skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{spouse_lady_skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<label data-i18n-title="enter spouse lady skill" title="enter spouse lady skill"><input data-i18n-placeholder="spouse lady skill" name="attr_spouse_lady_skill" placeholder="spouse lady skill" title="@{spouse_lady_skill}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter spouse value 1" title="enter spouse value 1"><input data-i18n-placeholder="spouse value 1" name="attr_spouse_value_1" placeholder="spouse value 1" title="@{spouse_value_1}" type="text" value=""/></label>
+<label data-i18n-title="enter spouse value 1" title="enter spouse value 1"><input data-i18n-placeholder="spouse value 1" name="attr_spouse_value_1" placeholder="spouse value 1" title="@{spouse_value_1}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter spouse value 2" title="enter spouse value 2"><input data-i18n-placeholder="spouse value 2" name="attr_spouse_value_2" placeholder="spouse value 2" title="@{spouse_value_2}" type="text" value=""/></label>
+<label data-i18n-title="enter spouse value 2" title="enter spouse value 2"><input data-i18n-placeholder="spouse value 2" name="attr_spouse_value_2" placeholder="spouse value 2" title="@{spouse_value_2}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter spouse value 3" title="enter spouse value 3"><input data-i18n-placeholder="spouse value 3" name="attr_spouse_value_3" placeholder="spouse value 3" title="@{spouse_value_3}" type="text" value=""/></label>
+<label data-i18n-title="enter spouse value 3" title="enter spouse value 3"><input data-i18n-placeholder="spouse value 3" name="attr_spouse_value_3" placeholder="spouse value 3" title="@{spouse_value_3}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="dower"></h2>
@@ -1773,7 +1823,9 @@
 <h2 data-i18n="number of children"></h2>
 <label data-i18n-title="enter number of children" title="enter number of children"><input data-i18n-placeholder="number of children" name="attr_number_of_children" placeholder="number of children" title="@{number_of_children}" type="text" value=""/></label>
 </div>
-<div class="row woman"><h1 data-i18n="husband"></h1></div>
+<div class="row woman">
+<h1 data-i18n="husband"></h1>
+</div>
 <div class="row husband woman">
 <div class="row 3column">
 <div class="col 2autocolumn">
@@ -1790,47 +1842,49 @@
 </div>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="knight skill"></h2>
-<label data-i18n-title="enter knight skill" title="enter knight skill"><input data-i18n-placeholder="knight skill" name="attr_knight_skill" placeholder="knight skill" title="@{knight_skill}" type="text" value=""/></label>
+<button class="text-capitalize" data-i18n="knight skill" name="roll_knight-skill" type="roll" value="&{template:rolls} {{header=^{knight skill}}} {{dice=[[{1d20+({@{knight_skill}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{knight_skill}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{knight_skill}+(?{Mod.|0}),0}kl1)]]}}"></button>
+<label data-i18n-title="enter knight skill" title="enter knight skill"><input data-i18n-placeholder="knight skill" name="attr_knight_skill" placeholder="knight skill" title="@{knight_skill}" type="number" value=""/></label>
 </div>
 <div class="row col-2">
 <div class="col">
 <div class="row 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_husband-skill-1" type="roll" value="&{template:rolls} {{header=@{husband_skill_1}}} {{dice=[[{1d20+({@{husband_value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{husband_value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{husband_value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter husband skill 1" title="enter husband skill 1"><input data-i18n-placeholder="husband skill 1" name="attr_husband_skill_1" placeholder="husband skill 1" title="@{husband_skill_1}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_husband-skill-2" type="roll" value="&{template:rolls} {{header=@{husband_skill_2}}} {{dice=[[{1d20+({@{husband_value_2}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{husband_value_2}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{husband_value_2}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter husband skill 2" title="enter husband skill 2"><input data-i18n-placeholder="husband skill 2" name="attr_husband_skill_2" placeholder="husband skill 2" title="@{husband_skill_2}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="loyalty lord"></h2>
+<button class="text-capitalize" data-i18n="loyalty lord" name="roll_loyalty-lord" type="roll" value="&{template:rolls} {{header=^{loyalty lord}}} {{dice=[[{1d20+({@{husband_value_3}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{husband_value_3}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{husband_value_3}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter husband loyalty lord" title="enter husband loyalty lord"><input data-i18n-placeholder="husband loyalty lord" name="attr_husband_loyalty_lord" placeholder="husband loyalty lord" title="@{husband_loyalty_lord}" type="text" value=""/></label>
 </div>
 <div class="row 2autocolumn">
-<h2 data-i18n="glory"></h2>
+<button class="text-capitalize" data-i18n="glory" name="roll_glory" type="roll" value="&{template:rolls} {{header=^{glory}}} {{dice=[[{1d20+({@{husband_glory}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{husband_glory}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{husband_glory}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter husband glory" title="enter husband glory"><input data-i18n-placeholder="husband glory" name="attr_husband_glory" placeholder="husband glory" title="@{husband_glory}" type="text" value=""/></label>
 </div>
 </div>
 <div class="col">
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter husband value 1" title="enter husband value 1"><input data-i18n-placeholder="husband value 1" name="attr_husband_value_1" placeholder="husband value 1" title="@{husband_value_1}" type="text" value=""/></label>
+<label data-i18n-title="enter husband value 1" title="enter husband value 1"><input data-i18n-placeholder="husband value 1" name="attr_husband_value_1" placeholder="husband value 1" title="@{husband_value_1}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter husband value 2" title="enter husband value 2"><input data-i18n-placeholder="husband value 2" name="attr_husband_value_2" placeholder="husband value 2" title="@{husband_value_2}" type="text" value=""/></label>
+<label data-i18n-title="enter husband value 2" title="enter husband value 2"><input data-i18n-placeholder="husband value 2" name="attr_husband_value_2" placeholder="husband value 2" title="@{husband_value_2}" type="number" value="0"/></label>
 </div>
 <div class="row 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter husband value 3" title="enter husband value 3"><input data-i18n-placeholder="husband value 3" name="attr_husband_value_3" placeholder="husband value 3" title="@{husband_value_3}" type="text" value=""/></label>
+<label data-i18n-title="enter husband value 3" title="enter husband value 3"><input data-i18n-placeholder="husband value 3" name="attr_husband_value_3" placeholder="husband value 3" title="@{husband_value_3}" type="number" value="0"/></label>
 </div>
 </div>
 </div>
 </div>
 </div>
 <div class="col commoners gold-left-border">
-<div class="row"><h1 data-i18n="entourage"></h1></div>
+<div class="row">
+<h1 data-i18n="entourage"></h1>
+</div>
 <div class="repeating-container">
 <fieldset class="repeating_entourage">
 <div class="row col-2">
@@ -1845,32 +1899,32 @@
 </div>
 <div class="row col-2">
 <div class="col 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_skill-1" type="roll" value="&{template:rolls} {{header=@{skill_1}}} {{dice=[[{1d20+({@{value_1}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_1}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_1}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter skill 1" title="enter skill 1"><input data-i18n-placeholder="skill 1" name="attr_skill_1" placeholder="skill 1" title="@{skill_1}" type="text" value=""/></label>
 </div>
 <div class="col 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 1" title="enter value 1"><input data-i18n-placeholder="value 1" name="attr_value_1" placeholder="value 1" title="@{value_1}" type="text" value=""/></label>
+<label data-i18n-title="enter value 1" title="enter value 1"><input data-i18n-placeholder="value 1" name="attr_value_1" placeholder="value 1" title="@{value_1}" type="number" value="0"/></label>
 </div>
 </div>
 <div class="row col-2">
 <div class="col 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_skill-2" type="roll" value="&{template:rolls} {{header=@{skill_2}}} {{dice=[[{1d20+({@{value_2}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_2}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_2}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter skill 2" title="enter skill 2"><input data-i18n-placeholder="skill 2" name="attr_skill_2" placeholder="skill 2" title="@{skill_2}" type="text" value=""/></label>
 </div>
 <div class="col 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 2" title="enter value 2"><input data-i18n-placeholder="value 2" name="attr_value_2" placeholder="value 2" title="@{value_2}" type="text" value=""/></label>
+<label data-i18n-title="enter value 2" title="enter value 2"><input data-i18n-placeholder="value 2" name="attr_value_2" placeholder="value 2" title="@{value_2}" type="number" value="0"/></label>
 </div>
 </div>
 <div class="row col-2">
 <div class="col 2autocolumn">
-<h2 data-i18n="skill"></h2>
+<button class="text-capitalize" data-i18n="skill" name="roll_skill-3" type="roll" value="&{template:rolls} {{header=@{skill_3}}} {{dice=[[{1d20+({@{value_3}+(?{Mod.|0})-20,0}kh1),1d0+20}kl1 [Roll]]]}} {{threshold=[[{@{value_3}+(?{Mod.|0}),20}kl1[Threshold]]]}} {{fumbleVal=[[20+({@{value_3}+(?{Mod.|0}),0}kl1)]]}}"></button>
 <label data-i18n-title="enter skill 3" title="enter skill 3"><input data-i18n-placeholder="skill 3" name="attr_skill_3" placeholder="skill 3" title="@{skill_3}" type="text" value=""/></label>
 </div>
 <div class="col 2autocolumn">
 <h2 data-i18n="value"></h2>
-<label data-i18n-title="enter value 3" title="enter value 3"><input data-i18n-placeholder="value 3" name="attr_value_3" placeholder="value 3" title="@{value_3}" type="text" value=""/></label>
+<label data-i18n-title="enter value 3" title="enter value 3"><input data-i18n-placeholder="value 3" name="attr_value_3" placeholder="value 3" title="@{value_3}" type="number" value="0"/></label>
 </div>
 </div>
 </fieldset>


### PR DESCRIPTION
The Entourage tab in the character sheet allows players to track members of their entourage (squires, spouse, soldiers, professionals working for them, etc)

That tab as it is now is pretty much useless. No buttons for the skills of the entourage, code is a mess, etc...

Using the Pendragon 5.2 character sheet as a basis, I made some much needed changes to the tab, to make it much more usable & enjoyable for players, without touching the attributes:

-adding buttons for actions, with rolls with modifiers as per the rest of the sheet
-re-arranged columns to make them more easily readable 
-cleaned up the code

All the changes are functional & greatly enhance the use of that tab

**Note :** wanted to create a different pull request from the other one I have waiting, as it is quite a substantial job on the tab, and I want to make it easy to review

**COMPARISON
SQUIRE SECTION NOW**
<img width="314" alt="image" src="https://github.com/Roll20/roll20-character-sheets/assets/72399500/e57268f5-1b3e-40fc-b78a-e383841513ec">

**SQUIRE SECTION WITH CHANGES**
<img width="313" alt="image" src="https://github.com/Roll20/roll20-character-sheets/assets/72399500/da846aeb-fe50-4e52-8b06-56440a4617fd">

