### PR TITLE
[Star Wars Saga Edition] Skill display fix

### DIFF
--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -373,7 +373,7 @@
 				</div>
 			</div>
 		</div>
-		
+
 		<div class="sheet-col">
 			<table class="spacing" style="margin-top:-1px;">
 				<tr>
@@ -2360,7 +2360,7 @@
 					</fieldset>
 				</div>
 			</div>
-		
+
 			<!-- Attack options, Special actions, Force powers and startship maneuver text fields. -->
 			<div>
 				<input type="checkbox" class="hidden sect-show" name="attr_attack-options-section-show" value="1" checked="false" id="show-attack-options-section-PC" />
@@ -2498,7 +2498,7 @@
 						<!-- Armor base cost, for applying the armors sell/purchase cost. -->
 						<input type="text" name="attr_ArmorCost" value="0" title="Armor Base Cost @{ArmorCost}" />
 						<!-- Total armor cost, is setable since armor could have been upgraded-->
-					
+
 						<input type="text" name="attr_ArmorTotalCost" value="0" title="Armor Total Cost after Upgrades @{ArmorTotalCost}" />
 					</div>
 					<!-- Show/Hide section of armor. -->
@@ -2514,7 +2514,7 @@
 						the upgrade.
 					-->
 				</div>
-				<!-- 
+				<!--
 					Fieldset telling the repeating section how the divs should
 					be created.
 				-->
@@ -2549,7 +2549,7 @@
 						<textarea type="text" class="equipment-note-field" name="attr_EquipmentNotes" title="Item Notes @{repeating_equipment_X_EquipmentNotes}" placeholder="Item Notes"></textarea>
 					</div>
 				</fieldset>
-				<!-- 
+				<!--
 					Equipment repeating fields and the repeating fields
 					control buttons will be automatically added here
 					for the equipment section.
@@ -2638,12 +2638,12 @@
 			</div>
 			<!-- Alternative encumbrance section layout -->
 			<!--<div class="encumbrance-grid2 encumbrance-sect">
-				<!-- First row of grid 
+				<!-- First row of grid
 				<span class="vertical-center grid-title" data-i18n="carried">Carried</span>
 				<span style="grid-column:span 1;"></span>
 				<span class="vertical-center grid-title" data-i18n="capacity">Capacity</span>
 				<span class="vertical-center grid-title" data-i18n="max_lift">Max Lift</span>
-				<!-- Second row of grid 
+				<!-- Second row of grid
 				<input type="text" name="attr_TotalEquipmentWt" value="0" readonly="readonly" title="Total Equipment Weight @{TotalEquipmentWt}" />
 				<span class="center vertical-center" style="grid-column:span 1;">/</span>
 				<input type="number" name="attr_EquipmentCapacity" value="(@{Str}/2)*(@{Str}/2)*@{CarryingCapacitySize}*@{EquipmentLoadMultiplier}" disabled="true" title="Equipment Weight Capacity @{EquipmentCapacity}" />
@@ -2655,7 +2655,7 @@
 					<label for="Encumbrance-load" class="heavy-load">Heavy Load</label>
 				</div>
 				<span class="vertical-center grid-title small" data-i18n="carrying_capacity_multiplier" style="grid-column:5/8">Carrying Capacity Multiplier</span>
-				<!-- Fourth row of grid 
+				<!-- Fourth row of grid
 				<input type="number" class="vertical-center2" style="width: 50px; grid-column: 5/8; margin-left: 50%; transform: translate(-50%);" value="1.0" step="0.25" min="0" name="attr_EquipmentLoadMultiplier" title="Equipment load multiplier, not including size @{EquipmentLoadMultiplier}" />
 			</div>-->
 		</div>
@@ -3321,7 +3321,7 @@
 											<span class="sheet-table-data col1" style="min-width:55px">Damage</span>
 											<span class="sheet-table-data" style="min-width:130px">
 												<input type="text" name="attr_damage" value="2d8" style="width:60px" title="Weapon Damage @{repeating_npc-attack_X_damage}"/>
-												+	
+												+
 												<input type="number" name="attr_DamageTotal" value="@{damage|max}" disabled="true" title="Damage Total @{repeating_npc-attack_X_DamageTotal}" />
 											</span>
 											<span class="sheet-table-data center" style="padding:0px 5px;">|</span>
@@ -5021,7 +5021,7 @@
 		<div class="sheet-col">
 			<div class="textHead" data-i18n="equipment">Equipment</div>
 			<textarea type="text" name="attr_Equipment" style="height:80px" title="Equipment List @{Equipment}"></textarea>
-			
+
 			<input type="checkbox" class="sect-show hidden" value="1" name="attr_droid-Show" />
 			<div class="textHead sect" data-i18n="droid_systems">Droid Systems</div>
 			<textarea type="text" name="attr_DroidSystems" rows="2" class="sect" title="Droid Systems @{DroidSystems}"></textarea>
@@ -5047,7 +5047,7 @@
 		<div class="sheet-col">
 			<div class="textHead" data-i18n="special_qualities">Special Qualities</div>
 				<textarea type="text" name="attr_SpecialQualities" title="Special Qualities @{SpecialQualities}" ></textarea>
-			
+
 			<input type="checkbox" class="forceShow hidden" value="1" name="attr_force-Show" />
 				<div class="textHead forceBody" data-i18n="force_techniques">Force Techniques</div>
 				<textarea type="text" name="attr_ForceTechniques" rows="2" class="forceBody" title="Force Techniques @{ForceTechniques}"></textarea>
@@ -5152,7 +5152,7 @@
 			<textarea type="text" name="attr_Notes" title="Notes @{Notes}"></textarea>
 	</div>
 	<div class="clear"></div>
-	
+
 	<div class="sheet-2colrow">
 		<div class="sheet-col">
 			<div class="textHead2Col">
@@ -5236,7 +5236,7 @@
 	<div class="sheet-col">
 		<div class="textHead" data-i18n="attributes" >Attributes</div>
 		<div class="sheet-table" style="border-spacing: 1px;">
-				
+
 			<div class="sheet-table-row">
 				<div class="sheet-table-data col1"><span data-i18n="str">STR</span><br><div class="small" data-i18n="strength">Strength</div></div>
 				<div class="sheet-table-data"><input type="number" name="attr_vehicle-STR" value="8" title="Strength Score @{vehicle-STR}" /></div>
@@ -5311,7 +5311,7 @@
 			</tr>
 		</table>
 	</div>
-	
+
 	<div class="sheet-col">
 		<table>
 			<tr><td colspan="5"><div class="textHead" data-i18n="threshold">Threshold</div> </td></tr>
@@ -5385,7 +5385,7 @@
 				<tbody>
 					<tr>
 						<td class="col1" rowspan="2" data-i18n="reflex">Reflex</td>
-						<td><input type="number" name="attr_vehicle-Reflex" value="10+@{vehicle-dex|max}+@{vehicle-sizeMod}[Mod]+@{vehicle-RefLevel}+@{vehicle-RefMisc}[Misc]+@{vehicle-CT}" disabled="true" title="Reflex @{vehicle-Reflex}" /></td> 
+						<td><input type="number" name="attr_vehicle-Reflex" value="10+@{vehicle-dex|max}+@{vehicle-sizeMod}[Mod]+@{vehicle-RefLevel}+@{vehicle-RefMisc}[Misc]+@{vehicle-CT}" disabled="true" title="Reflex @{vehicle-Reflex}" /></td>
 						<td>&nbsp;=&nbsp;10&nbsp;+&nbsp;</td>
 						<td><input type="number" name="attr_vehicle-RefMod" value="@{vehicle-dex|max}" disabled="true" title="Vehicle's DEX Modifier @{vehicle-RefMod}" /></td>
 						<td>+</td>
@@ -5447,7 +5447,7 @@
 						<button type="roll" name="roll_vehicle-WeaponCheck" class="other-mod-on" value="&{template:attack} {{name=@{vehicle-WeaponName}}} {{type=@{vehicle-WeaponPosition} in @{character_name}}} {{atkeffect=@{vehicle-WeaponNotes|max}}} {{attack=[[1d20cs>@{WeaponCrit} + @{vehicle-AttackBAB}[BAB] + [[{[[@{vehicle-WeaponPosition|max}*@{vehicle-AttackBAB|max}]]+0d1,0d1}kh1]][Pilot Weapon] + @{vehicle-int|max}[Vehicle Int] + @{vehicle-attackModMisc}[Misc] + @{vehicle-CT}[CT] + ?{Other Modifiers (Attack)|0}[Other]]]}} {{damage=[[(@{vehicle-damage} + @{vehicle-damageMisc}[Misc])*@{vehicle-damage|max}]]}} {{dmgcrit=[[((@{vehicle-damage} + @{vehicle-damageMisc}[Misc])*@{vehicle-damage|max})*@{WeaponCrit|max}]]}}" title="Attack Roll"> </button>
 						<button type="roll" name="roll_vehicle-WeaponCheck" class="other-mod-off" value="&{template:attack} {{name=@{vehicle-WeaponName}}} {{type=@{vehicle-WeaponPosition} in @{character_name}}} {{atkeffect=@{vehicle-WeaponNotes|max}}} {{attack=[[1d20cs>@{WeaponCrit} + @{vehicle-AttackBAB}[BAB] + [[{[[@{vehicle-WeaponPosition|max}*@{vehicle-AttackBAB|max}]]+0d1,0d1}kh1]][Pilot Weapon] + @{vehicle-int|max}[Vehicle Int] + @{vehicle-attackModMisc}[Misc] + @{vehicle-CT}[CT] + 0[Other]]]}} {{damage=[[(@{vehicle-damage} + @{vehicle-damageMisc}[Misc])*@{vehicle-damage|max}]]}} {{dmgcrit=[[((@{vehicle-damage} + @{vehicle-damageMisc}[Misc])*@{vehicle-damage|max})*@{WeaponCrit|max}]]}}" title="Attack Roll"> </button>
 						</td>
-						
+
 					</tr>
 					<tr>
 						<!-- rowspan placholder -->
@@ -5505,10 +5505,10 @@
 				<option value="Passenger">Passenger</option>
 			</select>
 			</span>
-			
+
 			<div class="crew-skills-grid">
 				<!-- First row of grid (headers) -->
-				<input type="checkbox" class="pilotSkillShow hidden" checked value="Pilot" name="attr_vehicle-CrewStation" /> 
+				<input type="checkbox" class="pilotSkillShow hidden" checked value="Pilot" name="attr_vehicle-CrewStation" />
 				<div class="grid-title skillsCrewCol1 vertical-center2" style="text-align:center;">
 					<button type="roll" name="roll_VehicleInitiativeTurn" class="other-mod-on small-roll-button" style="line-height: 8px; font-size: 11px; margin-bottom: 6px;" value="&{template:skill} {{name=Rolling for Turn Order}} {{crewname=@{vehicle-CrewName} in @{character_name}}} {{skill=[[ 1d20+@{vehicle-Initiative}[Initiative]+@{vehicle-CT}[CT]+[[@{vehicle-Initiative}*0.01]][Initiative Decimal]+?{Other Modifiers|0}[Other]&{tracker}]]}}" title="Roll Initiative/Pilot to Turn Order window %{VehicleInitiativeTurn}">Turn Order</button>
 					<button type="roll" name="roll_VehicleInitiativeTurn" class="other-mod-off small-roll-button" style="line-height: 8px; font-size: 11px; margin-bottom: 6px;" value="&{template:skill} {{name=Rolling for Turn Order}} {{crewname=@{vehicle-CrewName} in @{character_name}}} {{skill=[[ 1d20+@{vehicle-Initiative}[Initiative]+@{vehicle-CT}[CT]+[[@{vehicle-Initiative}*0.01]][Initiative Decimal]+0[Other]&{tracker}]]}}" title="Roll Initiative/Pilot to Turn Order window %{VehicleInitiativeTurn}">Turn Order</button>
@@ -5525,7 +5525,7 @@
 						<span data-i18n="deception">Deception</span>
 						<br/>
 						<span class="smallSkills">Create a Diversion</span>
-						<input type="checkbox" class="hidden" value="1" name="attr_Skill-DeceptionDiversion-Show" /> 
+						<input type="checkbox" class="hidden" value="1" name="attr_Skill-DeceptionDiversion-Show" />
 					</label>
 				</div>
 				<div class="pilotBody">
@@ -5535,7 +5535,7 @@
 				<div class="pilotBody">
 					<input type="number" name="attr_vehicle-DeceptionDiversion" value="@{vehicle-sizeMod}[Size]+@{vehicle-dex|max}[Dex]+[[@{vehicle-PilotMod|max}-5]][Untrained Penalty]+@{vehicle-DeceptionDiversionMod}[Deception]+@{vehicle-DeceptionDiversionMisc}[Misc]" disabled="true" title="Deception Total (includes Vehicle Size Mod and Dex Mod, and -5 if not trained in Pilot)" />
 				</div>
-				<div class="pilotBody">=</div> 
+				<div class="pilotBody">=</div>
 				<div class="pilotBody">
 					<input type="checkbox" class="defaultCrew hidden" checked value="CustomCrew" name="attr_CrewQuality" />
 					<input type="number" name="attr_vehicle-DeceptionDiversionMod" value="0" title="Crew Member's Deception Mod" class="defaultCrewLock" />
@@ -5558,7 +5558,7 @@
 						<span data-i18n="deception">Deception</span>
 						<br/>
 						<span class="smallSkills">Deceptive Appearance</span>
-						<input type="checkbox" class="hidden" value="1" name="attr_Skill-DeceptionAppearance-Show" /> 
+						<input type="checkbox" class="hidden" value="1" name="attr_Skill-DeceptionAppearance-Show" />
 					</label>
 				</div>
 				<div class="pilotBody">
@@ -5568,7 +5568,7 @@
 				<div class="pilotBody">
 					<input type="number" name="attr_vehicle-DeceptionAppearance" value="@{vehicle-sizeMod}[Size]+@{vehicle-dex|max}[Dex]+[[@{vehicle-PilotMod|max}-5]][Untrained Penalty]+@{vehicle-DeceptionMod}[Deception]+@{vehicle-DeceptionMisc}[Misc]" readonly title="Deceptive Appearance Total (or Pilot, if that is higher)" />
 				</div>
-				<div class="pilotBody">=</div> 
+				<div class="pilotBody">=</div>
 				<div class="pilotBody">
 					<input type="checkbox" class="defaultCrew hidden" checked value="CustomCrew" name="attr_CrewQuality" />
 					<input type="number" name="attr_vehicle-DeceptionAppearanceMod" value="@{vehicle-DeceptionDiversionMod}[Mod]" readonly title="Crew Member's Deception/Pilot Mod" />
@@ -5723,7 +5723,7 @@
 				<div class="pilotBody">
 					<input type="number" name="attr_vehicle-Stealth" value="@{vehicle-stealthSize}[Size]+@{vehicle-dex|max}[Dex]+[[@{vehicle-PilotMod|max}-5]][Untrained Penalty]+@{vehicle-StealthMod}[Pilot]+@{vehicle-StealthMisc}[Misc]" disabled="true" title="Stealth Total (includes Vehicle Size Mod and Dex Mod, and -5 if not trained in Pilot)" />
 				</div>
-				<div class="pilotBody">=</div> 
+				<div class="pilotBody">=</div>
 				<div class="pilotBody">
 					<input type="checkbox" class="defaultCrew hidden" checked value="CustomCrew" name="attr_CrewQuality" />
 					<input type="number" name="attr_vehicle-StealthMod" value="0" title="Crew Member's Stealth Mod" class="defaultCrewLock"/>
@@ -6012,9 +6012,9 @@
 			</div>
 		</div>
 	</div>
-	<!-- start help section --> 
-	<div> 
-		For help, please see the wiki page. 
+	<!-- start help section -->
+	<div>
+		For help, please see the wiki page.
 		<input type="text" disabled="true" name="wiki_URL" style="width:30em" title="Wiki URL" value="https://wiki.roll20.net/Star_Wars_Saga_Edition_Character_Sheet"/>
 		<button type="roll" class="wiki-url" value="https://wiki.roll20.net/Star_Wars_Saga_Edition_Character_Sheet">Send to chat</button>
 		<br/>
@@ -6035,23 +6035,23 @@
 		<tr><th>{{name}}</th></tr>
 		<tr>{{#type}}<td class="subheader">{{type}}{{/type}}</td></tr>
 		{{#attack}}<tr><td><span class="tcat">Attack: </span>{{attack}}</td></tr>{{/attack}}
-		
+
 		{{#damage}}<tr><td>
-				{{#^rollWasCrit() attack}}		
-					<span class="tcat">Damage: </span>{{damage}}		
+				{{#^rollWasCrit() attack}}
+					<span class="tcat">Damage: </span>{{damage}}
 				{{/^rollWasCrit() attack}}
 				{{#rollWasCrit() attack}}
 					{{^dmgcrit}}	<span class="tcat">Damage: </span>{{damage}}	{{/dmgcrit}}
 					{{#dmgcrit}}	<span class="tcat">Crit Damage: </span>{{dmgcrit}}	{{/dmgcrit}}
-				{{/rollWasCrit() attack}}			
-		</td></tr>{{/damage}}	
-				
+				{{/rollWasCrit() attack}}
+		</td></tr>{{/damage}}
+
 		{{#allprops() header type atkeffect attack damage dmgcrit}}
 			<tr><td><span class="tcat">{{key}} </span>{{value}}</td></tr>
 		{{/allprops() header type atkeffect attack damage dmgcrit}}
-		
+
 		{{#atkeffect}}	<tr><td><span class="tcat">Notes: </span>{{atkeffect}}</td></tr>{{/atkeffect}}
-		
+
 	</table>
 	</div>
 </rolltemplate>
@@ -6076,55 +6076,55 @@
 			<span class="tcat">Init </span>{{init}}; 		<span class="tcat">Senses </span>{{#perception-notes}}{{perception-notes}}; {{/perception-notes}}Perception&nbsp;{{perception}}			<br />
 			{{#language}}	<span class="tcat">Languages </span>{{language}}	{{/language}}
 			<hr />
-			<span class="tcat">Defenses </span>Ref&nbsp;{{ref}}&nbsp;(flat-footed&nbsp;{{flatref}}), Fort&nbsp;{{fort}}{{#will}}, Will&nbsp;{{will}}{{/will}}{{#vehicle-armor}};	+{{vehicle-armor}} Armor	{{/vehicle-armor}}{{#defensenotes}}; {{defensenotes}}{{/defensenotes}}	<br /> 
-			
+			<span class="tcat">Defenses </span>Ref&nbsp;{{ref}}&nbsp;(flat-footed&nbsp;{{flatref}}), Fort&nbsp;{{fort}}{{#will}}, Will&nbsp;{{will}}{{/will}}{{#vehicle-armor}};	+{{vehicle-armor}} Armor	{{/vehicle-armor}}{{#defensenotes}}; {{defensenotes}}{{/defensenotes}}	<br />
+
 			<span class="tcat">HP&nbsp;</span>{{hp}}; <span class="tcat">CT Penalty&nbsp;</span>{{ct}}{{#dr}}; <span class="tcat">DR&nbsp;</span>{{dr}}{{/dr}}{{#sr}}; <span class="tcat">SR&nbsp;</span>{{sr}}{{/sr}}; <span class="tcat">Threshold&nbsp;</span>{{dt}}			<br />
-			
-			{{#immune}}	<span class="tcat">Immune </span>{{immune}}	{{/immune}}			
+
+			{{#immune}}	<span class="tcat">Immune </span>{{immune}}	{{/immune}}
 			<hr />
-			<span class="tcat">Speed </span>{{speed}}			
+			<span class="tcat">Speed </span>{{speed}}
 			{{#fightingspace}}<br /><span class="tcat">Fighting Space </span>{{fightingspace}}	{{/fightingspace}}
 				{{#cover}} <span class="tcat">Cover </span>{{cover}}	{{/cover}}
 			<br />
 			<span class="tcat">Melee by Weapon </span>{{meleeatk}} (dmg {{meleedmg}})			<br />
-			
+
 			<span class="tcat">Ranged by Weapon </span>{{rangedatk}} (dmg {{rangeddmg}})			<br />
-			
+
 			<span class="tcat">Base Atk </span>{{bab}}; 	<span class="tcat">Grp </span>{{grapple}}			<br />
-			
+
 			{{#atkoptions}}	<span class="tcat">Atk Options </span>{{atkoptions}}	<br />{{/atkoptions}}
-			
-			{{#specialactions}}	<span class="tcat">Special Actions </span>{{specialactions}}	<br />{{/specialactions}}		
-			
-			{{#powers}}	<span class="tcat">Force Powers Known </span>(Use the Force +{{utf}}) {{powers}}	<br />{{/powers}}		
-			
-			{{#regimens}}	<span class="tcat">Regimens Known </span>{{regimens}}	<br />{{/regimens}}		
-			
-			{{#techniques}}	<span class="tcat">Force Techniques </span>{{techniques}}	<br />{{/techniques}}	
-			
+
+			{{#specialactions}}	<span class="tcat">Special Actions </span>{{specialactions}}	<br />{{/specialactions}}
+
+			{{#powers}}	<span class="tcat">Force Powers Known </span>(Use the Force +{{utf}}) {{powers}}	<br />{{/powers}}
+
+			{{#regimens}}	<span class="tcat">Regimens Known </span>{{regimens}}	<br />{{/regimens}}
+
+			{{#techniques}}	<span class="tcat">Force Techniques </span>{{techniques}}	<br />{{/techniques}}
+
 			{{#secrets}}	<span class="tcat">Force Secrets </span>{{secrets}}	<br />{{/secrets}}
-			
+
 			{{#maneuvers}}	<span class="tcat">Starship Maneuvers </span>(Pilot +{{pilot}}) {{maneuvers}}	<br />{{/maneuvers}}
 
-			{{#possessions}}	<span class="tcat">Possessions </span> {{possessions}}	<br />{{/possessions}}			
+			{{#possessions}}	<span class="tcat">Possessions </span> {{possessions}}	<br />{{/possessions}}
 			<hr />
 			<span class="tcat">Abilities </span> Str&nbsp;{{str}}, Dex&nbsp;{{dex}}, Con&nbsp;{{con}}, Int&nbsp;{{int}}, Wis&nbsp;{{wis}}, Cha&nbsp;{{cha}}
-			
-			{{#specialqualities}}	<br /><span class="tcat">Special Qualities </span>{{specialqualities}}{{/specialqualities}}		
-			
+
+			{{#specialqualities}}	<br /><span class="tcat">Special Qualities </span>{{specialqualities}}{{/specialqualities}}
+
 			{{#talent}}	<br /><span class="tcat">Talents </span> {{talent}}	{{/talent}}
-			
+
 			{{#feat}}	<br /><span class="tcat">Feats </span> {{feat}}	{{/feat}}
-			
+
 			{{#skills}}	<br /><span class="tcat">Skills </span> {{skills}}	{{/skills}}
-			
+
 			{{#systems}}	<br /><span class="tcat">Systems/Upgrades </span>{{systems}}		{{/systems}}
-			
-			{{#crew}}	<hr /><span class="tcat">Crew </span>{{crew}};	{{/crew}} 	
+
+			{{#crew}}	<hr /><span class="tcat">Crew </span>{{crew}};	{{/crew}}
 				{{#passengers}}<span class="tcat">Passengers </span>{{passengers}};	{{/passengers}}
-			<div>{{#cargo}}	<span class="tcat">Cargo </span>{{cargo}};	{{/cargo}} 	
+			<div>{{#cargo}}	<span class="tcat">Cargo </span>{{cargo}};	{{/cargo}}
 				{{#consumables}}<span class="tcat">Consumables </span>{{consumables}};	{{/consumables}} </div>
-			{{#payload}}	<br /><span class="tcat">Payload </span>{{payload}};	{{/payload}}	
+			{{#payload}}	<br /><span class="tcat">Payload </span>{{payload}};	{{/payload}}
 			{{#hyperdrive}}	<br /><span class="tcat">Hyperdrive </span>{{hyperdrive}};	{{/hyperdrive}}
 			<div>{{#availability}}<span class="tcat">Availability </span>{{availability}};	{{/availability}}
 				{{#cost}}<span class="tcat">Cost </span>{{cost}};	{{/cost}}		</div>
@@ -6141,7 +6141,7 @@
 			<span class="tcat">HP&nbsp;</span>{{hp}}; <span class="tcat">CT Penalty&nbsp;</span>{{ct}}; <span class="tcat">Threshold&nbsp;</span>{{dt}}{{#dr}}; <span class="tcat">DR&nbsp;</span>{{dr}}{{/dr}}{{#sr}}; <span class="tcat">SR&nbsp;</span>{{sr}}{{/sr}}
 			<hr style="margin-top: 2px; margin-bottom: 2px" />
 				{{#force}}<span class="tcat">FP&nbsp;</span>{{force}}&nbsp;({{forcedice}}){{/force}}; {{#secondwindmax}}<span class="tcat">Second&nbsp;Wind</span>&nbsp;{{secondwindcount}}/{{secondwindmax}} for {{hiddensecondwind}} HP{{/secondwindmax}}<br />
-			<span class="tcat">Senses </span>Perception&nbsp;{{perception}}{{#perception-notes}}; {{perception-notes}}{{/perception-notes}}			
+			<span class="tcat">Senses </span>Perception&nbsp;{{perception}}{{#perception-notes}}; {{perception-notes}}{{/perception-notes}}
 			{{#defensenotes}}	<br /> {{defensenotes}}{{/defensenotes}}
 			{{#immune}}	<br /><span class="tcat">Immune </span>{{immune}}{{/immune}}
 		</td></tr>
@@ -6161,35 +6161,35 @@
 				{{#less10}}
 					{{#rollLess() skillcheck 10 }}
 						<tr><td><span class="tcat"><i>{{less10}}</i></span></td></tr>
-					{{/rollLess() skillcheck 10 }}	
-					
+					{{/rollLess() skillcheck 10 }}
+
 					{{#rollBetween() skillcheck 10 14 }}
 						<tr><td><span class="tcat">DC 10 </span>{{10}}</td></tr>
-					{{/rollBetween() skillcheck 10 14 }}				
-				
+					{{/rollBetween() skillcheck 10 14 }}
+
 					{{#rollBetween() skillcheck 15 19 }}
 						<tr><td><span class="tcat">DC 15 </span>{{15}}</td></tr>
-					{{/rollBetween() skillcheck 15 19 }}		
+					{{/rollBetween() skillcheck 15 19 }}
 
 					{{#more20}}
-						{{#rollGreater() skillcheck 19 }}						
+						{{#rollGreater() skillcheck 19 }}
 							<tr><td><span class="tcat">DC 20 </span>{{more20}}</td></tr>
 						{{/rollGreater() skillcheck 19 }}
-					{{/more20}}	
-					
+					{{/more20}}
+
 					{{#more25}}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}					
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollGreater() skillcheck 24 }}
 							<tr><td><span class="tcat">DC 25 </span>{{more25}}</td></tr>
 						{{/rollGreater() skillcheck 24 }}
 					{{/more25}}
-					
+
 					{{#more30}}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}						
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
 						{{/rollBetween() skillcheck 25 29 }}
@@ -6197,11 +6197,11 @@
 							<tr><td><span class="tcat">DC 30 </span>{{more30}}</td></tr>
 						{{/rollGreater() skillcheck 29 }}
 					{{/more30}}
-					
+
 					{{#more35}}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}						
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
 						{{/rollBetween() skillcheck 25 29 }}
@@ -6215,13 +6215,13 @@
 					{{#more40}}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}						
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
-						{{/rollBetween() skillcheck 25 29 }}						
+						{{/rollBetween() skillcheck 25 29 }}
 						{{#rollBetween() skillcheck 30 34 }}
 							<tr><td><span class="tcat">DC 30 </span>{{30}}</td></tr>
-						{{/rollBetween() skillcheck 30 34 }}						
+						{{/rollBetween() skillcheck 30 34 }}
 						{{#rollBetween() skillcheck 35 39 }}
 							<tr><td><span class="tcat">DC 35 </span>{{35}}</td></tr>
 						{{/rollBetween() skillcheck 35 39 }}
@@ -6230,46 +6230,46 @@
 						{{/rollGreater() skillcheck 39 }}
 					{{/more40}}
 				{{/less10}}
-				
+
 				{{#less15}}
 					{{#rollLess() skillcheck 15 }}
 						<tr><td><span class="tcat"><i>{{less15}}</i></span></td></tr>
 					{{/rollLess() skillcheck 15 }}
-					
+
 					{{#more15}}
-						{{#rollGreater() skillcheck 14 }}						
+						{{#rollGreater() skillcheck 14 }}
 							<tr><td><span class="tcat">DC 15 </span>{{more15}}</td></tr>
 						{{/rollGreater() skillcheck 14 }}
-					{{/more15}}	
-					
+					{{/more15}}
+
 					{{#more20}}
 						{{#rollBetween() skillcheck 15 19 }}
 							<tr><td><span class="tcat">DC 15 </span>{{15}}</td></tr>
 						{{/rollBetween() skillcheck 15 19 }}
-						{{#rollGreater() skillcheck 19 }}						
+						{{#rollGreater() skillcheck 19 }}
 							<tr><td><span class="tcat">DC 20 </span>{{more20}}</td></tr>
 						{{/rollGreater() skillcheck 19 }}
-					{{/more20}}	
-					
+					{{/more20}}
+
 					{{#more25}}
 						{{#rollBetween() skillcheck 15 19 }}
 							<tr><td><span class="tcat">DC 15 </span>{{15}}</td></tr>
 						{{/rollBetween() skillcheck 15 19 }}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}					
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollGreater() skillcheck 24 }}
 							<tr><td><span class="tcat">DC 25 </span>{{more25}}</td></tr>
 						{{/rollGreater() skillcheck 24 }}
 					{{/more25}}
-					
+
 					{{#more30}}
 							{{#rollBetween() skillcheck 15 19 }}
 							<tr><td><span class="tcat">DC 15 </span>{{15}}</td></tr>
 						{{/rollBetween() skillcheck 15 19 }}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}						
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
 						{{/rollBetween() skillcheck 25 29 }}
@@ -6277,14 +6277,14 @@
 							<tr><td><span class="tcat">DC 30 </span>{{more30}}</td></tr>
 						{{/rollGreater() skillcheck 29 }}
 					{{/more30}}
-					
+
 					{{#more35}}
 						{{#rollBetween() skillcheck 15 19 }}
 							<tr><td><span class="tcat">DC 15 </span>{{15}}</td></tr>
 						{{/rollBetween() skillcheck 15 19 }}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}						
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
 						{{/rollBetween() skillcheck 25 29 }}
@@ -6301,13 +6301,13 @@
 						{{/rollBetween() skillcheck 15 19 }}
 						{{#rollBetween() skillcheck 20 24 }}
 							<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
-						{{/rollBetween() skillcheck 20 24 }}						
+						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
-						{{/rollBetween() skillcheck 25 29 }}						
+						{{/rollBetween() skillcheck 25 29 }}
 						{{#rollBetween() skillcheck 30 34 }}
 							<tr><td><span class="tcat">DC 30 </span>{{30}}</td></tr>
-						{{/rollBetween() skillcheck 30 34 }}						
+						{{/rollBetween() skillcheck 30 34 }}
 						{{#rollBetween() skillcheck 35 39 }}
 							<tr><td><span class="tcat">DC 35 </span>{{35}}</td></tr>
 						{{/rollBetween() skillcheck 35 39 }}
@@ -6316,19 +6316,19 @@
 						{{/rollGreater() skillcheck 39 }}
 					{{/more40}}
 				{{/less15}}
-				
+
 				{{#less20}}
 					{{#rollLess() skillcheck 20 }}
 						<tr><td><span class="tcat"><i>{{less20}}</i></span></td></tr>
 					{{/rollLess() skillcheck 20 }}
-					
-					{{#more20}}	
+
+					{{#more20}}
 						{{#rollGreater() skillcheck 19 }}
 							<tr><td><span class="tcat">DC 20 </span>{{more20}}</td></tr>
 						{{/rollGreater() skillcheck 19 }}
 					{{/more20}}
-					
-					{{#more25}}	
+
+					{{#more25}}
 						{{#rollBetween() skillcheck 20 24 }}
 						<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
 						{{/rollBetween() skillcheck 20 24 }}
@@ -6336,8 +6336,8 @@
 							<tr><td><span class="tcat">DC 25 </span>{{more25}}</td></tr>
 						{{/rollGreater() skillcheck 24 }}
 					{{/more25}}
-					
-					{{#more30}}		
+
+					{{#more30}}
 						{{#rollBetween() skillcheck 20 24 }}
 						<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
 						{{/rollBetween() skillcheck 20 24 }}
@@ -6348,8 +6348,8 @@
 							<tr><td><span class="tcat">DC 30 </span>{{more30}}</td></tr>
 						{{/rollGreater() skillcheck 29 }}
 					{{/more30}}
-					
-					{{#more35}}	
+
+					{{#more35}}
 						{{#rollBetween() skillcheck 20 24 }}
 						<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
 						{{/rollBetween() skillcheck 20 24 }}
@@ -6363,16 +6363,16 @@
 							<tr><td><span class="tcat">DC 35 </span>{{more35}}</td></tr>
 						{{/rollGreater() skillcheck 34 }}
 					{{/more35}}
-					{{#more40}}		
+					{{#more40}}
 						{{#rollBetween() skillcheck 20 24 }}
 						<tr><td><span class="tcat">DC 20 </span>{{20}}</td></tr>
 						{{/rollBetween() skillcheck 20 24 }}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
-						{{/rollBetween() skillcheck 25 29 }}						
+						{{/rollBetween() skillcheck 25 29 }}
 						{{#rollBetween() skillcheck 30 34 }}
 							<tr><td><span class="tcat">DC 30 </span>{{30}}</td></tr>
-						{{/rollBetween() skillcheck 30 34 }}						
+						{{/rollBetween() skillcheck 30 34 }}
 						{{#rollBetween() skillcheck 35 39 }}
 							<tr><td><span class="tcat">DC 35 </span>{{35}}</td></tr>
 						{{/rollBetween() skillcheck 35 39 }}
@@ -6381,18 +6381,18 @@
 						{{/rollGreater() skillcheck 39 }}
 					{{/more40}}
 				{{/less20}}
-				
+
 				{{#less25}}
 					{{#rollLess() skillcheck 25 }}
 						<tr><td><span class="tcat"><i>{{less25}}</i></span></td></tr>
-					{{/rollLess() skillcheck 25 }}					
-					
-					{{#more25}}	
+					{{/rollLess() skillcheck 25 }}
+
+					{{#more25}}
 						{{#rollGreater() skillcheck 24 }}
 							<tr><td><span class="tcat">DC 25 </span>{{more25}}</td></tr>
 						{{/rollGreater() skillcheck 24 }}
 					{{/more25}}
-					{{#more30}}	
+					{{#more30}}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
 						{{/rollBetween() skillcheck 25 29 }}
@@ -6400,10 +6400,10 @@
 							<tr><td><span class="tcat">DC 30 </span>{{more30}}</td></tr>
 						{{/rollGreater() skillcheck 29 }}
 					{{/more30}}
-					{{#more35}}	
+					{{#more35}}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
-						{{/rollBetween() skillcheck 25 29 }}					
+						{{/rollBetween() skillcheck 25 29 }}
 						{{#rollBetween() skillcheck 30 34 }}
 							<tr><td><span class="tcat">DC 30 </span>{{30}}</td></tr>
 						{{/rollBetween() skillcheck 30 34 }}
@@ -6411,13 +6411,13 @@
 							<tr><td><span class="tcat">DC 35 </span>{{more35}}</td></tr>
 						{{/rollGreater() skillcheck 34 }}
 					{{/more35}}
-					{{#more40}}	
+					{{#more40}}
 						{{#rollBetween() skillcheck 25 29 }}
 							<tr><td><span class="tcat">DC 25 </span>{{25}}</td></tr>
 						{{/rollBetween() skillcheck 25 29 }}
 						{{#rollBetween() skillcheck 30 34 }}
 							<tr><td><span class="tcat">DC 30 </span>{{30}}</td></tr>
-						{{/rollBetween() skillcheck 30 34 }}						
+						{{/rollBetween() skillcheck 30 34 }}
 						{{#rollBetween() skillcheck 35 39 }}
 							<tr><td><span class="tcat">DC 35 </span>{{35}}</td></tr>
 						{{/rollBetween() skillcheck 35 39 }}
@@ -6425,12 +6425,12 @@
 							<tr><td><span class="tcat">DC 40 </span>{{more40}}</td></tr>
 						{{/rollGreater() skillcheck 39 }}
 					{{/more40}}
-				{{/less25}}			
-				
+				{{/less25}}
+
 				{{#less30}}
 					{{#rollLess() skillcheck 30 }}
 						<tr><td><span class="tcat"><i>{{less30}}</i></span></td></tr>
-					{{/rollLess() skillcheck 30 }}						
+					{{/rollLess() skillcheck 30 }}
 					{{#more30}}
 						{{#rollGreater() skillcheck 29 }}
 							<tr><td><span class="tcat">DC 30 </span>{{more30}}</td></tr>
@@ -6444,10 +6444,10 @@
 							<tr><td><span class="tcat">DC 35 </span>{{more35}}</td></tr>
 						{{/rollGreater() skillcheck 34 }}
 					{{/more35}}
-					{{#more40}}						
+					{{#more40}}
 						{{#rollBetween() skillcheck 30 34 }}
 							<tr><td><span class="tcat">DC 30 </span>{{30}}</td></tr>
-						{{/rollBetween() skillcheck 30 34 }}						
+						{{/rollBetween() skillcheck 30 34 }}
 						{{#rollBetween() skillcheck 35 39 }}
 							<tr><td><span class="tcat">DC 35 </span>{{35}}</td></tr>
 						{{/rollBetween() skillcheck 35 39 }}
@@ -6456,26 +6456,26 @@
 						{{/rollGreater() skillcheck 39}}
 					{{/more40}}
 				{{/less30}}
-				
+
 				<!-- This next section of funky DCs is for Force Regimens. Only DCs of published regimens are included. -->
 				{{#less13}}
 					{{#rollLess() skillcheck 13 }}
 						<tr><td><span class="tcat"><i>{{less13}}</i></span></td></tr>
-					{{/rollLess() skillcheck 13 }}						
+					{{/rollLess() skillcheck 13 }}
 					{{#rollBetween() skillcheck 13 17 }}
 							<tr><td><span class="tcat">DC 13 </span>{{13}}</td></tr>
-					{{/rollBetween() skillcheck 13 17 }}	
+					{{/rollBetween() skillcheck 13 17 }}
 					{{#rollBetween() skillcheck 18 22 }}
 						<tr><td><span class="tcat">DC 18 </span>{{18}}</td></tr>
 					{{/rollBetween() skillcheck 18 22 }}
-					
+
 					{{#more23}}
 						{{#rollGreater() skillcheck 22 }}
 							<tr><td><span class="tcat">DC 23 </span>{{more23}}</td></tr>
 						{{/rollGreater() skillcheck 22 }}
 					{{/more23}}
-					
-					{{#more28}}						
+
+					{{#more28}}
 						{{#rollBetween() skillcheck 23 27 }}
 							<tr><td><span class="tcat">DC 23 </span>{{23}}</td></tr>
 						{{/rollBetween() skillcheck 23 27 }}
@@ -6484,14 +6484,14 @@
 						{{/rollGreater() skillcheck 27}}
 					{{/more28}}
 				{{/less13}}
-				
+
 				{{#less18}}
 					{{#rollLess() skillcheck 18 }}
 						<tr><td><span class="tcat"><i>{{less18}}</i></span></td></tr>
-					{{/rollLess() skillcheck 18 }}						
+					{{/rollLess() skillcheck 18 }}
 					{{#rollBetween() skillcheck 18 22 }}
 							<tr><td><span class="tcat">DC 18 </span>{{18}}</td></tr>
-					{{/rollBetween() skillcheck 18 22 }}	
+					{{/rollBetween() skillcheck 18 22 }}
 					{{#rollBetween() skillcheck 23 27 }}
 						<tr><td><span class="tcat">DC 23 </span>{{23}}</td></tr>
 					{{/rollBetween() skillcheck 23 27 }}
@@ -6499,11 +6499,11 @@
 						<tr><td><span class="tcat">DC 28 </span>{{more28}}</td></tr>
 					{{/rollGreater() skillcheck 27}}
 				{{/less18}}
-				
+
 				{{#less23}}
 					{{#rollLess() skillcheck 23 }}
 						<tr><td><span class="tcat"><i>{{less23}}</i></span></td></tr>
-					{{/rollLess() skillcheck 23 }}							
+					{{/rollLess() skillcheck 23 }}
 					{{#rollBetween() skillcheck 23 27 }}
 						<tr><td><span class="tcat">DC 23 </span>{{23}}</td></tr>
 					{{/rollBetween() skillcheck 23 27 }}
@@ -6514,11 +6514,11 @@
 						<tr><td><span class="tcat">DC 33 </span>{{more33}}</td></tr>
 					{{/rollGreater() skillcheck 32}}
 				{{/less23}}
-				
+
 				{{#less26}}
 					{{#rollLess() skillcheck 26 }}
 						<tr><td><span class="tcat"><i>{{less26}}</i></span></td></tr>
-					{{/rollLess() skillcheck 26 }}							
+					{{/rollLess() skillcheck 26 }}
 					{{#rollBetween() skillcheck 26 31 }}
 						<tr><td><span class="tcat">DC 26 </span>{{26}}</td></tr>
 					{{/rollBetween() skillcheck 26 31 }}
@@ -6529,11 +6529,11 @@
 						<tr><td><span class="tcat">DC 38 </span>{{more38}}</td></tr>
 					{{/rollGreater() skillcheck 37}}
 				{{/less26}}
-				
+
 				{{#less31}}
 					{{#rollLess() skillcheck 31 }}
 						<tr><td><span class="tcat"><i>{{less31}}</i></span></td></tr>
-					{{/rollLess() skillcheck 31 }}							
+					{{/rollLess() skillcheck 31 }}
 					{{#rollBetween() skillcheck 31 36 }}
 						<tr><td><span class="tcat">DC 31 </span>{{31}}</td></tr>
 					{{/rollBetween() skillcheck 31 36 }}
@@ -6544,7 +6544,7 @@
 						<tr><td><span class="tcat">DC 43 </span>{{more43}}</td></tr>
 					{{/rollGreater() skillcheck 42}}
 				{{/less31}}
-				
+
 		{{/skillcheck}}
 		{{#allprops() header subheader skillname skillcheck type less10 less15 less20 less25 less30 10 15 20 25 30 35 more20 more25 more30 more35 more40 less13 less18 less23 less26 less31 13 18 23 26 28 31 32 33 37 38 more23 more28 more33 more38 more43}}
 			<tr><td><span class="tcat">{{key}} </span>{{value}}</td></tr>
@@ -6674,7 +6674,7 @@ var TAS = TAS || (function(){
 					return pvalue;
 				}
 			});
-			
+
 			// string value
 			Object.defineProperty(obj.S, pname, {
 				enumerable: true,
@@ -6729,14 +6729,14 @@ var TAS = TAS || (function(){
 
 		}());
 	},
-	
+
 	repeating = function( section ) {
 		return (function(s){
 			var sectionName = s,
 				attrNames = [],
 				fieldNames = [],
 				operations = [],
-			
+
 			repAttrs = function(){
 				attrNames = namesFromArgs(arguments,attrNames);
 				return this;
@@ -6745,7 +6745,7 @@ var TAS = TAS || (function(){
 				fieldNames = namesFromArgs(arguments,fieldNames);
 				return this;
 			},
-			repReduce = function(func, initial, final, context) { 
+			repReduce = function(func, initial, final, context) {
 				operations.push({
 					type: 'reduce',
 					func: (func && _.isFunction(func) && func) || _.noop,
@@ -6852,7 +6852,7 @@ var TAS = TAS || (function(){
 					});
 				});
 			};
-				
+
 			return {
 				attrs: repAttrs,
 				attr: repAttrs,
@@ -6918,8 +6918,8 @@ const repeatingSum = (destinations, section, fields) => {
 				output[destination] = idArray.reduce((total, id) => total + getValue(section, id, fields[index]) * commonMultipliers.reduce((subtotal, mult) => subtotal * getValue(section, id, mult), 1), 0);
 			});
 			setAttrs(output);
-		}); 
-	}); 
+		});
+	});
 };
 // ====== PC /NPC Sheet ====== \\
 on("sheet:opened", function() {
@@ -6952,6 +6952,15 @@ on("sheet:opened", function() {
 		"TreatInjury":"@{TreatInjuryFormula}",
 		"UseComputer": "@{UseComputerFormula}",
 		"UsetheForce": "@{UsetheForceFormula}"
+	});
+	//That update did a similar thing with attribute modifiers, though this wasn't caught until May 2024. It should be fine to remove late in 2024.
+	setAttrs({
+		"str_max":"floor(@{STR}/2-5)",
+		"dex_max":"floor(@{DEX}/2-5)",
+		"con_max":"floor(@{CON}/2-5)",
+		"int_max":"floor(@{INT}/2-5)",
+		"cha_max":"floor(@{WIS}/2-5)",
+		"dex_max":"floor(@{CHA}/2-5)"
 	});
 });
 on("change:level", function() {
@@ -7005,7 +7014,7 @@ on("change:NoConstitution", function() {
 			DTDefense="@{str|max}";
 			fortequation=fortequation.replaceAll(/@{con\|max}/gi,'@{str\|max}');
 			enduranceformula=enduranceformula.replace('@{EnduranceMod}[Mod]','0[No Con]');
-		} 
+		}
 		else {
 			DTDefense="@{con|max}";
 			fortequation=fortequation.replaceAll('@{str\|max}','@{con\|max}');
@@ -7047,7 +7056,7 @@ on("change:NoneNPCSkills",function() {
 		"show-TreatInjury":0,
 		"show-UseComputer":0,
 		"show-UsetheForce":0
-	});	
+	});
 });
 on("change:CrucialNPCSkills",function() {
 	setAttrs({
@@ -7076,7 +7085,7 @@ on("change:CrucialNPCSkills",function() {
 		"show-Swim":0,
 		"show-TreatInjury":0,
 		"show-UseComputer":0
-	});	
+	});
 });
 on("change:StandardNPCSkills",function() {
 	setAttrs({
@@ -7105,7 +7114,7 @@ on("change:StandardNPCSkills",function() {
 		"show-Swim":1,
 		"show-TreatInjury":1,
 		"show-UseComputer":1
-	});	
+	});
 });
 on("clicked:SecondWind", function() {
 	  getAttrs(["hp_max","hp", "Second_Wind", "Second_Wind_Count", "hidden_second_wind"], function(values) {
@@ -7231,7 +7240,7 @@ on('change:QuerySkillModifier change:repeating_npc-skill',()=>{
 on("change:FocusHouseRule", function() {
 	getAttrs(["FocusHouseRule","AcrobaticsFormula","AthleticsFormula","ClimbFormula","DeceptionFormula","EnduranceFormula","GatherInformationFormula","InitiativeFormula","JumpFormula","Knowledge-BureaucracyFormula","Knowledge-GalacticLoreFormula","Knowledge-LifeSciencesFormula","Knowledge-PhysicalScienceFormula","Knowledge-SocialScienceFormula","Knowledge-TacticsFormula","Knowledge-TechnologyFormula","MechanicsFormula","PerceptionFormula","PersuasionFormula","PilotFormula","RideFormula","StealthFormula","SurvivalFormula","SwimFormula","TreatInjuryFormula","UseComputerFormula","UsetheForceFormula"], function(values) {
 		let FHR = values.FocusHouseRule||0;
-		let AcrobaticsFormula = values.AcrobaticsFormula; 
+		let AcrobaticsFormula = values.AcrobaticsFormula;
 		let AthleticsFormula = values.AthleticsFormula;
 		let ClimbFormula = values.ClimbFormula;
 		let DeceptionFormula = values.DeceptionFormula;
@@ -7348,7 +7357,7 @@ on("change:FocusHouseRule", function() {
 on("change:QuerySkillModifier", function() {
 	getAttrs(["QuerySkillModifier","AcrobaticsFormula_max","AthleticsFormula_max","ClimbFormula_max","DeceptionFormula_max","EnduranceFormula_max","GatherInformationFormula_max","InitiativeFormula_max","JumpFormula_max","Knowledge-BureaucracyFormula_max","Knowledge-GalacticLoreFormula_max","Knowledge-LifeSciencesFormula_max","Knowledge-PhysicalScienceFormula_max","Knowledge-SocialScienceFormula_max","Knowledge-TacticsFormula_max","Knowledge-TechnologyFormula_max","MechanicsFormula_max","PerceptionFormula_max","PersuasionFormula_max","PilotFormula_max","RideFormula_max","StealthFormula_max","SurvivalFormula_max","SwimFormula_max","TreatInjuryFormula_max","UseComputerFormula_max","UsetheForceFormula_max"], function(values) {
 		let QSM = values.QuerySkillModifier||0;
-		let AcrobaticsFormula_max = values.AcrobaticsFormula_max; 
+		let AcrobaticsFormula_max = values.AcrobaticsFormula_max;
 		let AthleticsFormula_max = values.AthleticsFormula_max;
 		let ClimbFormula_max = values.ClimbFormula_max;
 		let DeceptionFormula_max = values.DeceptionFormula_max;
@@ -7473,7 +7482,7 @@ on('change:repeating_powers:power-formula', function(eventInfo) {
 		const text = values[changedField];
 
 		const regex = /header=(.*?)}}/;
-		const match = text.match(regex);	
+		const match = text.match(regex);
 		if (match && match[1]) {
 			const extractedValue = match[1].trim();
 			console.log(extractedValue);
@@ -7501,14 +7510,14 @@ on("change:repeating_CrewAssn:CrewQuality",function(){
 
 // When something in inventory is changed...
 on("change:repeating_equipment remove:repeating_equipment",function(){
-	//TAS.repeatingSimpleSum('equipment','equipmentwt','equipmentrunningtotal');	
+	//TAS.repeatingSimpleSum('equipment','equipmentwt','equipmentrunningtotal');
 	TAS.repeating('equipment')
-		.attrs('equipmentwtrunningtotal','equipmentcostrunningtotal', "inventoryrunningsummary")  
-		.fields('equipmentqty','equipmentwt','equipmenttotalwt','equipmentcost','equipmenttotalcost',"equipmentcarry", "equipmentitem", "equipmentnotes") 		
+		.attrs('equipmentwtrunningtotal','equipmentcostrunningtotal', "inventoryrunningsummary")
+		.fields('equipmentqty','equipmentwt','equipmenttotalwt','equipmentcost','equipmenttotalcost',"equipmentcarry", "equipmentitem", "equipmentnotes")
 		.reduce(function(m,r){
 			m.weightTotal=(r.F.equipmentwt*r.I.equipmentqty)
 			m.costTotal=(r.I.equipmentcost*r.I.equipmentqty)
-			if(r.equipmentcarry == 1) {	m.weight+=m.weightTotal;} else {m.weight=m.weight}			
+			if(r.equipmentcarry == 1) {	m.weight+=m.weightTotal;} else {m.weight=m.weight}
 			r.D[1].equipmenttotalwt=m.weightTotal;
 			m.cost+=m.costTotal;
 			r.D[0].equipmenttotalcost=m.costTotal;
@@ -7520,15 +7529,15 @@ on("change:repeating_equipment remove:repeating_equipment",function(){
 			console.log("===== Equipment Running Totals =====" + '\n' +"EquipmentWtRunningTotal = " + m.weight + '\n' +"EquipmentCostRunningTotal = " + m.cost);
 			a.D[1].equipmentwtrunningtotal=m.weight;
 			a.I.equipmentcostrunningtotal=m.cost;
-			
+
 		})
-		.execute(); 
+		.execute();
 });
 
-on("change:equipmentwtrunningtotal change:armorwt change:armorcarry change:size change:str change:EquipmentLoadMultiplier change:NoEncumbranceHouseRule",function() {	
+on("change:equipmentwtrunningtotal change:armorwt change:armorcarry change:size change:str change:EquipmentLoadMultiplier change:NoEncumbranceHouseRule",function() {
 	EncumbranceUpdate();
 });
-on("change:equipmentcostrunningtotal change:armortotalcost",function(){	
+on("change:equipmentcostrunningtotal change:armortotalcost",function(){
 	getAttrs(["EquipmentCostRunningTotal", "ArmorTotalCost"], function(v) {
 		if(v["ArmorTotalCost"]){ArmorCost = parseInt(v["ArmorTotalCost"])} else {ArmorCost = 0}
 		TotalCost = parseInt(v["EquipmentCostRunningTotal"]) + ArmorCost;
@@ -7536,13 +7545,13 @@ on("change:equipmentcostrunningtotal change:armortotalcost",function(){
 		setAttrs({"TotalEquipmentWorth": TotalCost});
 	});
 });
-on("change:inventoryrunningsummary change:ArmorWorn",function(){	
+on("change:inventoryrunningsummary change:ArmorWorn",function(){
 	getAttrs(["inventoryrunningsummary", "ArmorWorn", "ArmorNotes", "ArmorRef", "ArmorFort"], function(v) {
 		armorAttr = " ("+v["ArmorRef"] +" armor, +"+ v["ArmorFort"] +" equipment)"
 		if(v["ArmorWorn"] && v["ArmorNotes"] ) {armorDesc = v["ArmorWorn"] + armorAttr + " ["+ v["ArmorNotes"] +"]"}
 		else if(v["ArmorWorn"]) {armorDesc = v["ArmorWorn"] + armorAttr}
 		else {armorDesc = ""}
-		
+
 		if (v["inventoryrunningsummary"].length > 0 && armorDesc.length > 0) {summary = armorDesc +", " + v["inventoryrunningsummary"]}
 		else if(v["inventoryrunningsummary"].length == 0 && armorDesc.length > 0) {summary = armorDesc}
 		else if(v["inventoryrunningsummary"].length > 0 && armorDesc.length == 0) {summary = v["inventoryrunningsummary"]}
@@ -7555,7 +7564,7 @@ on("change:repeating_organization remove:repeating_organization", function() {
 	console.log("Changing org score");
 	repeatingSum("OrganizationScore","organization","criteria_max");
 });
-on("change:repeating_attack:vehicle-WeaponPosition_max",function() { 
+on("change:repeating_attack:vehicle-WeaponPosition_max",function() {
 	getAttrs(["repeating_attack_vehicle-WeaponPosition_max"], function(values) {
 		switch (values['repeating_attack_vehicle-WeaponPosition_max']) {
 			case "1":
@@ -7578,9 +7587,9 @@ var ArmorPerception = function() {
 	getAttrs(["ArmorWornCheck", "ArmorPerception","ArmorPerception_max", "PerceptionMisc", "ArmorProf"], function(v) {
 		ArmorPerception_max = parseInt(v["ArmorPerception_max"]) || 0;
 		PerceptionMisc = parseInt(v["PerceptionMisc"]) || 0;
-		
-		console.log("ArmorPerception_max = " + ArmorPerception_max + '\n' + 
-				"PerceptionMisc = " + PerceptionMisc);	
+
+		console.log("ArmorPerception_max = " + ArmorPerception_max + '\n' +
+				"PerceptionMisc = " + PerceptionMisc);
 		if(v["ArmorWornCheck"] == "1" && v["ArmorProf"] == "1") {
 			switch (v["ArmorPerception"]) {
 				case "None":
@@ -7591,11 +7600,11 @@ var ArmorPerception = function() {
 					break;
 				case "Superior":
 					perception = 5;
-					break;		
+					break;
 			};
 			if (ArmorPerception_max > perception) {console.log("Old bonus greater than new"); newPerception = PerceptionMisc+ perception - ArmorPerception_max}
 			else if (ArmorPerception_max < perception) {console.log("New bonus greater than old"); newPerception = PerceptionMisc+ perception - ArmorPerception_max}
-			else {console.log("Bonus is the same"); return;}			
+			else {console.log("Bonus is the same"); return;}
 		}
 		else {perception = 0; newPerception = PerceptionMisc+ perception - ArmorPerception_max;};
 		console.log("New Perception = " + newPerception )
@@ -7620,10 +7629,10 @@ var ArmorUpdate = function() {
 				"ImpArmorDefense = " + ImpArmorDefense + '\n' +
 				"ArmorProf = " + ArmorProf + '\n' +
 				"ArmorType = " + ArmorType	); */
-	//Defenses	
+	//Defenses
 	ImpArmorDefenseBonus = level + Math.floor(ArmorRef/ 2)
 	if (ArmorProf == "0") {setAttrs({"ArmorDefense": "0", "ImpArmorDefense": "0" });}
-	
+
 	if(ArmorWornCheck == "1") { //If Armor is being Worn
 		setAttrs({"ArmorCarry": "1"}); // Armor is Carried
 		if(ArmorProf == "1") { //if Proficient
@@ -7643,7 +7652,7 @@ var ArmorUpdate = function() {
 				if (ImpArmorDefenseBonus >= ArmorRef) {armorReflex = "@{level}+floor(@{ArmorRef}/2)"; console.log("== ImpArmorDefense (" + ImpArmorDefenseBonus +") > ArmorRef ("+ ArmorRef +") ==");}
 				else {armorReflex = "@{ArmorRef}"; console.log("== ImpArmorDefense (" + ImpArmorDefense +") < ArmorRef ("+ ArmorRef +") ==");}
 			}
-			else {armorReflex = "@{level}"}		
+			else {armorReflex = "@{level}"}
 		}
 		else {
 			console.log("==== Not Proficient in Armor ====");
@@ -7661,9 +7670,9 @@ var ArmorUpdate = function() {
 				case "Heavy":
 					armorPenalty = "-10";
 					break;
-			};			
+			};
 		}
-	} 
+	}
 	else {
 			console.log("==== Not Wearing Armor ====");
 			armorReflex = "@{level}";
@@ -7677,8 +7686,8 @@ var ArmorUpdate = function() {
 			"RefLevel_max": armorReflex,
 			"FortLevel_max": armorFortitude,
 			"ArmorType_max": armorPenalty
-		});	
-	
+		});
+
 	//Determine which Dex mod to use
 	dexMod = Math.floor((parseInt(v["DEX"],10) - 10) / 2);
 	console.log("==== Dex Mod for Defenses ====");
@@ -7694,7 +7703,7 @@ var ArmorUpdate = function() {
 		setAttrs({"RefMod": "@{dex|max}"});
 	}
 	else{console.log("== NO OPTIONS ==" + '\n' + "dexmod = " +dexMod + '\n' + "ArmorDex = " +v["ArmorDex"] + "\nRefMod = " + v["RefMod"]);}
-	}); //End 
+	}); //End
 };
 
 var SizeUpdate = function() {
@@ -7714,7 +7723,7 @@ var SizeUpdate = function() {
 				RefSize = "-1";		StealthSize = "-5";			DTSize = "5";		CarrySize = "2";		Grapple = "5";
 				break;
 			case "Medium":
-			default:	
+			default:
 				RefSize = "0";		StealthSize = "0"; 			DTSize = "0";		CarrySize = "1";		Grapple = "0";
 				break;
 			case "Small":
@@ -7725,16 +7734,16 @@ var SizeUpdate = function() {
 				break;
 			case "Diminutive":
 				RefSize = "5";		StealthSize = "15";			DTSize = "0";		CarrySize = ".25";		Grapple = "-15";
-				break;		
+				break;
 			case "Fine":
 				RefSize = "10";		StealthSize = "20";			DTSize = "0";		CarrySize = ".01";		Grapple = "-20";
 				break;
 		};
-		
-		console.log("RefSize = " + RefSize   + '\n' + 
-			"StealthSize = " + StealthSize + '\n' + 
-			"DTSize = " + DTSize + '\n' + 
-			"CarrySize = " + CarrySize + '\n' + 
+
+		console.log("RefSize = " + RefSize   + '\n' +
+			"StealthSize = " + StealthSize + '\n' +
+			"DTSize = " + DTSize + '\n' +
+			"CarrySize = " + CarrySize + '\n' +
 			"GrappleSize = " + Grapple);
 		setAttrs({
 			"DamageThresholdSize": DTSize,
@@ -7742,7 +7751,7 @@ var SizeUpdate = function() {
 			"StealthSize": StealthSize,
 			"CarryingCapacitySize": CarrySize,
 			"GrappleSize": Grapple
-		});		
+		});
 	});
 };
 var SecondWindUpdate = function() {
@@ -7768,10 +7777,10 @@ var ForceDieUpdate = function() {
 		// Parse the different character sheet levels.
 		let heroic_level = parseInt(values.level);
 		let nonheroic_level = parseInt(values.nonlevel);
-		
+
 		// Log the initial value.
 		console.log(force_dice);
-		
+
 		// Extract the current die size (e.g d6, d8)
 		force_dice = force_dice.split("d").slice(-1);
 
@@ -7823,10 +7832,10 @@ var EncumbranceUpdate = function() {
 		}
 		TotalWeight = parseFloat(TotalWeight).toFixed(1);
 		console.log("===== Equipment Weight Totals =====" + '\n' +"EquipmentWtRunningTotal = " + v["EquipmentWtRunningTotal"] + '\n' +"TotalWeight = " + TotalWeight + '\n' +"Carry Capacity = " + EquipmentCapacity );
-		
+
 		setAttrs({
 			"TotalEquipmentWt": TotalWeight
-		});	
+		});
 		if(TotalWeight >= EquipmentCapacity) {
 			if(v["NoEncumbranceHouseRule"] == 1) {
 				console.log("Load is Heavy, but penalties not enforced due to No Encumbrance house rule");
@@ -7891,9 +7900,9 @@ var VehicleSizeUpdate = function() {
 				if(v["vehicle-alternateStealth"]=="1") {stealthSize = -1;} else {stealthSize = -5;}
 				break;
 		};
-		
-		console.log("vehicle-sizeMod = " + sizeMod + '\n' + 
-			"vehicle-GrpSize = " + grappleSize + '\n' + 
+
+		console.log("vehicle-sizeMod = " + sizeMod + '\n' +
+			"vehicle-GrpSize = " + grappleSize + '\n' +
 			"vehicle-DTSizeMod = " + dtSize + '\n' +
 			"vehicle-stealthSize = " + stealthSize);
 
@@ -7902,12 +7911,12 @@ var VehicleSizeUpdate = function() {
 			"ehicle-stealthSize": stealthSize,
 			"vehicle-GrpSize": grappleSize,
 			"vehicle-DTSizeMod": dtSize
-		});		
+		});
 	});
 };
 var CrewSet = function() {
 	getAttrs(["repeating_CrewAssn_CrewQuality"], function(v) {
-		if (v["repeating_CrewAssn_CrewQuality"] != "CustomCrew"){	
+		if (v["repeating_CrewAssn_CrewQuality"] != "CustomCrew"){
 			setAttrs({
 				"repeating_CrewAssn_vehicle-DeceptionDiversionMod": v["repeating_CrewAssn_CrewQuality"],
 				"repeating_CrewAssn_vehicle-InitiativeMod": v["repeating_CrewAssn_CrewQuality"],

--- a/Star Wars Saga Edition/StarWarsSagaEdition.html
+++ b/Star Wars Saga Edition/StarWarsSagaEdition.html
@@ -650,20 +650,24 @@
 						</tr>
 						<tr>
 							<th class="small">
-								<br/>Proficiency<br />
+								<br/>
+								<span style="display:inline-flex; margin-bottom: 2px;">Proficiency</span>
+								<br />
 								<input type="checkbox" class="visible-checkbox" value="1" name="attr_ArmorProf" title="Proficient in armor worn @{ArmorProf}" />
 							</th>
 							<th class="small">
-								Armored Defense
+								<span style="display:inline-flex; margin-bottom: 2px;">Armored Defense</span>
 								<br />
 								<input type="checkbox" class="visible-checkbox" value="1" name="attr_ArmorDefense" title="Armor Specialist: Armor Defense @{ArmorDefense}" />
 							</th>
 							<th class="small">
-								Improved Armored Def.
+								<span style="display:inline-flex; margin-bottom: 2px;">Improved Armored Def.</span>
 								<br />
 								<input type="checkbox" class="visible-checkbox" value="1" name="attr_ImpArmorDefense" title="Armor Specialist: Improved Armor Defense @{ImpArmorDefense}" />
 							</th>
-							<th class="small" colspan="2">Armor Type<br/>
+							<th class="small" colspan="2">
+								Armor Type
+								<br/>
 								<select name="attr_ArmorType" style="width:90px" title="Armor Type @{ArmorType}">
 									<option value="Light">Light</option>
 									<option value="Medium">Medium</option>
@@ -2379,13 +2383,13 @@
 					<div class="powers-flex-container">
 						<div>
 							<label class="clickable">
-								<input type="radio" value="1" name="attr_force-power-style" class="visible-checkbox" style="vertical-align: text-bottom;">
+								<input type="checkbox" value="1" name="attr_force-power-style" class="visible-checkbox" style="vertical-align: text-bottom;">
 								<span>Individual Powers</span>
 							</label>
 						</div>
 						<div>
 							<label class="clickable">
-								<input type="radio" value="0" name="attr_force-power-style" checked class="visible-checkbox" style="vertical-align: text-bottom;">
+								<input type="checkbox" value="0" name="attr_force-power-style" checked class="visible-checkbox" style="vertical-align: text-bottom;">
 								<span>Force Power Suite</span>
 							</label>
 						</div>
@@ -4937,12 +4941,67 @@
 			</div>
 			<input type="checkbox" class="forceShow hidden" value="1" name="attr_force-Show" />
 			<div class="forceBody">
-				<input type="checkbox" class="hidden sect-show" name="attr_force-powers-section-show" value="1" checked="false" id="show-force-powers-section-NPC" />
-				<label for="show-force-powers-section-NPC" class="textHead2Col clickable" title="Show/Hide Force Powers Section">
+				<input type="checkbox" class="hidden sect-show" name="attr_force-powers-section-show" value="1" checked="false" id="show-force-powers-section-PC" />
+				<label for="show-force-powers-section-PC" class="textHead2Col clickable" title="Show/Hide Force Powers Section">
 					<span data-i18n="force_powers" >Force Powers</span>
 					<button type="roll" name="roll_UsetheForceCheck" class="small-roll-button" value="@{UsetheForceFormula|max}" title="Roll Use the Force %{UsetheForceCheck}">Use the Force</button>
 				</label>
-				<textarea type="text" name="attr_ForcePowers" rows="2" class="ActionNotes sect" title="Force Power Suite @{ForcePowers}"></textarea>
+				<div class="sect">
+					<div class="powers-flex-container">
+						<div>
+							<label class="clickable">
+								<input type="checkbox" value="1" name="attr_force-power-style" class="visible-checkbox" style="vertical-align: text-bottom;">
+								<span>Individual Powers</span>
+							</label>
+						</div>
+						<div>
+							<label class="clickable">
+								<input type="checkbox" value="0" name="attr_force-power-style" checked class="visible-checkbox" style="vertical-align: text-bottom;">
+								<span>Force Power Suite</span>
+							</label>
+						</div>
+					</div>
+					<input type="checkbox" value="1" name="attr_force-power-style" id="individual-powers" class="hidden">
+					<input type="checkbox" value="0" name="attr_force-power-style" id="power-suite" class="hidden">
+					<textarea type="text" name="attr_ForcePowers" rows="2" class="ActionNotes sect" title="Force Power Suite @{ForcePowers}"></textarea>
+					<fieldset class="repeating_powers">
+						<div class="powers-grid">
+							<!-- First row of grid -->
+							<button type="roll" name="roll_PowerCheck" value="@{power-formula}" title="Use Power"></button>
+							<input type="text" name="attr_power-name" placeholder="Name" title="Name of Force Power" />
+							<input type="number" name="attr_power-uses" value="1" title="Number of uses left" />
+							<span class="center vertical-center">/</span>
+							<input type="number" name="attr_power-uses_max" value="1" title="Number of uses total" />
+							<!-- Second row of grid -->
+							<div class="powers-flex-container powers-notes-title">
+								<span>
+									<span>Notes</span>
+									<label class="toggle-bar" title="Show/Hide Power Notes">
+										<input type="checkbox" name="attr_power-notes-show" value="1">
+										<span class="toggle-knob"></span>
+									</label>
+								</span>
+								<span>
+									<span>Template Formula</span>
+									<label class="toggle-bar" title="Show/Hide Power Template Formula">
+										<input type="checkbox" name="attr_power-formula-show" value="1">
+										<span class="toggle-knob"></span>
+									</label>
+								</span>
+							</div>
+							<!-- Third row of grid -->
+							<div style="grid-column:2/7;">
+								<input type="checkbox" class="sect-show hidden" value="1" name="attr_power-notes-show">
+								<input type="text" class="sect" placeholder="Power notes" title="Force power notes" name="attr_power-notes" style="width:100%;">
+							</div>
+							<!-- Fourth row of grid -->
+							<div style="grid-column:2/7;">
+								<input type="checkbox" class="sect-show hidden" value="1" name="attr_power-formula-show">
+								<textarea class="sect" name="attr_power-formula" placeholder="Power formula" style="width:100%; resize:vertical; box-sizing: border-box;" title="See the Settings tab for a link to the wiki, where you can find another link to a document containing macros">&{template:sagadefault} {{header=[Name]}} {{subheader=[Description]}} {{Time:=[Time]]}} {{Target:=[Target]}} {{skillname=Use the Force}} {{skillcheck=[[1d20+@{UsetheForceformula}+?{Other Modifiers|0}[Other]]]}} {{less15=Nothing happens!}} {{15=...}} {{20=...}}{{more25=...}} {{?{Force Point to ...|No, **No Force Point Used**|Yes, **Force Point Used:**=...} }}</textarea>
+							</div>
+						</div>
+					</fieldset>
+				</div>
 			</div>
 			<div>
 				<input type="checkbox" class="sect-show hidden" value="1" name="attr_StarshipManeuvers-Show" />
@@ -6902,6 +6961,7 @@ on("change:level", function() {
 });
 on("change:nonlevel", function() {
 	ForceDieUpdate();
+	SkillUpdate();
 });
 on("change:size", function() {
 	SizeUpdate();
@@ -6909,12 +6969,12 @@ on("change:size", function() {
 
 on("change:dex", function() {
 	ArmorUpdate();
-	//SkillUpdate();
+	SkillUpdate();
 });
-// Not exactly sure why this doesn't work for attributes like it does for the level. The console log indicates success...
 on("change:str change:con change:int change:wis change:cha", function() {
 	SkillUpdate();
 });
+
 //Changes to Armor
 on("change:armorworncheck change:armorprof", function() {
 	ArmorUpdate();
@@ -7739,62 +7799,13 @@ var ForceDieUpdate = function() {
 	});
 }
 var SkillUpdate = function() {
-	getAttrs(["AcrobaticsFormula","AthleticsFormula","ClimbFormula","DeceptionFormula","EnduranceFormula","GatherInformationFormula","InitiativeFormula","JumpFormula","Knowledge-BureaucracyFormula","Knowledge-GalacticLoreFormula","Knowledge-LifeSciencesFormula","Knowledge-PhysicalScienceFormula","Knowledge-SocialScienceFormula","Knowledge-TacticsFormula","Knowledge-TechnologyFormula","MechanicsFormula","PerceptionFormula","PersuasionFormula","PilotFormula","RideFormula","StealthFormula","SurvivalFormula","SwimFormula","TreatInjuryFormula","UseComputerFormula","UsetheForceFormula"], function(values) {
-	let AcrobaticsFormula = values.AcrobaticsFormula;
-	let AthleticsFormula = values.AthleticsFormula;
-	let ClimbFormula = values.ClimbFormula;
-	let DeceptionFormula = values.DeceptionFormula;
-	let EnduranceFormula = values.EnduranceFormula;
-	let GatherInformationFormula = values.GatherInformationFormula;
-	let InitiativeFormula = values.InitiativeFormula;
-	let JumpFormula = values.JumpFormula;
-	let BureaucracyFormula = values['Knowledge-BureaucracyFormula'];
-	let GalacticLoreFormula = values['Knowledge-GalacticLoreFormula'];
-	let LifeSciencesFormula = values['Knowledge-LifeSciencesFormula'];
-	let PhysicalScienceFormula = values['Knowledge-PhysicalScienceFormula'];
-	let SocialScienceFormula = values['Knowledge-SocialScienceFormula'];
-	let TacticsFormula = values['Knowledge-TacticsFormula'];
-	let TechnologyFormula = values['Knowledge-TechnologyFormula'];
-	let MechanicsFormula = values.MechanicsFormula;
-	let PerceptionFormula = values.PerceptionFormula;
-	let PersuasionFormula = values.PersuasionFormula;
-	let PilotFormula = values.PilotFormula;
-	let RideFormula = values.RideFormula;
-	let StealthFormula = values.StealthFormula;
-	let SurvivalFormula = values.SurvivalFormula;
-	let SwimFormula = values.SwimFormula;
-	let TreatInjuryFormula = values.TreatInjuryFormula;
-	let UseComputerFormula = values.UseComputerFormula;
-	let UsetheForceFormula = values.UsetheForceFormula;
-	/*setAttrs({"AcrobaticsFormula": 0});*/
-	setAttrs({
-			"AcrobaticsFormula": AcrobaticsFormula,
-			"AthleticsFormula": AthleticsFormula,
-			"ClimbFormula": ClimbFormula,
-			"DeceptionFormula": DeceptionFormula,
-			"EnduranceFormula": EnduranceFormula,
-			"GatherInformationFormula": GatherInformationFormula,
-			"InitiativeFormula": InitiativeFormula,
-			"JumpFormula": JumpFormula,
-			"Knowledge-BureaucracyFormula": BureaucracyFormula,
-			"Knowledge-GalacticLoreFormula": GalacticLoreFormula,
-			"Knowledge-LifeSciencesFormula": LifeSciencesFormula,
-			"Knowledge-PhysicalScienceFormula": PhysicalScienceFormula,
-			"Knowledge-SocialScienceFormula": SocialScienceFormula,
-			"Knowledge-TacticsFormula": TacticsFormula,
-			"Knowledge-TechnologyFormula": TechnologyFormula,
-			"MechanicsFormula": MechanicsFormula,
-			"PerceptionFormula": PerceptionFormula,
-			"PersuasionFormula": PersuasionFormula,
-			"PilotFormula": PilotFormula,
-			"RideFormula": RideFormula,
-			"StealthFormula": StealthFormula,
-			"SurvivalFormula": SurvivalFormula,
-			"SwimFormula": SwimFormula,
-			"TreatInjuryFormula": TreatInjuryFormula,
-			"UseComputerFormula": UseComputerFormula,
-			"UsetheForceFormula": UsetheForceFormula
-			// Sets the formulas to what they already were.
+	getAttrs(["CT"], function(values) {
+		let storedCT = values.CT;
+		setAttrs({
+			"CT": 1
+		});
+		setAttrs({
+			"CT": storedCT
 		});
 	});
 	console.log("Updated skill modifiers");


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

I hate this update. It's so stupid that a bug which has been on the sheet since the beginning can be fixed with something as stupid as changing an attribute and then changing it right back.
Anyway, the skill values on the sheet update properly when attributes or level changes now. 

Also added the repeatable Force Powers section to the NPC sheet.

Also added a fix for a bug introduced in December 2023 where the attributes were manually calculated with sheetworkers, causing them to be forever stuck that way.
