### PR TITLE
[Old Dragon 2e] New Feature: Add attribute and modifier initialization on sheet open

### DIFF
--- a/olddragon2e/olddragon2e.html
+++ b/olddragon2e/olddragon2e.html
@@ -828,6 +828,36 @@
 
 <!-- Old Dragon 2e Script -->
 <script type="text/worker">
+  // Initialize attributes and modifiers
+  on("sheet:opened", () => {
+    const stats = ["forca", "destreza", "constituicao", "sabedoria", "inteligencia", "carisma"];
+    const additionalAttrs = ["jpd_class", "jpd_race", "jpc_class", "jpc_race", "jps_class", "jps_race", "ca_base", "ca_armor", "ca_shield", "ca_magic_weapon", "ba_base"];
+    const attrsToGet = stats.concat(stats.map(stat => `mod_${stat}`)).concat(additionalAttrs);
+  
+    getAttrs(attrsToGet, values => {
+      const initialAttrs = {};
+  
+      stats.forEach(stat => {
+        if (!values[stat]) {
+          initialAttrs[stat] = "10";
+        }
+        if (!values[`mod_${stat}`]) {
+          initialAttrs[`mod_${stat}`] = "+0";
+        }
+      });
+  
+      additionalAttrs.forEach(attr => {
+        if (!values[attr]) {
+          initialAttrs[attr] = "0";
+        }
+      });
+  
+      if (Object.keys(initialAttrs).length > 0) {
+        setAttrs(initialAttrs);
+      }
+    });
+  });
+
   // Calculate modifiers
   const int = score => parseInt(score, 10) || 0;
   const stats = ["forca", "destreza", "constituicao", "sabedoria", "inteligencia", "carisma"];


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] This sheet has been made on behalf of, or by, the game's publisher.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description (EN)

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

From now on, all attributes (Strength, Dexterity, Constitution, Intelligence, Wisdom and Charisma) will start with a value of "10". Consequently, all respective modifiers will have their initial value as "+0".

In addition, the JPD, JPC, JPS, BA and CA fields will also have their initial values ​​as "0".

This way, we prevent the rolls of these values ​​from presenting errors.

# Alterações / Descrição (PT-BR)

A partir de agora todos os atributos (Força, Destreza, Constituição, Inteligência, Sabedoria e Carisma) iniciarão com valor "10". Por consequência, os todos os respectivos modificadores terão seu valor inicial como "+0".

Além disso, os campos JPD, JPC, JPS, BA e CA também terão seus valores iniciais como "0".

Desta forma, evitamos que as rolagens destes valores não apresentem falhas.