### PR TITLE
[MetalAdventure][New Feature] Additional skills to add them when asked from books

### DIFF
--- a/Metal Adventures/MetalAdventures.html
+++ b/Metal Adventures/MetalAdventures.html
@@ -330,6 +330,24 @@
 						<input type="number" name="attr_Technologie_max" readonly>
 					</div>
 				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Agilite_Additional_01Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Agilite_Additional_01">
+						<input type="number" name="attr_Agilite_Additional_01_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Agilite_Additional_02_Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Agilite_Additional_02">
+						<input type="number" name="attr_Agilite_Additional_02_max" readonly>
+					</div>
+				</div>
 			</div>
 			<!-- Carrure -->
 			<div class="flex-grow1">
@@ -414,6 +432,24 @@
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Environement3">
 						<input type="number" name="attr_Environement3_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Carrure_Additional_01Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Carrure_Additional_01">
+						<input type="number" name="attr_Carrure_Additional_01_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Carrure_Additional_02_Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Carrure_Additional_02">
+						<input type="number" name="attr_Carrure_Additional_02_max" readonly>
 					</div>
 				</div>
 			</div>
@@ -506,6 +542,24 @@
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Vigilance">
 						<input type="number" name="attr_Vigilance_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Perception_Additional_01Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Perception_Additional_01">
+						<input type="number" name="attr_Perception_Additional_01_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Perception_Additional_02_Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Perception_Additional_02">
+						<input type="number" name="attr_Perception_Additional_02_max" readonly>
 					</div>
 				</div>
 			</div>
@@ -653,6 +707,24 @@
 						<input type="number" name="attr_Stategie_max" readonly>
 					</div>
 				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Intelligence_Additional_01Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Intelligence_Additional_01">
+						<input type="number" name="attr_Intelligence_Additional_01_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Intelligence_Additional_02_Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Intelligence_Additional_02">
+						<input type="number" name="attr_Intelligence_Additional_02_max" readonly>
+					</div>
+				</div>
 			</div>
 
 			<div class="flex-grow1">
@@ -756,6 +828,24 @@
 						<input type="number" name="attr_Seduction_max" readonly>
 					</div>
 				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Presence_Additional_01Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Presence_Additional_01">
+						<input type="number" name="attr_Presence_Additional_01_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_Presence_Additional_02_Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_Presence_Additional_02">
+						<input type="number" name="attr_Presence_Additional_02_max" readonly>
+					</div>
+				</div>
 			</div>
 
 			<div class="flex-grow1">
@@ -847,6 +937,24 @@
 					<div class="flex-grow1 flex-right">
 						<input type="number" name="attr_Tactique">
 						<input type="number" name="attr_Tactique_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_SangFroid_Additional_01Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_SangFroid_Additional_01">
+						<input type="number" name="attr_SangFroid_Additional_01_max" readonly>
+					</div>
+				</div>
+				<div class="row">
+					<div class="flex-grow1">
+						<span><input type="text" name="attr_SangFroid_Additional_02_Label"></span>
+					</div>
+					<div class="flex-grow1 flex-right">
+						<input type="number" name="attr_SangFroid_Additional_02">
+						<input type="number" name="attr_SangFroid_Additional_02_max" readonly>
 					</div>
 				</div>
 
@@ -1122,8 +1230,8 @@ on('sheet:opened',function(){
 });
 
 <!---------------------------------------  PJ  -------------------------------------------------------->
-on("change:Technique change:Acrobatie change:ArmesDePoing change:ArmesDEpaule change:ArmesEmbarquee change:Artisanat change:Pilotage1 change:Pilotage2 change:Technologie", function() {
-    getAttrs(["Technique", "Acrobatie", "ArmesDePoing", "ArmesDEpaule", "ArmesEmbarquee", "Artisanat", "Pilotage1", "Pilotage2", "Technologie"], function(v) {
+on("change:Technique change:Acrobatie change:ArmesDePoing change:ArmesDEpaule change:ArmesEmbarquee change:Artisanat change:Pilotage1 change:Pilotage2 change:Technologie change:Agilite_Additional_01 change:Agilite_Additional_02", function() {
+    getAttrs(["Technique", "Acrobatie", "ArmesDePoing", "ArmesDEpaule", "ArmesEmbarquee", "Artisanat", "Pilotage1", "Pilotage2", "Technologie", "Agilite_Additional_01", "Agilite_Additional_02"], function(v) {
        setAttrs({
 			Acrobatie_max: +v.Technique + +v.Acrobatie,
 			ArmesDePoing_max: +v.Technique + +v.ArmesDePoing,
@@ -1132,13 +1240,15 @@ on("change:Technique change:Acrobatie change:ArmesDePoing change:ArmesDEpaule ch
 			Artisanat_max: +v.Technique + +v.Artisanat,
 			Pilotage1_max: +v.Pilotage1>0?+v.Technique + +v.Pilotage1:0,
 			Pilotage2_max: +v.Pilotage2>0?+v.Technique + +v.Pilotage2:0,
-			Technologie_max: +v.Technique + +v.Technologie
+			Technologie_max: +v.Technique + +v.Technologie,
+			Agilite_Additional_01_max: +v.Agilite_Additional_01>0?+v.Technique + +v.Agilite_Additional_01:0,
+			Agilite_Additional_02_max: +v.Agilite_Additional_02>0?+v.Technique + +v.Agilite_Additional_02:0
 		});
    });
 });
 
-on("change:Survie change:ArmesdeJet change:ArmesLourdes change:Athletisme change:Equitation change:Melee change:Environement1 change:Environement2 change:Environement3", function() {
-    getAttrs(["Survie", "ArmesdeJet", "ArmesLourdes", "Athletisme", "Equitation", "Melee", "Environement1", "Environement2", "Environement3"], function(v) {
+on("change:Survie change:ArmesdeJet change:ArmesLourdes change:Athletisme change:Equitation change:Melee change:Environement1 change:Environement2 change:Environement3 change:Carrure_Additional_01 change:Carrure_Additional_02", function() {
+    getAttrs(["Survie", "ArmesdeJet", "ArmesLourdes", "Athletisme", "Equitation", "Melee", "Environement1", "Environement2", "Environement3", "Carrure_Additional_01", "Carrure_Additional_02"], function(v) {
        setAttrs({
 			ArmesdeJet_max: +v.Survie + +v.ArmesdeJet,
 			ArmesLourdes_max: +v.ArmesLourdes > 0 ? +v.Survie + +v.ArmesLourdes:0,
@@ -1148,12 +1258,14 @@ on("change:Survie change:ArmesdeJet change:ArmesLourdes change:Athletisme change
 			Environement1_max: +v.Survie + +v.Environement1,
 			Environement2_max: +v.Survie + +v.Environement2,
 			Environement3_max: +v.Survie + +v.Environement3,
+			Carrure_Additional_01_max: +v.Carrure_Additional_01>0?+v.Survie + +v.Carrure_Additional_01:0,
+			Carrure_Additional_02_max: +v.Carrure_Additional_02>0?+v.Survie + +v.Carrure_Additional_02:0
 		});
    });
 });
 
-on("change:Espionnage change:Deguisement change:Discretion change:Empathie change:Falsification change:Recherche change:Senseurs change:SysSecu change:Vigilance", function() {
-    getAttrs(["Espionnage", "Deguisement", "Discretion", "Empathie", "Falsification", "Recherche", "Senseurs", "SysSecu", "Vigilance"], function(v) {
+on("change:Espionnage change:Deguisement change:Discretion change:Empathie change:Falsification change:Recherche change:Senseurs change:SysSecu change:Vigilance change:Perception_Additional_01 change:Perception_Additional_02", function() {
+    getAttrs(["Espionnage", "Deguisement", "Discretion", "Empathie", "Falsification", "Recherche", "Senseurs", "SysSecu", "Vigilance", "Perception_Additional_01", "Perception_Additional_02"], function(v) {
        setAttrs({
 			Deguisement_max: +v.Espionnage + +v.Deguisement,
 			Discretion_max: +v.Espionnage + +v.Discretion,
@@ -1163,12 +1275,14 @@ on("change:Espionnage change:Deguisement change:Discretion change:Empathie chang
 			Senseurs_max: +v.Senseurs > 0 ? +v.Espionnage + +v.Senseurs:0,
 			SysSecu_max: +v.SysSecu > 0 ? +v.Espionnage + +v.SysSecu:0,
 			Vigilance_max: +v.Espionnage + +v.Vigilance,
+			Perception_Additional_01_max: +v.Perception_Additional_01>0?+v.Espionnage + +v.Perception_Additional_01:0,
+			Perception_Additional_02_max: +v.Perception_Additional_02>0?+v.Espionnage + +v.Perception_Additional_02:0
 		});
    });
 });
 
-on("change:Science change:Analyse change:Art change:Connaissance1 change:Connaissance2 change:Connaissance3 change:Esoterisme change:Histoire change:Ingenierie change:Medecine change:Navigation change:SciencesSolaires change:SciencesStellaires change:Stategie", function() {
-    getAttrs(["Science", "Analyse", "Art", "Connaissance1", "Connaissance2", "Connaissance3", "Esoterisme", "Histoire", "Ingenierie", "Medecine", "Navigation", "SciencesSolaires", "SciencesStellaires", "Stategie"], function(v) {
+on("change:Science change:Analyse change:Art change:Connaissance1 change:Connaissance2 change:Connaissance3 change:Esoterisme change:Histoire change:Ingenierie change:Medecine change:Navigation change:SciencesSolaires change:SciencesStellaires change:Stategie change:Intelligence_Additional_01 change:Intelligence_Additional_02", function() {
+    getAttrs(["Science", "Analyse", "Art", "Connaissance1", "Connaissance2", "Connaissance3", "Esoterisme", "Histoire", "Ingenierie", "Medecine", "Navigation", "SciencesSolaires", "SciencesStellaires", "Stategie", "Intelligence_Additional_01", "Intelligence_Additional_02"], function(v) {
        setAttrs({
 			Analyse_max: +v.Science + +v.Analyse,
 			Art_max: +v.Science + +v.Art,
@@ -1183,12 +1297,14 @@ on("change:Science change:Analyse change:Art change:Connaissance1 change:Connais
 			SciencesSolaires_max: +v.SciencesSolaires > 0 ? +v.Science + +v.SciencesSolaires:0,
 			SciencesStellaires_max: +v.SciencesStellaires > 0 ? +v.Science + +v.SciencesStellaires:0,
 			Stategie_max: +v.Stategie > 0 ? +v.Science + +v.Stategie:0,
+			Intelligence_Additional_01_max: +v.Intelligence_Additional_01>0?+v.Science + +v.Intelligence_Additional_01:0,
+			Intelligence_Additional_02_max: +v.Intelligence_Additional_02>0?+v.Science + +v.Intelligence_Additional_02:0
 		});
    });
 });
 
-on("change:Negociation change:Baration change:Bureaucratie change:Comedie change:Commerce change:Danse change:Eloquence change:Etiquette change:Jeux change:Seduction", function() {
-    getAttrs(["Negociation", "Baration", "Bureaucratie", "Comedie", "Commerce", "Danse", "Eloquence", "Etiquette", "Jeux", "Seduction"], function(v) {
+on("change:Negociation change:Baration change:Bureaucratie change:Comedie change:Commerce change:Danse change:Eloquence change:Etiquette change:Jeux change:Seduction change:Presence_Additional_01 change:Presence_Additional_02", function() {
+    getAttrs(["Negociation", "Baration", "Bureaucratie", "Comedie", "Commerce", "Danse", "Eloquence", "Etiquette", "Jeux", "Seduction", "Presence_Additional_01", "Presence_Additional_02"], function(v) {
        setAttrs({
 			Baration_max: +v.Negociation + +v.Baration,
 			Bureaucratie_max: +v.Negociation + +v.Bureaucratie,
@@ -1199,12 +1315,14 @@ on("change:Negociation change:Baration change:Bureaucratie change:Comedie change
 			Etiquette_max: +v.Negociation + +v.Etiquette,
 			Jeux_max: +v.Negociation + +v.Jeux,
 			Seduction_max: +v.Negociation + +v.Seduction,
+			Presence_Additional_01_max: +v.Presence_Additional_01>0?+v.Negociation + +v.Presence_Additional_01:0,
+			Presence_Additional_02_max: +v.Presence_Additional_02>0?+v.Negociation + +v.Presence_Additional_02:0
 		});
    });
 });
 
-on("change:Trempe change:Commandement change:Demolition change:Determination change:Dressage change:Illegalites change:Intimidation change:Premierssoins change:Tactique change:Jeux change:Seduction", function() {
-    getAttrs(["Trempe", "Commandement", "Demolition", "Determination", "Dressage", "Illegalites", "Intimidation", "Premierssoins", "Tactique", "Jeux", "Seduction"], function(v) {
+on("change:Trempe change:Commandement change:Demolition change:Determination change:Dressage change:Illegalites change:Intimidation change:Premierssoins change:Tactique change:SangFroid_Additional_01 change:SangFroid_Additional_02", function() {
+    getAttrs(["Trempe", "Commandement", "Demolition", "Determination", "Dressage", "Illegalites", "Intimidation", "Premierssoins", "Tactique", "SangFroid_Additional_01", "SangFroid_Additional_02"], function(v) {
        setAttrs({
 			Commandement_max: +v.Trempe + +v.Commandement,
 			Demolition_max: +v.Demolition > 0 ? +v.Trempe + +v.Demolition:0,
@@ -1214,6 +1332,8 @@ on("change:Trempe change:Commandement change:Demolition change:Determination cha
 			Intimidation_max: +v.Trempe + +v.Intimidation,
 			Premierssoins_max: +v.Trempe + +v.Premierssoins,
 			Tactique_max: +v.Trempe + +v.Tactique,
+			SangFroid_Additional_01_max: +v.SangFroid_Additional_01>0?+v.Trempe + +v.SangFroid_Additional_01:0,
+			SangFroid_Additional_02_max: +v.SangFroid_Additional_02>0?+v.Trempe + +v.SangFroid_Additional_02:0
 		});
    });
 });


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

In the MetalAdventures books, there are many skills that can be learned during the adventures.
However, the current sheet does not allow these skills to be added.
The paper sheets provide empty slots specifically for these cases.

Thus this pull request suggests adding 2 blank skills for each characteristic.

For years, we've been using extra lines for equipment, transfers and even specialities, but every time we have to think that we have a skill.
We often forget that we have an additional skill.



