### PR TITLE
[Paladin] - adding darkmode support

### DIFF
--- a/Paladin/paladin.css
+++ b/Paladin/paladin.css
@@ -738,8 +738,18 @@ input:focus + .sheet-slider {
   background-color: whitesmoke;
 }
 
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-rolls div.sheet-template-container div.sheet-template-body {
+  color: whitesmoke;
+  background-color: #000;
+}
+
 .sheet-rolltemplate-rolls div.sheet-template-container div.sheet-template-body div.sheet-template-row:nth-child(2n+0) {
   background-color: #fefcea;
+}
+
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-rolls div.sheet-template-container div.sheet-template-body div.sheet-template-row:nth-child(2n+0) {
+  color: #fefcea;
+  background-color: #000;
 }
 
 .sheet-rolltemplate-rolls div.sheet-template-container div.sheet-template-body div.sheet-template-row span.sheet-inlinerollresult {
@@ -759,6 +769,11 @@ input:focus + .sheet-slider {
 .sheet-rolltemplate-rolls div.sheet-template-container div.sheet-template-body div.sheet-template-damage {
   background-color: #fff;
   padding: 3% 2%;
+}
+
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-rolls div.sheet-template-container div.sheet-template-body div.sheet-template-damage {
+  color: #fff;
+  background-color: #000;
 }
 
 .sheet-rolltemplate-rolls div.sheet-template-container div.sheet-template-body div.sheet-template-roll {


### PR DESCRIPTION
Darkmode is not set for this sheet (as it is an old character sheet), and I got requests from some players who would like to be able to use the sheet with darkmode. As it is now, the roll template is unreadable while in darkmode.

This makes the roll template usable & readable:

**Changes to the roll template in darkmode**
![image](https://github.com/Roll20/roll20-character-sheets/assets/72399500/376e83de-df76-44ff-b999-c286a738dce1)
