### PR TITLE
[Das_Schwarze_Auge_4-1] Fixes to Spell Representations

### DIFF
--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/footer.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/footer.html
@@ -1,3 +1,3 @@
 <!-- sheet footer start -->
-	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240510"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
+	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240519"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
 <!-- sheet footer end -->

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_info.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_info.html
@@ -7,15 +7,17 @@
 		</p>
 		<h3>Infos zum Charakterbogen</h3>
 		<p>Dieser Charakterbogen wird weiterentwickelt. Dabei bleibt es nicht aus, dass alte Daten nicht mehr ohne Weiteres in den veränderten Bogen passen. Wenn es nötig wird, werden die alten Daten automatisch im Hintergrund umgewandelt. Da es aber immer zu Fehlern kommen kann, stehen für jeden Versionssprung hier weiterhin die alten Daten (inklusive ihrer Funktionalität) zur Verfügung. So wird sichergestellt, dass keine Daten verlorengehen und das Spiel weitergehen kann.</p>
-		<p>Zu besonderen Updates&nbsp;&ndash;&nbsp;sprich: alles, was über einfache Fehlerbehebungen und eher kleine kosmetische Veränderungen hinausgeht&nbsp;&ndash;&nbsp;gibt es in der Regel, wenn auch nicht immer pünktlich zum Release einer neuen Charakterbogenversion, Videos mit vielen Details: <br>
+		<p>Zu besonderen Updates&nbsp;&ndash;&nbsp;sprich: alles, was über einfache Fehlerbehebungen und eher kleine kosmetische Veränderungen hinausgeht&nbsp;&ndash;&nbsp;gibt es in der Regel, wenn auch nicht immer pünktlich zum Release einer neuen Charakterbogenversion, Videos mit vielen Details. Die Playlist liegt unter folgender Adresse: <br>
 				<input type="text" class="selectable-text" style="width: 52em" value="https://www.youtube.com/watch?v=l2SCwz51T9g&amp;list=PLGBXxa8pcNCqzNe4CrKvy-_QgjfgLDOZ-">
 		</p>
+		<p>In der Überschrift zu den einzelnen Versionen zeigt ein Filmklappen-Emoji (&#x1f3ac;) an, dass ein Link zum entsprechenden Video angegeben ist.</p>
 		<p>Änderungen &bdquo;unter der Haube&ldquo; erspare ich euch an dieser Stelle. Wer Interesse daran hat, findet all die Infos auf GitHub (siehe oben). Bei Bedarf könnt ihr auch gerne fragen: &bdquo;Isurandil&ldquo; auf (in stark fallender Lesehäufigkeit) Orkenspalter, Mastodon (@Isurandil@mastodon.online), Twitter, YouTube und Roll20.</p>
 
 		<details open>
 			<summary>
-				<h4>Update auf Version 20240510</h4>
+				<h4>&#x1f3ac; Update auf Version 20240510</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=y_SQMOk_Oe8"></p>
 			<h5>Neues Feature: Repräsentationen für Zauber</h5>
 			<p>
 				<ul>
@@ -160,8 +162,9 @@
 
 		<details>
 			<summary>
-				<h4>Update auf Version 20230618</h4>
+				<h4>&#x1f3ac; Update auf Version 20230618</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=vGTkwBy1uWE"></p>
 			<h5>Neues Betafeature &bdquo;Bestätigungswürfe im Kampf einzeln/manuell würfeln&ldquo;</h5>
 			<p>
 				<ul>
@@ -804,8 +807,9 @@
 
 		<details>
 			<summary>
-				<h4>Update auf Version 20220116</h4>
+				<h4>&#x1f3ac; Update auf Version 20220116</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=taCNRr3_08s"></p>
 			<h5>Einführung von Betafeatures</h5>
 			<p>
 				<ul>
@@ -1003,16 +1007,19 @@
 
 		<details>
 			<summary>
-				<h4>Updates auf Version 20210415</h4>
+				<h4>&#x1f3ac; Updates auf Version 20210415</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=5sOdcxNbn2s"></p>
 			<p>Beim letzten Update habe ich versehentlich einen sehr ärgerlichen Fehler eingebaut, der verhindert hat, dass der TP-Würfel-Knopf von Nahkampfwaffen funktioniert. Mit dieser Version wurde dies behoben.</p>
 			<p><strong>Hinweis:</strong> Wer einen der Workarounds benutzt hat, sollte die im Zuge dessen angelegten Attribute &bdquo;TP_W_Aktiv&ldquo; und &bdquo;TP_Bonus_Aktiv&ldquo; wieder löschen. Mehr Infos dazu gibt es in einem Video.</p>
 		</details>
 
 		<details>
 			<summary>
-				<h4>Updates auf Versionen 20200809 und 20210413</h4>
+				<h4>&#x1f3ac; Updates auf Versionen 20200809 und 20210413</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=rqgyaCXuMUM"></p>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=le3ys6T389o"></p>
 			<p>Es werden zwar gewisse Migrationen durchgeführt, dabei aber keine größeren Umstellungen vorgenommen. Daher gibt es hier auch keine alten Daten, die möglicherweise gerettet werden müssten. :)</p>
 		</details>
 
@@ -1025,8 +1032,9 @@
 
 		<details>
 			<summary>
-				<h4>Update auf Version 20190427</h4>
+				<h4>&#x1f3ac; Update auf Version 20190427</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=a6KadwTIcQY"></p>
 			<p>Gaben und Metatalente wurden verändert, sodass eine Migration der alten Daten notwendig wurde. Spalten für spezielle Erfahrungen (SE) wurden entfernt, da diese ausschließlich für die Steigerung relevant sind, Steigerungen aber seitens Roll20 nicht im Charakterbogen umgesetzt sein dürfen. Um die Information dauerhafter zu speichern, empfiehlt es sich die Notizen zu benutzen. Spezielle Erfahrungen in Metatalenten sind darüber hinaus nicht regelkonform.</p>
 			<h5>Gaben</h5>
 			<fieldset class="repeating_GabenTalente">

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_info.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_info.html
@@ -15,6 +15,30 @@
 
 		<details open>
 			<summary>
+				<h4>Update auf Version 20240519</h4>
+			</summary>
+			<h5>Design</h5>
+			<p>
+				<ul>
+					<li>Tab &bdquo;Info&ldquo;: Updates, zu denen ein Video erschienen ist, sind nun mit einem Filmklappen-Emoji markiert und der Link zum Video ist angegeben.</li>
+					</li>
+				</ul>
+			</p>
+			<h5>Fehlerbehebungen</h5>
+			<p>
+				<ul>
+					<li>Repräsentationen: Einige Zauber haben die beim Zauber angegebene Repräsentation ignoriert und damit keine Eigenschaften ersetzt. Nun sollten sämtliche Zauber wie erwartet funktionieren.
+						<ul>
+							<li>Die betroffenen Zauber waren: Animatio, Auris Nasus Oculus, Band und Fessel, Beherrschung brechen, Bewegung stören, Dichter und Denker, Eigenschaft wiederherstellen, Elementarer Diener, Flim Flam, Fluch der Pestilenz, Gefäß der Jahre, Harmlose Gestalt, Hartes schmelze, Heilkraft bannen, Hellsicht trüben, Höllenpein, Illusion auflösen, Klarum Purum, Körperlose Reise, Kraft des Erzes, Limbus versiegeln, Madas Spiegel, Magischer Raub, Metamagie neutralisieren, Metamorpho Felsenform, Metamorpho Gletscherform, Murks und Patz, Objecto obscuro, Objekt entzaubern, Pestilenz erspüren, Ruhe Körper, Schleier der Unwissenheit, Seelentier erkennen, Staub wandle, Stimmen des Windes, Tempus Stasis, Unberührt, Veränderung aufheben, Verständigung stören, Verwandlung beenden, Wand aus Flammen, Warmes Blut, Warmes Gefriere, Weiches erstarre.</li>
+							<li>Einige weitere Zauber waren zwar vom selben Fehler betroffen, der sich auf diese aber nicht ausgewirken konnte, da ohnehin keine Eigenschaften ersetzt werden konnten: Ängste lindern, Auge des Limbus, Bärenruhe, Beschwörung vereiteln, Böser Blick, Dämonenbann, Eigne Ängste, Einfluss bannen, Eins mit der Natur, Erinnerung verlasse dich, Granit und Marmor, Herbeirufung vereiteln, Herr über das Tierreich, Herzschlag ruhe, Hilfreiche Tatze, Iribaars Hand, Komm Kobold Komm, Krabbelnder Schrecken, Krähenruf, Kraft des Humus, Krötensprung, Lach dich gesund, Langer Lulatsch, Last des Alters, Levthans Feuer, Lunge des Leviatan, Paralysis, Satuarias Herrlichkeit, Schadenszauber bannen, Stein wandle, Sumus Elixiere, Tiere besprechen, Tlalucs Odem, Totes handle, Unsichtbarer Jäger, Weisheit der Bäume, Zorn der Elemente, Zunge lähmen.</li>
+						</ul>
+					</li>
+				</ul>
+			</p>
+		</details>
+
+		<details open>
+			<summary>
 				<h4>&#x1f3ac; Update auf Version 20240510</h4>
 			</summary>
 			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=y_SQMOk_Oe8"></p>

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_info.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_info.html
@@ -20,7 +20,7 @@
 			<p>
 				<ul>
 					<li>Für jeden Zauber kann die dazugehörige Repräsentation angegeben werden. Wählbar sind alle Repräsentationen der Jetztzeit, alle Repräsentationen der Dunklen Zeiten und ein Platzhalter für Magiedilettanten: Ach, Bor, Dil, Dru, Elf, Geo, Hex, Mag, Srl und Sch; Alh, Geo/Dru, Gro, Gül, Kop, Mud und Sat. Außergewöhnliche Repräsentationen wie jene der Drachen, der Krakonier oder der Schratigen stehen nicht zur Wahl.</li>
-					<li>Es können auch eigene Repräsentationen eingetragen werden, weshalb die außergewöhnlichen Repräsentationen so ebenfalls eingetragen werden können- <span class="highlight">Regeltechnisch berücksichtigt</span> werden aktuell jedoch nur <span class="highlight">Ach, Elf und Kop</span>.</li>
+					<li>Es können auch eigene Repräsentationen eingetragen werden, weshalb die außergewöhnlichen Repräsentationen so ebenfalls eingetragen werden können. <span class="highlight">Regeltechnisch berücksichtigt</span> werden aktuell jedoch nur <span class="highlight">Ach, Elf und Kop</span>.</li>
 					<li>Allen drei Repräsentationen ist gemein, dass <span class="highlight">in der Zauberprobe Eigenschaften ersetzt</span> werden dürfen. Beim Würfeln der Probe wählt der Charakterbogen stets die <span class="highlight">günstigsten Eigenschaften für den Wurf automatisch</span> aus.</li>
 					<li>Es sind stets mehrere Repräsentationseinträge möglich, dabei gilt es jedoch die folgenden Punkte zu beachten:
 						<ul>

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
@@ -426,7 +426,7 @@
 						<button type="roll" name="roll_z_aengstelindern" value="@{z_aengstelindern_action}"> <span>Ängste lindern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_aengstelindern_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_angste_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_angste">
 					<input type="number" class="talent-taw" name="attr_ZfW_angste" min="0" value="0">
 					<div class="talent-cell talent-taw">23</div>
@@ -441,7 +441,7 @@
 						<button type="roll" name="roll_z_animatio" value="@{z_animatio_action}"> <span>Animatio Stummer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_animatio_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_animato_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Animato">
 					<input type="number" class="talent-taw" name="attr_ZfW_Animato" min="0" value="0">
 					<div class="talent-cell talent-taw">24</div>
@@ -647,7 +647,7 @@
 						<button type="roll" name="roll_z_augedeslimbus" value="@{z_augedeslimbus_action}"> <span>Auge des Limbus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_augedeslimbus_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Auge_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Auge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Auge" min="0" value="0">
 					<div class="talent-cell talent-taw">32</div>
@@ -752,7 +752,7 @@
 						<button type="roll" name="roll_z_baerenruhe" value="@{z_baerenruhe_action}"> <span>Bärenruhe Winterschlaf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Modifikator für die Dauer des Schlafs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_baerenruhe_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Barenruhe_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Barenruhe">
 					<input type="number" class="talent-taw" name="attr_ZfW_Barenruhe" min="0" value="0">
 					<div class="talent-cell talent-taw">40</div>
@@ -767,7 +767,7 @@
 						<button type="roll" name="roll_z_beherrschungbrechen" value="@{z_beherrschungbrechen_action}"> <span>Beherrschung brechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_beherrschungbrechen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Beherrschung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Beherrschung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Beherrschung" min="0" value="0">
 					<div class="talent-cell talent-taw">41</div>
@@ -812,7 +812,7 @@
 						<button type="roll" name="roll_z_bewegungstoeren" value="@{z_bewegungstoeren_action}"> <span>Bewegung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_bewegungstoeren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Bewegung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Bewegung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bewegung" min="0" value="0">
 					<div class="talent-cell talent-taw">43</div>
@@ -932,7 +932,7 @@
 						<button type="roll" name="roll_z_boeserblick" value="@{z_boeserblick_action}"> <span>Böser Blick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_boeserblick_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_boser_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_boser">
 					<input type="number" class="talent-taw" name="attr_ZfW_boser" min="0" value="0">
 					<div class="talent-cell talent-taw">50</div>
@@ -1112,7 +1112,7 @@
 						<button type="roll" name="roll_z_daemonenbann" value="@{z_daemonenbann_action}"> <span>Dämonenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_daemonenbann_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_damonenbann_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_damonenbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_damonenbann" min="0" value="0">
 					<div class="talent-cell talent-taw">63</div>
@@ -1172,7 +1172,7 @@
 						<button type="roll" name="roll_z_dichterunddenker" value="@{z_dichterunddenker_action}"> <span>Dichter und Denker</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_dichterunddenker_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_dichter_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_dichter">
 					<input type="number" class="talent-taw" name="attr_ZfW_dichter" min="0" value="0">
 					<div class="talent-cell talent-taw">67</div>
@@ -1247,7 +1247,7 @@
 						<button type="roll" name="roll_z_eigenschaftwiederherstellen" value="@{z_eigenschaftwiederherstellen_action}"> <span>Eigenschaft wiederherstellen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_eigenschaftwiederherstellen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_eigenschaft_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_eigenschaft">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigenschaft" min="0" value="0">
 					<div class="talent-cell talent-taw">73</div>
@@ -1262,7 +1262,7 @@
 						<button type="roll" name="roll_z_eigneaengste" value="@{z_eigneaengste_action}"> <span>Eigne Ängste quälen dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_eigneaengste_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_eigne_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_eigne">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigne" min="0" value="0">
 					<div class="talent-cell talent-taw">74</div>
@@ -1277,7 +1277,7 @@
 						<button type="roll" name="roll_z_einflussbannen" value="@{z_einflussbannen_action}"> <span>Einfluss bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_einflussbannen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_einfluss_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_einfluss">
 					<input type="number" class="talent-taw" name="attr_ZfW_einfluss" min="0" value="0">
 					<div class="talent-cell talent-taw">75</div>
@@ -1292,7 +1292,7 @@
 						<button type="roll" name="roll_z_einsmitdernatur" value="@{z_einsmitdernatur_action}"> <span>Eins mit der Natur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_einsmitdernatur_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_eins_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_eins">
 					<input type="number" class="talent-taw" name="attr_ZfW_eins" min="0" value="0">
 					<div class="talent-cell talent-taw">76</div>
@@ -1367,7 +1367,7 @@
 						<button type="roll" name="roll_z_elementarerdiener" value="@{z_elementarerdiener_action}"> <span>Elementarer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_elementarerdiener_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_elementarer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_elementarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_elementarer" min="0" value="0">
 					<div class="talent-cell talent-taw">80</div>
@@ -1412,7 +1412,7 @@
 						<button type="roll" name="roll_z_erinnerungverlassedich" value="@{z_erinnerungverlassedich_action}"> <span>Erinnerung verlasse dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_erinnerungverlassedich_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_erinnerung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_erinnerung">
 					<input type="number" class="talent-taw" name="attr_ZfW_erinnerung" min="0" value="0">
 					<div class="talent-cell talent-taw">82</div>
@@ -1532,7 +1532,7 @@
 						<button type="roll" name="roll_z_flimflam" value="@{z_flimflam_action}"> <span>Flim Flam Funkel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
-					<input type="text" class="talent-rep" name="attr_z_flimflam_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_flim_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_flim">
 					<input type="number" class="talent-taw" name="attr_ZfW_flim" min="0" value="0">
 					<div class="talent-cell talent-taw">87</div>
@@ -1547,7 +1547,7 @@
 						<button type="roll" name="roll_z_fluchderpestilenz" value="@{z_fluchderpestilenz_action}"> <span>Fluch der Pestilenz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_fluchderpestilenz_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_fluch_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_fluch">
 					<input type="number" class="talent-taw" name="attr_ZfW_fluch" min="0" value="0">
 					<div class="talent-cell talent-taw">88</div>
@@ -1682,7 +1682,7 @@
 						<button type="roll" name="roll_z_gefaessderjahre" value="@{z_gefaessderjahre_action}"> <span>Gefäß der Jahre</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_gefaessderjahre_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_gefass_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_gefass">
 					<input type="number" class="talent-taw" name="attr_ZfW_gefass" min="0" value="0">
 					<div class="talent-cell talent-taw">95</div>
@@ -1787,7 +1787,7 @@
 						<button type="roll" name="roll_z_granitundmarmor" value="@{z_granitundmarmor_action}"> <span>Granit und Marmor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_granitundmarmor_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_granit_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_granit">
 					<input type="number" class="talent-taw" name="attr_ZfW_granit" min="0" value="0">
 					<div class="talent-cell talent-taw">99</div>
@@ -1862,7 +1862,7 @@
 						<button type="roll" name="roll_z_harmlosegestalt" value="@{z_harmlosegestalt_action}"> <span>Harmlose Gestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_harmlosegestalt_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_harmlose_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Harmlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_Harmlose" min="0" value="0">
 					<div class="talent-cell talent-taw">103</div>
@@ -1877,7 +1877,7 @@
 						<button type="roll" name="roll_z_hartesschmelze" value="@{z_hartesschmelze_action}"> <span>Hartes schmelze!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_hartesschmelze_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hartes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hartes">
 					<input type="number" class="talent-taw" name="attr_ZfW_hartes" min="0" value="0">
 					<div class="talent-cell talent-taw">104</div>
@@ -1922,7 +1922,7 @@
 						<button type="roll" name="roll_z_heilkraftbannen" value="@{z_heilkraftbannen_action}"> <span>Heilkraft bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_heilkraftbannen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_heilkraft_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_heilkraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_heilkraft" min="0" value="0">
 					<div class="talent-cell talent-taw">107</div>
@@ -1937,7 +1937,7 @@
 						<button type="roll" name="roll_z_hellsichttrueben" value="@{z_hellsichttrueben_action}"> <span>Hellsicht trüben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_hellsichttrueben_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hellsicht_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hellsicht">
 					<input type="number" class="talent-taw" name="attr_ZfW_hellsicht" min="0" value="0">
 					<div class="talent-cell talent-taw">108</div>
@@ -1952,7 +1952,7 @@
 						<button type="roll" name="roll_z_herbeirufungvereiteln" value="@{z_herbeirufungvereiteln_action}"> <span>Herbeirufung vereiteln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_herbeirufungvereiteln_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_herbeirufung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_herbeirufung">
 					<input type="number" class="talent-taw" name="attr_ZfW_herbeirufung" min="0" value="0">
 					<div class="talent-cell talent-taw">109</div>
@@ -1967,7 +1967,7 @@
 						<button type="roll" name="roll_z_herrueberdastierreich" value="@{z_herrueberdastierreich_action}"> <span>Herr über das Tierreich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_herrueberdastierreich_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_herr_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_herr">
 					<input type="number" class="talent-taw" name="attr_ZfW_herr" min="0" value="0">
 					<div class="talent-cell talent-taw">110</div>
@@ -1982,7 +1982,7 @@
 						<button type="roll" name="roll_z_herzschlagruhe" value="@{z_herzschlagruhe_action}"> <span>Herzschlag ruhe!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_herzschlagruhe_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_herzschlag_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_herzschlag">
 					<input type="number" class="talent-taw" name="attr_ZfW_herzschlag" min="0" value="0">
 					<div class="talent-cell talent-taw">111</div>
@@ -2102,7 +2102,7 @@
 						<button type="roll" name="roll_z_hilfreichetatze" value="@{z_hilfreichetatze_action}"> <span>Hilfreiche Tatze</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="geistige Magieresistenz des Tieres">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_hilfreichetatze_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hilfreiche_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hilfreiche">
 					<input type="number" class="talent-taw" name="attr_ZfW_hilfreiche" min="0" value="0">
 					<div class="talent-cell talent-taw">118</div>
@@ -2117,7 +2117,7 @@
 						<button type="roll" name="roll_z_hoellenpein" value="@{z_hoellenpein_action}"> <span>Höllenpein zerreiße dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_hoellenpein_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hollenpein_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hollenpein">
 					<input type="number" class="talent-taw" name="attr_ZfW_hollenpein" min="0" value="0">
 					<div class="talent-cell talent-taw">119</div>
@@ -2327,7 +2327,7 @@
 						<button type="roll" name="roll_z_illusionaufloesen" value="@{z_illusionaufloesen_action}"> <span>Illusion auflösen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_illusionaufloesen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_illusion_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_illusion">
 					<input type="number" class="talent-taw" name="attr_ZfW_illusion" min="0" value="0">
 					<div class="talent-cell talent-taw">126</div>
@@ -2447,7 +2447,7 @@
 						<button type="roll" name="roll_z_iribaarshand" value="@{z_iribaarshand_action}"> <span>Iribaars Hand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_iribaarshand_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_iribaars_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_iribaars">
 					<input type="number" class="talent-taw" name="attr_ZfW_iribaars" min="0" value="0">
 					<div class="talent-cell talent-taw">134</div>
@@ -2507,7 +2507,7 @@
 						<button type="roll" name="roll_z_klarumpurum" value="@{z_klarumpurum_action}"> <span>Klarum Purum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Modifikator für die Giftstufe">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_klarumpurum_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_klarum_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_klarum">
 					<input type="number" class="talent-taw" name="attr_ZfW_klarum" min="0" value="0">
 					<div class="talent-cell talent-taw">138</div>
@@ -2567,7 +2567,7 @@
 						<button type="roll" name="roll_z_kommkoboldkomm" value="@{z_kommkoboldkomm_action}"> <span>Komm Kobold Komm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_kommkoboldkomm_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_komm_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_komm">
 					<input type="number" class="talent-taw" name="attr_ZfW_komm" min="0" value="0">
 					<div class="talent-cell talent-taw">142</div>
@@ -2582,7 +2582,7 @@
 						<button type="roll" name="roll_z_koerperlosereise" value="@{z_koerperlosereise_action}"> <span>Körperlose Reise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_koerperlosereise_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_koerperlose_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_koerperlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_koerperlose" min="0" value="0">
 					<div class="talent-cell talent-taw">143</div>
@@ -2597,7 +2597,7 @@
 						<button type="roll" name="roll_z_krabbelnderschrecken" value="@{z_krabbelnderschrecken_action}"> <span>Krabbelnder Schrecken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_krabbelnderschrecken_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_krabbelnder_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_krabbelnder">
 					<input type="number" class="talent-taw" name="attr_ZfW_krabbelnder" min="0" value="0">
 					<div class="talent-cell talent-taw">144</div>
@@ -2612,7 +2612,7 @@
 						<button type="roll" name="roll_z_kraftdeserzes" value="@{z_kraftdeserzes_action}"> <span>Kraft des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_kraftdeserzes_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_kraft_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_kraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft" min="0" value="0">
 					<div class="talent-cell talent-taw">145</div>
@@ -2627,7 +2627,7 @@
 						<button type="roll" name="roll_z_kraftdeshumus" value="@{z_kraftdeshumus_action}"> <span>Kraft des Humus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_kraftdeshumus_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_kraft_humus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_kraft_humus">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft_humus" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -2642,7 +2642,7 @@
 						<button type="roll" name="roll_z_kraehenruf" value="@{z_kraehenruf_action}"> <span>Krähenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_kraehenruf_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_krahenruf_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_krahenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_krahenruf" min="0" value="0">
 					<div class="talent-cell talent-taw">146</div>
@@ -2657,7 +2657,7 @@
 						<button type="roll" name="roll_z_kroetensprung" value="@{z_kroetensprung_action}"> <span>Krötensprung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_kroetensprung_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_krotensprung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_krotensprung">
 					<input type="number" class="talent-taw" name="attr_ZfW_krotensprung" min="0" value="0">
 					<div class="talent-cell talent-taw">148</div>
@@ -2702,7 +2702,7 @@
 						<button type="roll" name="roll_z_lachdichgesund" value="@{z_lachdichgesund_action}"> <span>Lach dich gesund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_lachdichgesund_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_lach_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_lach">
 					<input type="number" class="talent-taw" name="attr_ZfW_lach" min="0" value="0">
 					<div class="talent-cell talent-taw">151</div>
@@ -2732,7 +2732,7 @@
 						<button type="roll" name="roll_z_langerlulatsch" value="@{z_langerlulatsch_action}"> <span>Langer Lulatsch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_langerlulatsch_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_langer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_langer">
 					<input type="number" class="talent-taw" name="attr_ZfW_langer" min="0" value="0">
 					<div class="talent-cell talent-taw">153</div>
@@ -2747,7 +2747,7 @@
 						<button type="roll" name="roll_z_lastdesalters" value="@{z_lastdesalters_action}"> <span>Last des Alters</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_lastdesalters_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_last_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_last">
 					<input type="number" class="talent-taw" name="attr_ZfW_last" min="0" value="0">
 					<div class="talent-cell talent-taw">154</div>
@@ -2882,7 +2882,7 @@
 						<button type="roll" name="roll_z_levthansfeuer" value="@{z_levthansfeuer_action}"> <span>Levthans Feuer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_levthansfeuer_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_levthans_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_levthans">
 					<input type="number" class="talent-taw" name="attr_ZfW_levthans" min="0" value="0">
 					<div class="talent-cell talent-taw">166</div>
@@ -2897,7 +2897,7 @@
 						<button type="roll" name="roll_z_limbusversiegeln" value="@{z_limbusversiegeln_action}"> <span>Limbus versiegeln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_limbusversiegeln_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_limbus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_limbus">
 					<input type="number" class="talent-taw" name="attr_ZfW_limbus" min="0" value="0">
 					<div class="talent-cell talent-taw">167</div>
@@ -2927,7 +2927,7 @@
 						<button type="roll" name="roll_z_lungedesleviatan" value="@{z_lungedesleviatan_action}"> <span>Lunge des Leviatan</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_lungedesleviatan_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_lunge_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_lunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_lunge" min="0" value="0">
 					<div class="talent-cell talent-taw">169</div>
@@ -2942,7 +2942,7 @@
 						<button type="roll" name="roll_z_madasspiegel" value="@{z_madasspiegel_action}"> <span>Madas Spiegel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_madasspiegel_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_madas_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_madas">
 					<input type="number" class="talent-taw" name="attr_ZfW_madas" min="0" value="0">
 					<div class="talent-cell talent-taw">170</div>
@@ -2957,7 +2957,7 @@
 						<button type="roll" name="roll_z_magischerraub" value="@{z_magischerraub_action}"> <span>Magischer Raub</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_magischerraub_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_magischer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_magischer">
 					<input type="number" class="talent-taw" name="attr_ZfW_magischer" min="0" value="0">
 					<div class="talent-cell talent-taw">171</div>
@@ -3092,7 +3092,7 @@
 						<button type="roll" name="roll_z_metamagieneutralisieren" value="@{z_metamagieneutralisieren_action}"> <span>Metamagie neutralisieren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_metamagieneutralisieren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_metamagie_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_metamagie">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamagie" min="0" value="0">
 					<div class="talent-cell talent-taw">179</div>
@@ -3107,7 +3107,7 @@
 						<button type="roll" name="roll_z_metamorphofelsenform" value="@{z_metamorphofelsenform_action}"> <span>Metamorpho Felsenform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_metamorphofelsenform_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_metamorpho_felsenform_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho_felsenform">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho_felsenform" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -3122,7 +3122,7 @@
 						<button type="roll" name="roll_z_metamorphogletscherform" value="@{z_metamorphogletscherform_action}"> <span>Metamorpho Gletscherform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_metamorphogletscherform_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_metamorpho_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -3167,7 +3167,7 @@
 						<button type="roll" name="roll_z_murksundpatz" value="@{z_murksundpatz_action}"> <span>Murks und Patz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="höchste Magieresistenz plus Anzahl Betroffener">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_murksundpatz_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_murks_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_murks">
 					<input type="number" class="talent-taw" name="attr_ZfW_murks" min="0" value="0">
 					<div class="talent-cell talent-taw">184</div>
@@ -3272,7 +3272,7 @@
 						<button type="roll" name="roll_z_objectoobscuro" value="@{z_objectoobscuro_action}"> <span>Objecto Obscuro</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_objectoobscuro_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_objecto_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_objecto">
 					<input type="number" class="talent-taw" name="attr_ZfW_objecto" min="0" value="0">
 					<div class="talent-cell talent-taw">191</div>
@@ -3317,7 +3317,7 @@
 						<button type="roll" name="roll_z_objektentzaubern" value="@{z_objektentzaubern_action}"> <span>Objekt entzaubern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_objektentzaubern_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_objekt_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_objekt">
 					<input type="number" class="talent-taw" name="attr_ZfW_objekt" min="0" value="0">
 					<div class="talent-cell talent-taw">194</div>
@@ -3437,7 +3437,7 @@
 						<button type="roll" name="roll_z_paralysis" value="@{z_paralysis_action}"> <span>Paralysis starr wie Stein</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_paralysis_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_paralys_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_paralys">
 					<input type="number" class="talent-taw" name="attr_ZfW_paralys" min="0" value="0">
 					<div class="talent-cell talent-taw">202</div>
@@ -3497,7 +3497,7 @@
 						<button type="roll" name="roll_z_pestilenzerspueren" value="@{z_pestilenzerspueren_action}"> <span>Pestilenz erspüren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Entdeckungsschwierigkeit der Krankheit oder der Giftstufe des Giftes">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_pestilenzerspueren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_pestilenz_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_pestilenz">
 					<input type="number" class="talent-taw" name="attr_ZfW_pestilenz" min="0" value="0">
 					<div class="talent-cell talent-taw">207</div>
@@ -3812,7 +3812,7 @@
 						<button type="roll" name="roll_z_satuariasherrlichkeit" value="@{z_satuariasherrlichkeit_action}"> <span>Satuarias Herrlichkeit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_satuariasherrlichkeit_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_satuarias_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_satuarias">
 					<input type="number" class="talent-taw" name="attr_ZfW_satuarias" min="0" value="0">
 					<div class="talent-cell talent-taw">224</div>
@@ -3842,7 +3842,7 @@
 						<button type="roll" name="roll_z_schadenszauberbannen" value="@{z_schadenszauberbannen_action}"> <span>Schadenszauber bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_schadenszauberbannen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_schadenszauber_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_schadenszauber">
 					<input type="number" class="talent-taw" name="attr_ZfW_schadenszauber" min="0" value="0">
 					<div class="talent-cell talent-taw">226</div>
@@ -3932,7 +3932,7 @@
 						<button type="roll" name="roll_z_schleierderunwissenheit" value="@{z_schleierderunwissenheit_action}"> <span>Schleier der Unwissenheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
-					<input type="text" class="talent-rep" name="attr_z_schleierderunwissenheit_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_schleier_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_schleier">
 					<input type="number" class="talent-taw" name="attr_ZfW_schleier" min="0" value="0">
 					<div class="talent-cell talent-taw">231</div>
@@ -3992,7 +3992,7 @@
 						<button type="roll" name="roll_z_seelentiererkennen" value="@{z_seelentiererkennen_action}"> <span>Seelentier erkennen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_seelentiererkennen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_seelentier_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_seelentier">
 					<input type="number" class="talent-taw" name="attr_ZfW_seelentier" min="0" value="0">
 					<div class="talent-cell talent-taw">234</div>
@@ -4262,7 +4262,7 @@
 						<button type="roll" name="roll_z_staubwandle" value="@{z_staubwandle_action}"> <span>Staub wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golemids, das Grundmaterial, die elementare Reinheit des Ausgangsmaterials, der Größe des Golemids, der Eigenschaften des Golemids, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golemids und die Talentwerte des Golemids">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_staubwandle_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_staub_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_staub">
 					<input type="number" class="talent-taw" name="attr_ZfW_staub" min="0" value="0">
 					<div class="talent-cell talent-taw">250</div>
@@ -4292,7 +4292,7 @@
 						<button type="roll" name="roll_z_steinwandle" value="@{z_steinwandle_action}"> <span>Stein wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golems, das Grundmaterial, die Affinität des Materials zum Erzdämonen, der Größe des Golems, der Eigenschaften des Golems, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golems und die Talentwerte des Golems">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_steinwandle_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_stein_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_stein">
 					<input type="number" class="talent-taw" name="attr_ZfW_stein" min="0" value="0">
 					<div class="talent-cell talent-taw">251</div>
@@ -4322,7 +4322,7 @@
 						<button type="roll" name="roll_z_stimmendeswindes" value="@{z_stimmendeswindes_action}"> <span>Stimmen des Windes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_stimmendeswindes_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Stimmen_des_Windes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Stimmen_des_Windes">
 					<input type="number" class="talent-taw" name="attr_ZfW_Stimmen_des_Windes" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4352,7 +4352,7 @@
 						<button type="roll" name="roll_z_sumuselixiere" value="@{z_sumuselixiere_action}"> <span>Sumus Elixiere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
-					<input type="text" class="talent-rep" name="attr_z_sumuselixiere_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_sumus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_sumus">
 					<input type="number" class="talent-taw" name="attr_ZfW_sumus" min="0" value="0">
 					<div class="talent-cell talent-taw">253</div>
@@ -4397,7 +4397,7 @@
 						<button type="roll" name="roll_z_tempusstasis" value="@{z_tempusstasis_action}"> <span>Tempus Stasis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK + <span class="abbr" title="1 pro Kampfrunde">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_tempusstasis_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_tempus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_tempus">
 					<input type="number" class="talent-taw" name="attr_ZfW_tempus" min="0" value="0">
 					<div class="talent-cell talent-taw">255</div>
@@ -4427,7 +4427,7 @@
 						<button type="roll" name="roll_z_tierebesprechen" value="@{z_tierebesprechen_action}"> <span>Tiere besprechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Anzahl zu heilender regeltechnischer Wunden, der Stufe der Krankheit oder der halben Giftstufe">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_tierebesprechen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_tiere_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_tiere">
 					<input type="number" class="talent-taw" name="attr_ZfW_tiere" min="0" value="0">
 					<div class="talent-cell talent-taw">256</div>
@@ -4472,7 +4472,7 @@
 						<button type="roll" name="roll_z_tlalucsodem" value="@{z_tlalucsodem_action}"> <span>Tlalucs Odem Pestgestank</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_tlalucsodem_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_tlalucs_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_tlalucs">
 					<input type="number" class="talent-taw" name="attr_ZfW_tlalucs" min="0" value="0">
 					<div class="talent-cell talent-taw">258</div>
@@ -4487,7 +4487,7 @@
 						<button type="roll" name="roll_z_toteshandle" value="@{z_toteshandle_action}"> <span>Totes Handle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_toteshandle_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_totes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_totes">
 					<input type="number" class="talent-taw" name="attr_ZfW_totes" min="0" value="0">
 					<div class="talent-cell talent-taw">259</div>
@@ -4577,7 +4577,7 @@
 						<button type="roll" name="roll_z_unberuehrt" value="@{z_unberuehrt_action}"> <span>Unberührt von Satinav</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO + <span class="abbr" title="1 pro Tag Wirkungsdauer über den ersten hinaus">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_unberuehrt_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_unberuhrt_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_unberuhrt">
 					<input type="number" class="talent-taw" name="attr_ZfW_unberuhrt" min="0" value="0">
 					<div class="talent-cell talent-taw">264</div>
@@ -4622,7 +4622,7 @@
 						<button type="roll" name="roll_z_unsichtbarerjaeger" value="@{z_unsichtbarerjaeger_action}"> <span>Unsichtbarer Jäger</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_unsichtbarerjaeger_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_unsichtbarer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_unsichtbarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_unsichtbarer" min="0" value="0">
 					<div class="talent-cell talent-taw">266</div>
@@ -4652,7 +4652,7 @@
 						<button type="roll" name="roll_z_veraenderungaufheben" value="@{z_veraenderungaufheben_action}"> <span>Veränderung aufheben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_veraenderungaufheben_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_veranderung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_veranderung">
 					<input type="number" class="talent-taw" name="attr_ZfW_veranderung" min="0" value="0">
 					<div class="talent-cell talent-taw">267</div>
@@ -4682,7 +4682,7 @@
 						<button type="roll" name="roll_z_verstaendigungstoeren" value="@{z_verstaendigungstoeren_action}"> <span>Verständigung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_verstaendigungstoeren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_verstandigung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_verstandigung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verstandigung" min="0" value="0">
 					<div class="talent-cell talent-taw">269</div>
@@ -4697,7 +4697,7 @@
 						<button type="roll" name="roll_z_verwandlungbeenden" value="@{z_verwandlungbeenden_action}"> <span>Verwandlung beenden</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_verwandlungbeenden_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_verwandlung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_verwandlung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verwandlung" min="0" value="0">
 					<div class="talent-cell talent-taw">270</div>
@@ -4787,7 +4787,7 @@
 						<button type="roll" name="roll_z_wandausflammen" value="@{z_wandausflammen_action}"> <span>Wand aus Flammen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_wandausflammen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Wand_aus_Flammen_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Wand_aus_Flammen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wand_aus_Flammen" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4802,7 +4802,7 @@
 						<button type="roll" name="roll_z_warmesblut" value="@{z_warmesblut_action}"> <span>Warmes Blut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_warmesblut_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_warmes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_warmes">
 					<input type="number" class="talent-taw" name="attr_ZfW_warmes" min="0" value="0">
 					<div class="talent-cell talent-taw">276</div>
@@ -4817,7 +4817,7 @@
 						<button type="roll" name="roll_z_warmesgefriere" value="@{z_warmesgefriere_action}"> <span>Warmes gefriere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_warmesgefriere_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Warmes_gefriere_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Warmes_gefriere">
 					<input type="number" class="talent-taw" name="attr_ZfW_Warmes_gefriere" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4862,7 +4862,7 @@
 						<button type="roll" name="roll_z_weicheserstarre" value="@{z_weicheserstarre_action}"> <span>Weiches erstarre!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_weicheserstarre_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_weiches_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_weiches">
 					<input type="number" class="talent-taw" name="attr_ZfW_weiches" min="0" value="0">
 					<div class="talent-cell talent-taw">278</div>
@@ -4892,7 +4892,7 @@
 						<button type="roll" name="roll_z_weisheitderbaeume" value="@{z_weisheitderbaeume_action}"> <span>Weisheit der Bäume</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_weisheitderbaeume_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_weisheit_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_weisheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_weisheit" min="0" value="0">
 					<div class="talent-cell talent-taw">280</div>
@@ -5162,7 +5162,7 @@
 						<button type="roll" name="roll_z_zornderelemente" value="@{z_zornderelemente_action}"> <span>Zorn der Elemente</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Elementspezialisierung">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_zornderelemente_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_zorn_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_zorn">
 					<input type="number" class="talent-taw" name="attr_ZfW_zorn" min="0" value="0">
 					<div class="talent-cell talent-taw">296</div>
@@ -5177,7 +5177,7 @@
 						<button type="roll" name="roll_z_zungelaehmen" value="@{z_zungelaehmen_action}"> <span>Zunge lähmen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_zungelaehmen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_zunge_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_zunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_zunge" min="0" value="0">
 					<div class="talent-cell talent-taw">297</div>

--- a/Das_Schwarze_Auge_4-1/dev/js/migration.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/migration.js
@@ -13,7 +13,8 @@ var versionsWithMigrations = [
 		20220821,
 		20230618,
 		20240414,
-		20240510
+		20240510,
+		20240519
 ];
 
 /*
@@ -930,6 +931,201 @@ function migrateTo20240510(migrationChain) {
 		if (valueMap.hasOwnProperty(v["subtag1"]))
 		{
 			attrsToChange["sf_representations"] = valueMap[v["subtag1"]];
+		}
+		debugLog(caller, attrsToChange);
+		safeSetAttrs(attrsToChange, {}, function () {
+			callNextMigration(migrationChain);
+		});
+	});
+}
+
+/*
+	Migration steps:
+	- Migrate attributes to old names (full clean-up of spell name attributes will follow in the future, if that should still be necessary)
+*/
+function migrateTo20240519(migrationChain) {
+	const caller = "migrateTo20240519";
+	debugLog(caller, "Invoked.");
+	const attrMap = {
+		"z_angste_representation": "z_aengstelindern_representation",
+		"z_animato_representation": "z_animatio_representation",
+		"z_Auge_representation": "z_augedeslimbus_representation",
+		"z_Auris_representation": "z_aurisnasusoculus_representation",
+		"z_band_representation": "z_bandundfessel_representation",
+		"z_Barenruhe_representation": "z_baerenruhe_representation",
+		"z_Beherrschung_representation": "z_beherrschungbrechen_representation",
+		"z_Beschworung_representation": "z_beschwoerungvereiteln_representation",
+		"z_Bewegung_representation": "z_bewegungstoeren_representation",
+		"z_boser_representation": "z_boeserblick_representation",
+		"z_damonenbann_representation": "z_daemonenbann_representation",
+		"z_dichter_representation": "z_dichterunddenker_representation",
+		"z_eigenschaft_representation": "z_eigenschaftwiederherstellen_representation",
+		"z_eigne_representation": "z_eigneaengste_representation",
+		"z_einfluss_representation": "z_einflussbannen_representation",
+		"z_eins_representation": "z_einsmitdernatur_representation",
+		"z_elementarer_representation": "z_elementarerdiener_representation",
+		"z_erinnerung_representation": "z_erinnerungverlassedich_representation",
+		"z_flim_representation": "z_flimflam_representation",
+		"z_fluch_representation": "z_fluchderpestilenz_representation",
+		"z_gefass_representation": "z_gefaessderjahre_representation",
+		"z_granit_representation": "z_granitundmarmor_representation",
+		"z_Harmlose_representation": "z_harmlosegestalt_representation",
+		"z_hartes_representation": "z_hartesschmelze_representation",
+		"z_heilkraft_representation": "z_heilkraftbannen_representation",
+		"z_hellsicht_representation": "z_hellsichttrueben_representation",
+		"z_herbeirufung_representation": "z_herbeirufungvereiteln_representation",
+		"z_herr_representation": "z_herrueberdastierreich_representation",
+		"z_herzschlag_representation": "z_herzschlagruhe_representation",
+		"z_hilfreiche_representation": "z_hilfreichetatze_representation",
+		"z_hollenpein_representation": "z_hoellenpein_representation",
+		"z_illusion_representation": "z_illusionaufloesen_representation",
+		"z_iribaars_representation": "z_iribaarshand_representation",
+		"z_klarum_representation": "z_klarumpurum_representation",
+		"z_komm_representation": "z_kommkoboldkomm_representation",
+		"z_koerperlose_representation": "z_koerperlosereise_representation",
+		"z_krabbelnder_representation": "z_krabbelnderschrecken_representation",
+		"z_kraft_representation": "z_kraftdeserzes_representation",
+		"z_kraft_humus_representation": "z_kraftdeshumus_representation",
+		"z_krahenruf_representation": "z_kraehenruf_representation",
+		"z_krotensprung_representation": "z_kroetensprung_representation",
+		"z_lach_representation": "z_lachdichgesund_representation",
+		"z_langer_representation": "z_langerlulatsch_representation",
+		"z_last_representation": "z_lastdesalters_representation",
+		"z_levthans_representation": "z_levthansfeuer_representation",
+		"z_limbus_representation": "z_limbusversiegeln_representation",
+		"z_lunge_representation": "z_lungedesleviatan_representation",
+		"z_madas_representation": "z_madasspiegel_representation",
+		"z_magischer_representation": "z_magischerraub_representation",
+		"z_metamagie_representation": "z_metamagieneutralisieren_representation",
+		"z_metamorpho_felsenform_representation": "z_metamorphofelsenform_representation",
+		"z_metamorpho_representation": "z_metamorphogletscherform_representation",
+		"z_murks_representation": "z_murksundpatz_representation",
+		"z_objecto_representation": "z_objectoobscuro_representation",
+		"z_objekt_representation": "z_objektentzaubern_representation",
+		"z_paralys_representation": "z_paralysis_representation",
+		"z_pestilenz_representation": "z_pestilenzerspueren_representation",
+		"z_ruhe_representation": "z_ruhekoerper_representation",
+		"z_satuarias_representation": "z_satuariasherrlichkeit_representation",
+		"z_schadenszauber_representation": "z_schadenszauberbannen_representation",
+		"z_schleier_representation": "z_schleierderunwissenheit_representation",
+		"z_seelentier_representation": "z_seelentiererkennen_representation",
+		"z_staub_representation": "z_staubwandle_representation",
+		"z_stein_representation": "z_steinwandle_representation",
+		"z_Stimmen_des_Windes_representation": "z_stimmendeswindes_representation",
+		"z_sumus_representation": "z_sumuselixiere_representation",
+		"z_tempus_representation": "z_tempusstasis_representation",
+		"z_tiere_representation": "z_tierebesprechen_representation",
+		"z_tlalucs_representation": "z_tlalucsodem_representation",
+		"z_totes_representation": "z_toteshandle_representation",
+		"z_unberuhrt_representation": "z_unberuehrt_representation",
+		"z_unsichtbarer_representation": "z_unsichtbarerjaeger_representation",
+		"z_veranderung_representation": "z_veraenderungaufheben_representation",
+		"z_verstandigung_representation": "z_verstaendigungstoeren_representation",
+		"z_verwandlung_representation": "z_verwandlungbeenden_representation",
+		"z_Wand_aus_Flammen_representation": "z_wandausflammen_representation",
+		"z_warmes_representation": "z_warmesblut_representation",
+		"z_Warmes_gefriere_representation": "z_warmesgefriere_representation",
+		"z_weiches_representation": "z_weicheserstarre_representation",
+		"z_weisheit_representation": "z_weisheitderbaeume_representation",
+		"z_zorn_representation": "z_zornderelemente_representation",
+		"z_zunge_representation": "z_zungelaehmen_representation"
+	}
+	const attrsToGet = [
+		"z_aengstelindern_representation",
+		"z_animatio_representation",
+		"z_augedeslimbus_representation",
+		"z_aurisnasusoculus_representation",
+		"z_bandundfessel_representation",
+		"z_baerenruhe_representation",
+		"z_beherrschungbrechen_representation",
+		"z_beschwoerungvereiteln_representation",
+		"z_bewegungstoeren_representation",
+		"z_boeserblick_representation",
+		"z_daemonenbann_representation",
+		"z_dichterunddenker_representation",
+		"z_eigenschaftwiederherstellen_representation",
+		"z_eigneaengste_representation",
+		"z_einflussbannen_representation",
+		"z_einsmitdernatur_representation",
+		"z_elementarerdiener_representation",
+		"z_erinnerungverlassedich_representation",
+		"z_flimflam_representation",
+		"z_fluchderpestilenz_representation",
+		"z_gefaessderjahre_representation",
+		"z_granitundmarmor_representation",
+		"z_harmlosegestalt_representation",
+		"z_hartesschmelze_representation",
+		"z_heilkraftbannen_representation",
+		"z_hellsichttrueben_representation",
+		"z_herbeirufungvereiteln_representation",
+		"z_herrueberdastierreich_representation",
+		"z_herzschlagruhe_representation",
+		"z_hilfreichetatze_representation",
+		"z_hoellenpein_representation",
+		"z_illusionaufloesen_representation",
+		"z_iribaarshand_representation",
+		"z_klarumpurum_representation",
+		"z_kommkoboldkomm_representation",
+		"z_koerperlosereise_representation",
+		"z_krabbelnderschrecken_representation",
+		"z_kraftdeserzes_representation",
+		"z_kraftdeshumus_representation",
+		"z_kraehenruf_representation",
+		"z_kroetensprung_representation",
+		"z_lachdichgesund_representation",
+		"z_langerlulatsch_representation",
+		"z_lastdesalters_representation",
+		"z_levthansfeuer_representation",
+		"z_limbusversiegeln_representation",
+		"z_lungedesleviatan_representation",
+		"z_madasspiegel_representation",
+		"z_magischerraub_representation",
+		"z_metamagieneutralisieren_representation",
+		"z_metamorphofelsenform_representation",
+		"z_metamorphogletscherform_representation",
+		"z_murksundpatz_representation",
+		"z_objectoobscuro_representation",
+		"z_objektentzaubern_representation",
+		"z_paralysis_representation",
+		"z_pestilenzerspueren_representation",
+		"z_ruhekoerper_representation",
+		"z_satuariasherrlichkeit_representation",
+		"z_schadenszauberbannen_representation",
+		"z_schleierderunwissenheit_representation",
+		"z_seelentiererkennen_representation",
+		"z_staubwandle_representation",
+		"z_steinwandle_representation",
+		"z_stimmendeswindes_representation",
+		"z_sumuselixiere_representation",
+		"z_tempusstasis_representation",
+		"z_tierebesprechen_representation",
+		"z_tlalucsodem_representation",
+		"z_toteshandle_representation",
+		"z_unberuehrt_representation",
+		"z_unsichtbarerjaeger_representation",
+		"z_veraenderungaufheben_representation",
+		"z_verstaendigungstoeren_representation",
+		"z_verwandlungbeenden_representation",
+		"z_wandausflammen_representation",
+		"z_warmesblut_representation",
+		"z_warmesgefriere_representation",
+		"z_weicheserstarre_representation",
+		"z_weisheitderbaeume_representation",
+		"z_zornderelemente_representation",
+		"z_zungelaehmen_representation"
+	];
+
+	safeGetAttrs(attrsToGet, function (v) {
+		var attrsToChange = {};
+
+		for (property in attrMap)
+		{
+			let oldAttr = attrMap[property];
+			if (v[oldAttr] === 0)
+			{
+				v[oldAttr] = "";
+			}
+			attrsToChange[property] = v[oldAttr];
 		}
 		debugLog(caller, attrsToChange);
 		safeSetAttrs(attrsToChange, {}, function () {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -7682,7 +7682,7 @@
 						<button type="roll" name="roll_z_aengstelindern" value="@{z_aengstelindern_action}"> <span>Ängste lindern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_aengstelindern_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_angste_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_angste">
 					<input type="number" class="talent-taw" name="attr_ZfW_angste" min="0" value="0">
 					<div class="talent-cell talent-taw">23</div>
@@ -7697,7 +7697,7 @@
 						<button type="roll" name="roll_z_animatio" value="@{z_animatio_action}"> <span>Animatio Stummer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_animatio_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_animato_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Animato">
 					<input type="number" class="talent-taw" name="attr_ZfW_Animato" min="0" value="0">
 					<div class="talent-cell talent-taw">24</div>
@@ -7903,7 +7903,7 @@
 						<button type="roll" name="roll_z_augedeslimbus" value="@{z_augedeslimbus_action}"> <span>Auge des Limbus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_augedeslimbus_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Auge_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Auge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Auge" min="0" value="0">
 					<div class="talent-cell talent-taw">32</div>
@@ -8008,7 +8008,7 @@
 						<button type="roll" name="roll_z_baerenruhe" value="@{z_baerenruhe_action}"> <span>Bärenruhe Winterschlaf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Modifikator für die Dauer des Schlafs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_baerenruhe_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Barenruhe_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Barenruhe">
 					<input type="number" class="talent-taw" name="attr_ZfW_Barenruhe" min="0" value="0">
 					<div class="talent-cell talent-taw">40</div>
@@ -8023,7 +8023,7 @@
 						<button type="roll" name="roll_z_beherrschungbrechen" value="@{z_beherrschungbrechen_action}"> <span>Beherrschung brechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_beherrschungbrechen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Beherrschung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Beherrschung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Beherrschung" min="0" value="0">
 					<div class="talent-cell talent-taw">41</div>
@@ -8068,7 +8068,7 @@
 						<button type="roll" name="roll_z_bewegungstoeren" value="@{z_bewegungstoeren_action}"> <span>Bewegung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_bewegungstoeren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Bewegung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Bewegung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bewegung" min="0" value="0">
 					<div class="talent-cell talent-taw">43</div>
@@ -8188,7 +8188,7 @@
 						<button type="roll" name="roll_z_boeserblick" value="@{z_boeserblick_action}"> <span>Böser Blick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_boeserblick_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_boser_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_boser">
 					<input type="number" class="talent-taw" name="attr_ZfW_boser" min="0" value="0">
 					<div class="talent-cell talent-taw">50</div>
@@ -8368,7 +8368,7 @@
 						<button type="roll" name="roll_z_daemonenbann" value="@{z_daemonenbann_action}"> <span>Dämonenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_daemonenbann_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_damonenbann_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_damonenbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_damonenbann" min="0" value="0">
 					<div class="talent-cell talent-taw">63</div>
@@ -8428,7 +8428,7 @@
 						<button type="roll" name="roll_z_dichterunddenker" value="@{z_dichterunddenker_action}"> <span>Dichter und Denker</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_dichterunddenker_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_dichter_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_dichter">
 					<input type="number" class="talent-taw" name="attr_ZfW_dichter" min="0" value="0">
 					<div class="talent-cell talent-taw">67</div>
@@ -8503,7 +8503,7 @@
 						<button type="roll" name="roll_z_eigenschaftwiederherstellen" value="@{z_eigenschaftwiederherstellen_action}"> <span>Eigenschaft wiederherstellen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_eigenschaftwiederherstellen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_eigenschaft_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_eigenschaft">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigenschaft" min="0" value="0">
 					<div class="talent-cell talent-taw">73</div>
@@ -8518,7 +8518,7 @@
 						<button type="roll" name="roll_z_eigneaengste" value="@{z_eigneaengste_action}"> <span>Eigne Ängste quälen dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_eigneaengste_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_eigne_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_eigne">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigne" min="0" value="0">
 					<div class="talent-cell talent-taw">74</div>
@@ -8533,7 +8533,7 @@
 						<button type="roll" name="roll_z_einflussbannen" value="@{z_einflussbannen_action}"> <span>Einfluss bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_einflussbannen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_einfluss_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_einfluss">
 					<input type="number" class="talent-taw" name="attr_ZfW_einfluss" min="0" value="0">
 					<div class="talent-cell talent-taw">75</div>
@@ -8548,7 +8548,7 @@
 						<button type="roll" name="roll_z_einsmitdernatur" value="@{z_einsmitdernatur_action}"> <span>Eins mit der Natur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_einsmitdernatur_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_eins_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_eins">
 					<input type="number" class="talent-taw" name="attr_ZfW_eins" min="0" value="0">
 					<div class="talent-cell talent-taw">76</div>
@@ -8623,7 +8623,7 @@
 						<button type="roll" name="roll_z_elementarerdiener" value="@{z_elementarerdiener_action}"> <span>Elementarer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_elementarerdiener_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_elementarer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_elementarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_elementarer" min="0" value="0">
 					<div class="talent-cell talent-taw">80</div>
@@ -8668,7 +8668,7 @@
 						<button type="roll" name="roll_z_erinnerungverlassedich" value="@{z_erinnerungverlassedich_action}"> <span>Erinnerung verlasse dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_erinnerungverlassedich_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_erinnerung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_erinnerung">
 					<input type="number" class="talent-taw" name="attr_ZfW_erinnerung" min="0" value="0">
 					<div class="talent-cell talent-taw">82</div>
@@ -8788,7 +8788,7 @@
 						<button type="roll" name="roll_z_flimflam" value="@{z_flimflam_action}"> <span>Flim Flam Funkel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
-					<input type="text" class="talent-rep" name="attr_z_flimflam_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_flim_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_flim">
 					<input type="number" class="talent-taw" name="attr_ZfW_flim" min="0" value="0">
 					<div class="talent-cell talent-taw">87</div>
@@ -8803,7 +8803,7 @@
 						<button type="roll" name="roll_z_fluchderpestilenz" value="@{z_fluchderpestilenz_action}"> <span>Fluch der Pestilenz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_fluchderpestilenz_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_fluch_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_fluch">
 					<input type="number" class="talent-taw" name="attr_ZfW_fluch" min="0" value="0">
 					<div class="talent-cell talent-taw">88</div>
@@ -8938,7 +8938,7 @@
 						<button type="roll" name="roll_z_gefaessderjahre" value="@{z_gefaessderjahre_action}"> <span>Gefäß der Jahre</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_gefaessderjahre_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_gefass_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_gefass">
 					<input type="number" class="talent-taw" name="attr_ZfW_gefass" min="0" value="0">
 					<div class="talent-cell talent-taw">95</div>
@@ -9043,7 +9043,7 @@
 						<button type="roll" name="roll_z_granitundmarmor" value="@{z_granitundmarmor_action}"> <span>Granit und Marmor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_granitundmarmor_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_granit_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_granit">
 					<input type="number" class="talent-taw" name="attr_ZfW_granit" min="0" value="0">
 					<div class="talent-cell talent-taw">99</div>
@@ -9118,7 +9118,7 @@
 						<button type="roll" name="roll_z_harmlosegestalt" value="@{z_harmlosegestalt_action}"> <span>Harmlose Gestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_harmlosegestalt_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_harmlose_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Harmlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_Harmlose" min="0" value="0">
 					<div class="talent-cell talent-taw">103</div>
@@ -9133,7 +9133,7 @@
 						<button type="roll" name="roll_z_hartesschmelze" value="@{z_hartesschmelze_action}"> <span>Hartes schmelze!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_hartesschmelze_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hartes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hartes">
 					<input type="number" class="talent-taw" name="attr_ZfW_hartes" min="0" value="0">
 					<div class="talent-cell talent-taw">104</div>
@@ -9178,7 +9178,7 @@
 						<button type="roll" name="roll_z_heilkraftbannen" value="@{z_heilkraftbannen_action}"> <span>Heilkraft bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_heilkraftbannen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_heilkraft_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_heilkraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_heilkraft" min="0" value="0">
 					<div class="talent-cell talent-taw">107</div>
@@ -9193,7 +9193,7 @@
 						<button type="roll" name="roll_z_hellsichttrueben" value="@{z_hellsichttrueben_action}"> <span>Hellsicht trüben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_hellsichttrueben_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hellsicht_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hellsicht">
 					<input type="number" class="talent-taw" name="attr_ZfW_hellsicht" min="0" value="0">
 					<div class="talent-cell talent-taw">108</div>
@@ -9208,7 +9208,7 @@
 						<button type="roll" name="roll_z_herbeirufungvereiteln" value="@{z_herbeirufungvereiteln_action}"> <span>Herbeirufung vereiteln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_herbeirufungvereiteln_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_herbeirufung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_herbeirufung">
 					<input type="number" class="talent-taw" name="attr_ZfW_herbeirufung" min="0" value="0">
 					<div class="talent-cell talent-taw">109</div>
@@ -9223,7 +9223,7 @@
 						<button type="roll" name="roll_z_herrueberdastierreich" value="@{z_herrueberdastierreich_action}"> <span>Herr über das Tierreich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_herrueberdastierreich_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_herr_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_herr">
 					<input type="number" class="talent-taw" name="attr_ZfW_herr" min="0" value="0">
 					<div class="talent-cell talent-taw">110</div>
@@ -9238,7 +9238,7 @@
 						<button type="roll" name="roll_z_herzschlagruhe" value="@{z_herzschlagruhe_action}"> <span>Herzschlag ruhe!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_herzschlagruhe_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_herzschlag_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_herzschlag">
 					<input type="number" class="talent-taw" name="attr_ZfW_herzschlag" min="0" value="0">
 					<div class="talent-cell talent-taw">111</div>
@@ -9358,7 +9358,7 @@
 						<button type="roll" name="roll_z_hilfreichetatze" value="@{z_hilfreichetatze_action}"> <span>Hilfreiche Tatze</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="geistige Magieresistenz des Tieres">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_hilfreichetatze_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hilfreiche_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hilfreiche">
 					<input type="number" class="talent-taw" name="attr_ZfW_hilfreiche" min="0" value="0">
 					<div class="talent-cell talent-taw">118</div>
@@ -9373,7 +9373,7 @@
 						<button type="roll" name="roll_z_hoellenpein" value="@{z_hoellenpein_action}"> <span>Höllenpein zerreiße dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_hoellenpein_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_hollenpein_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_hollenpein">
 					<input type="number" class="talent-taw" name="attr_ZfW_hollenpein" min="0" value="0">
 					<div class="talent-cell talent-taw">119</div>
@@ -9583,7 +9583,7 @@
 						<button type="roll" name="roll_z_illusionaufloesen" value="@{z_illusionaufloesen_action}"> <span>Illusion auflösen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_illusionaufloesen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_illusion_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_illusion">
 					<input type="number" class="talent-taw" name="attr_ZfW_illusion" min="0" value="0">
 					<div class="talent-cell talent-taw">126</div>
@@ -9703,7 +9703,7 @@
 						<button type="roll" name="roll_z_iribaarshand" value="@{z_iribaarshand_action}"> <span>Iribaars Hand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_iribaarshand_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_iribaars_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_iribaars">
 					<input type="number" class="talent-taw" name="attr_ZfW_iribaars" min="0" value="0">
 					<div class="talent-cell talent-taw">134</div>
@@ -9763,7 +9763,7 @@
 						<button type="roll" name="roll_z_klarumpurum" value="@{z_klarumpurum_action}"> <span>Klarum Purum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Modifikator für die Giftstufe">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_klarumpurum_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_klarum_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_klarum">
 					<input type="number" class="talent-taw" name="attr_ZfW_klarum" min="0" value="0">
 					<div class="talent-cell talent-taw">138</div>
@@ -9823,7 +9823,7 @@
 						<button type="roll" name="roll_z_kommkoboldkomm" value="@{z_kommkoboldkomm_action}"> <span>Komm Kobold Komm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_kommkoboldkomm_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_komm_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_komm">
 					<input type="number" class="talent-taw" name="attr_ZfW_komm" min="0" value="0">
 					<div class="talent-cell talent-taw">142</div>
@@ -9838,7 +9838,7 @@
 						<button type="roll" name="roll_z_koerperlosereise" value="@{z_koerperlosereise_action}"> <span>Körperlose Reise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_koerperlosereise_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_koerperlose_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_koerperlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_koerperlose" min="0" value="0">
 					<div class="talent-cell talent-taw">143</div>
@@ -9853,7 +9853,7 @@
 						<button type="roll" name="roll_z_krabbelnderschrecken" value="@{z_krabbelnderschrecken_action}"> <span>Krabbelnder Schrecken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_krabbelnderschrecken_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_krabbelnder_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_krabbelnder">
 					<input type="number" class="talent-taw" name="attr_ZfW_krabbelnder" min="0" value="0">
 					<div class="talent-cell talent-taw">144</div>
@@ -9868,7 +9868,7 @@
 						<button type="roll" name="roll_z_kraftdeserzes" value="@{z_kraftdeserzes_action}"> <span>Kraft des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_kraftdeserzes_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_kraft_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_kraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft" min="0" value="0">
 					<div class="talent-cell talent-taw">145</div>
@@ -9883,7 +9883,7 @@
 						<button type="roll" name="roll_z_kraftdeshumus" value="@{z_kraftdeshumus_action}"> <span>Kraft des Humus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_kraftdeshumus_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_kraft_humus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_kraft_humus">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft_humus" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9898,7 +9898,7 @@
 						<button type="roll" name="roll_z_kraehenruf" value="@{z_kraehenruf_action}"> <span>Krähenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_kraehenruf_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_krahenruf_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_krahenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_krahenruf" min="0" value="0">
 					<div class="talent-cell talent-taw">146</div>
@@ -9913,7 +9913,7 @@
 						<button type="roll" name="roll_z_kroetensprung" value="@{z_kroetensprung_action}"> <span>Krötensprung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_kroetensprung_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_krotensprung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_krotensprung">
 					<input type="number" class="talent-taw" name="attr_ZfW_krotensprung" min="0" value="0">
 					<div class="talent-cell talent-taw">148</div>
@@ -9958,7 +9958,7 @@
 						<button type="roll" name="roll_z_lachdichgesund" value="@{z_lachdichgesund_action}"> <span>Lach dich gesund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_lachdichgesund_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_lach_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_lach">
 					<input type="number" class="talent-taw" name="attr_ZfW_lach" min="0" value="0">
 					<div class="talent-cell talent-taw">151</div>
@@ -9988,7 +9988,7 @@
 						<button type="roll" name="roll_z_langerlulatsch" value="@{z_langerlulatsch_action}"> <span>Langer Lulatsch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_langerlulatsch_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_langer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_langer">
 					<input type="number" class="talent-taw" name="attr_ZfW_langer" min="0" value="0">
 					<div class="talent-cell talent-taw">153</div>
@@ -10003,7 +10003,7 @@
 						<button type="roll" name="roll_z_lastdesalters" value="@{z_lastdesalters_action}"> <span>Last des Alters</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_lastdesalters_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_last_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_last">
 					<input type="number" class="talent-taw" name="attr_ZfW_last" min="0" value="0">
 					<div class="talent-cell talent-taw">154</div>
@@ -10138,7 +10138,7 @@
 						<button type="roll" name="roll_z_levthansfeuer" value="@{z_levthansfeuer_action}"> <span>Levthans Feuer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_levthansfeuer_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_levthans_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_levthans">
 					<input type="number" class="talent-taw" name="attr_ZfW_levthans" min="0" value="0">
 					<div class="talent-cell talent-taw">166</div>
@@ -10153,7 +10153,7 @@
 						<button type="roll" name="roll_z_limbusversiegeln" value="@{z_limbusversiegeln_action}"> <span>Limbus versiegeln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_limbusversiegeln_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_limbus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_limbus">
 					<input type="number" class="talent-taw" name="attr_ZfW_limbus" min="0" value="0">
 					<div class="talent-cell talent-taw">167</div>
@@ -10183,7 +10183,7 @@
 						<button type="roll" name="roll_z_lungedesleviatan" value="@{z_lungedesleviatan_action}"> <span>Lunge des Leviatan</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_lungedesleviatan_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_lunge_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_lunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_lunge" min="0" value="0">
 					<div class="talent-cell talent-taw">169</div>
@@ -10198,7 +10198,7 @@
 						<button type="roll" name="roll_z_madasspiegel" value="@{z_madasspiegel_action}"> <span>Madas Spiegel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_madasspiegel_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_madas_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_madas">
 					<input type="number" class="talent-taw" name="attr_ZfW_madas" min="0" value="0">
 					<div class="talent-cell talent-taw">170</div>
@@ -10213,7 +10213,7 @@
 						<button type="roll" name="roll_z_magischerraub" value="@{z_magischerraub_action}"> <span>Magischer Raub</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_magischerraub_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_magischer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_magischer">
 					<input type="number" class="talent-taw" name="attr_ZfW_magischer" min="0" value="0">
 					<div class="talent-cell talent-taw">171</div>
@@ -10348,7 +10348,7 @@
 						<button type="roll" name="roll_z_metamagieneutralisieren" value="@{z_metamagieneutralisieren_action}"> <span>Metamagie neutralisieren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_metamagieneutralisieren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_metamagie_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_metamagie">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamagie" min="0" value="0">
 					<div class="talent-cell talent-taw">179</div>
@@ -10363,7 +10363,7 @@
 						<button type="roll" name="roll_z_metamorphofelsenform" value="@{z_metamorphofelsenform_action}"> <span>Metamorpho Felsenform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_metamorphofelsenform_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_metamorpho_felsenform_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho_felsenform">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho_felsenform" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -10378,7 +10378,7 @@
 						<button type="roll" name="roll_z_metamorphogletscherform" value="@{z_metamorphogletscherform_action}"> <span>Metamorpho Gletscherform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_metamorphogletscherform_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_metamorpho_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -10423,7 +10423,7 @@
 						<button type="roll" name="roll_z_murksundpatz" value="@{z_murksundpatz_action}"> <span>Murks und Patz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="höchste Magieresistenz plus Anzahl Betroffener">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_murksundpatz_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_murks_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_murks">
 					<input type="number" class="talent-taw" name="attr_ZfW_murks" min="0" value="0">
 					<div class="talent-cell talent-taw">184</div>
@@ -10528,7 +10528,7 @@
 						<button type="roll" name="roll_z_objectoobscuro" value="@{z_objectoobscuro_action}"> <span>Objecto Obscuro</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
-					<input type="text" class="talent-rep" name="attr_z_objectoobscuro_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_objecto_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_objecto">
 					<input type="number" class="talent-taw" name="attr_ZfW_objecto" min="0" value="0">
 					<div class="talent-cell talent-taw">191</div>
@@ -10573,7 +10573,7 @@
 						<button type="roll" name="roll_z_objektentzaubern" value="@{z_objektentzaubern_action}"> <span>Objekt entzaubern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_objektentzaubern_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_objekt_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_objekt">
 					<input type="number" class="talent-taw" name="attr_ZfW_objekt" min="0" value="0">
 					<div class="talent-cell talent-taw">194</div>
@@ -10693,7 +10693,7 @@
 						<button type="roll" name="roll_z_paralysis" value="@{z_paralysis_action}"> <span>Paralysis starr wie Stein</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_paralysis_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_paralys_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_paralys">
 					<input type="number" class="talent-taw" name="attr_ZfW_paralys" min="0" value="0">
 					<div class="talent-cell talent-taw">202</div>
@@ -10753,7 +10753,7 @@
 						<button type="roll" name="roll_z_pestilenzerspueren" value="@{z_pestilenzerspueren_action}"> <span>Pestilenz erspüren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Entdeckungsschwierigkeit der Krankheit oder der Giftstufe des Giftes">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_pestilenzerspueren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_pestilenz_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_pestilenz">
 					<input type="number" class="talent-taw" name="attr_ZfW_pestilenz" min="0" value="0">
 					<div class="talent-cell talent-taw">207</div>
@@ -11068,7 +11068,7 @@
 						<button type="roll" name="roll_z_satuariasherrlichkeit" value="@{z_satuariasherrlichkeit_action}"> <span>Satuarias Herrlichkeit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_satuariasherrlichkeit_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_satuarias_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_satuarias">
 					<input type="number" class="talent-taw" name="attr_ZfW_satuarias" min="0" value="0">
 					<div class="talent-cell talent-taw">224</div>
@@ -11098,7 +11098,7 @@
 						<button type="roll" name="roll_z_schadenszauberbannen" value="@{z_schadenszauberbannen_action}"> <span>Schadenszauber bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_schadenszauberbannen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_schadenszauber_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_schadenszauber">
 					<input type="number" class="talent-taw" name="attr_ZfW_schadenszauber" min="0" value="0">
 					<div class="talent-cell talent-taw">226</div>
@@ -11188,7 +11188,7 @@
 						<button type="roll" name="roll_z_schleierderunwissenheit" value="@{z_schleierderunwissenheit_action}"> <span>Schleier der Unwissenheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
-					<input type="text" class="talent-rep" name="attr_z_schleierderunwissenheit_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_schleier_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_schleier">
 					<input type="number" class="talent-taw" name="attr_ZfW_schleier" min="0" value="0">
 					<div class="talent-cell talent-taw">231</div>
@@ -11248,7 +11248,7 @@
 						<button type="roll" name="roll_z_seelentiererkennen" value="@{z_seelentiererkennen_action}"> <span>Seelentier erkennen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_seelentiererkennen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_seelentier_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_seelentier">
 					<input type="number" class="talent-taw" name="attr_ZfW_seelentier" min="0" value="0">
 					<div class="talent-cell talent-taw">234</div>
@@ -11518,7 +11518,7 @@
 						<button type="roll" name="roll_z_staubwandle" value="@{z_staubwandle_action}"> <span>Staub wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golemids, das Grundmaterial, die elementare Reinheit des Ausgangsmaterials, der Größe des Golemids, der Eigenschaften des Golemids, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golemids und die Talentwerte des Golemids">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_staubwandle_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_staub_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_staub">
 					<input type="number" class="talent-taw" name="attr_ZfW_staub" min="0" value="0">
 					<div class="talent-cell talent-taw">250</div>
@@ -11548,7 +11548,7 @@
 						<button type="roll" name="roll_z_steinwandle" value="@{z_steinwandle_action}"> <span>Stein wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golems, das Grundmaterial, die Affinität des Materials zum Erzdämonen, der Größe des Golems, der Eigenschaften des Golems, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golems und die Talentwerte des Golems">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_steinwandle_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_stein_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_stein">
 					<input type="number" class="talent-taw" name="attr_ZfW_stein" min="0" value="0">
 					<div class="talent-cell talent-taw">251</div>
@@ -11578,7 +11578,7 @@
 						<button type="roll" name="roll_z_stimmendeswindes" value="@{z_stimmendeswindes_action}"> <span>Stimmen des Windes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_stimmendeswindes_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Stimmen_des_Windes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Stimmen_des_Windes">
 					<input type="number" class="talent-taw" name="attr_ZfW_Stimmen_des_Windes" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11608,7 +11608,7 @@
 						<button type="roll" name="roll_z_sumuselixiere" value="@{z_sumuselixiere_action}"> <span>Sumus Elixiere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
-					<input type="text" class="talent-rep" name="attr_z_sumuselixiere_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_sumus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_sumus">
 					<input type="number" class="talent-taw" name="attr_ZfW_sumus" min="0" value="0">
 					<div class="talent-cell talent-taw">253</div>
@@ -11653,7 +11653,7 @@
 						<button type="roll" name="roll_z_tempusstasis" value="@{z_tempusstasis_action}"> <span>Tempus Stasis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK + <span class="abbr" title="1 pro Kampfrunde">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_tempusstasis_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_tempus_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_tempus">
 					<input type="number" class="talent-taw" name="attr_ZfW_tempus" min="0" value="0">
 					<div class="talent-cell talent-taw">255</div>
@@ -11683,7 +11683,7 @@
 						<button type="roll" name="roll_z_tierebesprechen" value="@{z_tierebesprechen_action}"> <span>Tiere besprechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Anzahl zu heilender regeltechnischer Wunden, der Stufe der Krankheit oder der halben Giftstufe">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_tierebesprechen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_tiere_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_tiere">
 					<input type="number" class="talent-taw" name="attr_ZfW_tiere" min="0" value="0">
 					<div class="talent-cell talent-taw">256</div>
@@ -11728,7 +11728,7 @@
 						<button type="roll" name="roll_z_tlalucsodem" value="@{z_tlalucsodem_action}"> <span>Tlalucs Odem Pestgestank</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_tlalucsodem_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_tlalucs_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_tlalucs">
 					<input type="number" class="talent-taw" name="attr_ZfW_tlalucs" min="0" value="0">
 					<div class="talent-cell talent-taw">258</div>
@@ -11743,7 +11743,7 @@
 						<button type="roll" name="roll_z_toteshandle" value="@{z_toteshandle_action}"> <span>Totes Handle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_toteshandle_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_totes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_totes">
 					<input type="number" class="talent-taw" name="attr_ZfW_totes" min="0" value="0">
 					<div class="talent-cell talent-taw">259</div>
@@ -11833,7 +11833,7 @@
 						<button type="roll" name="roll_z_unberuehrt" value="@{z_unberuehrt_action}"> <span>Unberührt von Satinav</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO + <span class="abbr" title="1 pro Tag Wirkungsdauer über den ersten hinaus">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_unberuehrt_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_unberuhrt_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_unberuhrt">
 					<input type="number" class="talent-taw" name="attr_ZfW_unberuhrt" min="0" value="0">
 					<div class="talent-cell talent-taw">264</div>
@@ -11878,7 +11878,7 @@
 						<button type="roll" name="roll_z_unsichtbarerjaeger" value="@{z_unsichtbarerjaeger_action}"> <span>Unsichtbarer Jäger</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
-					<input type="text" class="talent-rep" name="attr_z_unsichtbarerjaeger_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_unsichtbarer_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_unsichtbarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_unsichtbarer" min="0" value="0">
 					<div class="talent-cell talent-taw">266</div>
@@ -11908,7 +11908,7 @@
 						<button type="roll" name="roll_z_veraenderungaufheben" value="@{z_veraenderungaufheben_action}"> <span>Veränderung aufheben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_veraenderungaufheben_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_veranderung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_veranderung">
 					<input type="number" class="talent-taw" name="attr_ZfW_veranderung" min="0" value="0">
 					<div class="talent-cell talent-taw">267</div>
@@ -11938,7 +11938,7 @@
 						<button type="roll" name="roll_z_verstaendigungstoeren" value="@{z_verstaendigungstoeren_action}"> <span>Verständigung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_verstaendigungstoeren_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_verstandigung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_verstandigung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verstandigung" min="0" value="0">
 					<div class="talent-cell talent-taw">269</div>
@@ -11953,7 +11953,7 @@
 						<button type="roll" name="roll_z_verwandlungbeenden" value="@{z_verwandlungbeenden_action}"> <span>Verwandlung beenden</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_verwandlungbeenden_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_verwandlung_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_verwandlung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verwandlung" min="0" value="0">
 					<div class="talent-cell talent-taw">270</div>
@@ -12043,7 +12043,7 @@
 						<button type="roll" name="roll_z_wandausflammen" value="@{z_wandausflammen_action}"> <span>Wand aus Flammen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
-					<input type="text" class="talent-rep" name="attr_z_wandausflammen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Wand_aus_Flammen_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Wand_aus_Flammen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wand_aus_Flammen" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -12058,7 +12058,7 @@
 						<button type="roll" name="roll_z_warmesblut" value="@{z_warmesblut_action}"> <span>Warmes Blut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
-					<input type="text" class="talent-rep" name="attr_z_warmesblut_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_warmes_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_warmes">
 					<input type="number" class="talent-taw" name="attr_ZfW_warmes" min="0" value="0">
 					<div class="talent-cell talent-taw">276</div>
@@ -12073,7 +12073,7 @@
 						<button type="roll" name="roll_z_warmesgefriere" value="@{z_warmesgefriere_action}"> <span>Warmes gefriere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_warmesgefriere_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_Warmes_gefriere_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_Warmes_gefriere">
 					<input type="number" class="talent-taw" name="attr_ZfW_Warmes_gefriere" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -12118,7 +12118,7 @@
 						<button type="roll" name="roll_z_weicheserstarre" value="@{z_weicheserstarre_action}"> <span>Weiches erstarre!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
-					<input type="text" class="talent-rep" name="attr_z_weicheserstarre_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_weiches_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_weiches">
 					<input type="number" class="talent-taw" name="attr_ZfW_weiches" min="0" value="0">
 					<div class="talent-cell talent-taw">278</div>
@@ -12148,7 +12148,7 @@
 						<button type="roll" name="roll_z_weisheitderbaeume" value="@{z_weisheitderbaeume_action}"> <span>Weisheit der Bäume</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_weisheitderbaeume_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_weisheit_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_weisheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_weisheit" min="0" value="0">
 					<div class="talent-cell talent-taw">280</div>
@@ -12418,7 +12418,7 @@
 						<button type="roll" name="roll_z_zornderelemente" value="@{z_zornderelemente_action}"> <span>Zorn der Elemente</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Elementspezialisierung">Mod.</span></div>
-					<input type="text" class="talent-rep" name="attr_z_zornderelemente_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_zorn_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_zorn">
 					<input type="number" class="talent-taw" name="attr_ZfW_zorn" min="0" value="0">
 					<div class="talent-cell talent-taw">296</div>
@@ -12433,7 +12433,7 @@
 						<button type="roll" name="roll_z_zungelaehmen" value="@{z_zungelaehmen_action}"> <span>Zunge lähmen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
-					<input type="text" class="talent-rep" name="attr_z_zungelaehmen_representation" list="magic_representations_nonesoteric_short">
+					<input type="text" class="talent-rep" name="attr_z_zunge_representation" list="magic_representations_nonesoteric_short">
 					<input type="text" class="talent-spez" name="attr_Spez_zunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_zunge" min="0" value="0">
 					<div class="talent-cell talent-taw">297</div>
@@ -15631,20 +15631,46 @@
 		</p>
 		<h3>Infos zum Charakterbogen</h3>
 		<p>Dieser Charakterbogen wird weiterentwickelt. Dabei bleibt es nicht aus, dass alte Daten nicht mehr ohne Weiteres in den veränderten Bogen passen. Wenn es nötig wird, werden die alten Daten automatisch im Hintergrund umgewandelt. Da es aber immer zu Fehlern kommen kann, stehen für jeden Versionssprung hier weiterhin die alten Daten (inklusive ihrer Funktionalität) zur Verfügung. So wird sichergestellt, dass keine Daten verlorengehen und das Spiel weitergehen kann.</p>
-		<p>Zu besonderen Updates&nbsp;&ndash;&nbsp;sprich: alles, was über einfache Fehlerbehebungen und eher kleine kosmetische Veränderungen hinausgeht&nbsp;&ndash;&nbsp;gibt es in der Regel, wenn auch nicht immer pünktlich zum Release einer neuen Charakterbogenversion, Videos mit vielen Details: <br>
+		<p>Zu besonderen Updates&nbsp;&ndash;&nbsp;sprich: alles, was über einfache Fehlerbehebungen und eher kleine kosmetische Veränderungen hinausgeht&nbsp;&ndash;&nbsp;gibt es in der Regel, wenn auch nicht immer pünktlich zum Release einer neuen Charakterbogenversion, Videos mit vielen Details. Die Playlist liegt unter folgender Adresse: <br>
 				<input type="text" class="selectable-text" style="width: 52em" value="https://www.youtube.com/watch?v=l2SCwz51T9g&amp;list=PLGBXxa8pcNCqzNe4CrKvy-_QgjfgLDOZ-">
 		</p>
+		<p>In der Überschrift zu den einzelnen Versionen zeigt ein Filmklappen-Emoji (&#x1f3ac;) an, dass ein Link zum entsprechenden Video angegeben ist.</p>
 		<p>Änderungen &bdquo;unter der Haube&ldquo; erspare ich euch an dieser Stelle. Wer Interesse daran hat, findet all die Infos auf GitHub (siehe oben). Bei Bedarf könnt ihr auch gerne fragen: &bdquo;Isurandil&ldquo; auf (in stark fallender Lesehäufigkeit) Orkenspalter, Mastodon (@Isurandil@mastodon.online), Twitter, YouTube und Roll20.</p>
 
 		<details open>
 			<summary>
-				<h4>Update auf Version 20240510</h4>
+				<h4>Update auf Version 20240519</h4>
 			</summary>
+			<h5>Design</h5>
+			<p>
+				<ul>
+					<li>Tab &bdquo;Info&ldquo;: Updates, zu denen ein Video erschienen ist, sind nun mit einem Filmklappen-Emoji markiert und der Link zum Video ist angegeben.</li>
+					</li>
+				</ul>
+			</p>
+			<h5>Fehlerbehebungen</h5>
+			<p>
+				<ul>
+					<li>Repräsentationen: Einige Zauber haben die beim Zauber angegebene Repräsentation ignoriert und damit keine Eigenschaften ersetzt. Nun sollten sämtliche Zauber wie erwartet funktionieren.
+						<ul>
+							<li>Die betroffenen Zauber waren: Animatio, Auris Nasus Oculus, Band und Fessel, Beherrschung brechen, Bewegung stören, Dichter und Denker, Eigenschaft wiederherstellen, Elementarer Diener, Flim Flam, Fluch der Pestilenz, Gefäß der Jahre, Harmlose Gestalt, Hartes schmelze, Heilkraft bannen, Hellsicht trüben, Höllenpein, Illusion auflösen, Klarum Purum, Körperlose Reise, Kraft des Erzes, Limbus versiegeln, Madas Spiegel, Magischer Raub, Metamagie neutralisieren, Metamorpho Felsenform, Metamorpho Gletscherform, Murks und Patz, Objecto obscuro, Objekt entzaubern, Pestilenz erspüren, Ruhe Körper, Schleier der Unwissenheit, Seelentier erkennen, Staub wandle, Stimmen des Windes, Tempus Stasis, Unberührt, Veränderung aufheben, Verständigung stören, Verwandlung beenden, Wand aus Flammen, Warmes Blut, Warmes Gefriere, Weiches erstarre.</li>
+							<li>Einige weitere Zauber waren zwar vom selben Fehler betroffen, der sich auf diese aber nicht ausgewirken konnte, da ohnehin keine Eigenschaften ersetzt werden konnten: Ängste lindern, Auge des Limbus, Bärenruhe, Beschwörung vereiteln, Böser Blick, Dämonenbann, Eigne Ängste, Einfluss bannen, Eins mit der Natur, Erinnerung verlasse dich, Granit und Marmor, Herbeirufung vereiteln, Herr über das Tierreich, Herzschlag ruhe, Hilfreiche Tatze, Iribaars Hand, Komm Kobold Komm, Krabbelnder Schrecken, Krähenruf, Kraft des Humus, Krötensprung, Lach dich gesund, Langer Lulatsch, Last des Alters, Levthans Feuer, Lunge des Leviatan, Paralysis, Satuarias Herrlichkeit, Schadenszauber bannen, Stein wandle, Sumus Elixiere, Tiere besprechen, Tlalucs Odem, Totes handle, Unsichtbarer Jäger, Weisheit der Bäume, Zorn der Elemente, Zunge lähmen.</li>
+						</ul>
+					</li>
+				</ul>
+			</p>
+		</details>
+
+		<details open>
+			<summary>
+				<h4>&#x1f3ac; Update auf Version 20240510</h4>
+			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=y_SQMOk_Oe8"></p>
 			<h5>Neues Feature: Repräsentationen für Zauber</h5>
 			<p>
 				<ul>
 					<li>Für jeden Zauber kann die dazugehörige Repräsentation angegeben werden. Wählbar sind alle Repräsentationen der Jetztzeit, alle Repräsentationen der Dunklen Zeiten und ein Platzhalter für Magiedilettanten: Ach, Bor, Dil, Dru, Elf, Geo, Hex, Mag, Srl und Sch; Alh, Geo/Dru, Gro, Gül, Kop, Mud und Sat. Außergewöhnliche Repräsentationen wie jene der Drachen, der Krakonier oder der Schratigen stehen nicht zur Wahl.</li>
-					<li>Es können auch eigene Repräsentationen eingetragen werden, weshalb die außergewöhnlichen Repräsentationen so ebenfalls eingetragen werden können- <span class="highlight">Regeltechnisch berücksichtigt</span> werden aktuell jedoch nur <span class="highlight">Ach, Elf und Kop</span>.</li>
+					<li>Es können auch eigene Repräsentationen eingetragen werden, weshalb die außergewöhnlichen Repräsentationen so ebenfalls eingetragen werden können. <span class="highlight">Regeltechnisch berücksichtigt</span> werden aktuell jedoch nur <span class="highlight">Ach, Elf und Kop</span>.</li>
 					<li>Allen drei Repräsentationen ist gemein, dass <span class="highlight">in der Zauberprobe Eigenschaften ersetzt</span> werden dürfen. Beim Würfeln der Probe wählt der Charakterbogen stets die <span class="highlight">günstigsten Eigenschaften für den Wurf automatisch</span> aus.</li>
 					<li>Es sind stets mehrere Repräsentationseinträge möglich, dabei gilt es jedoch die folgenden Punkte zu beachten:
 						<ul>
@@ -15784,8 +15810,9 @@
 
 		<details>
 			<summary>
-				<h4>Update auf Version 20230618</h4>
+				<h4>&#x1f3ac; Update auf Version 20230618</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=vGTkwBy1uWE"></p>
 			<h5>Neues Betafeature &bdquo;Bestätigungswürfe im Kampf einzeln/manuell würfeln&ldquo;</h5>
 			<p>
 				<ul>
@@ -16428,8 +16455,9 @@
 
 		<details>
 			<summary>
-				<h4>Update auf Version 20220116</h4>
+				<h4>&#x1f3ac; Update auf Version 20220116</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=taCNRr3_08s"></p>
 			<h5>Einführung von Betafeatures</h5>
 			<p>
 				<ul>
@@ -16627,16 +16655,19 @@
 
 		<details>
 			<summary>
-				<h4>Updates auf Version 20210415</h4>
+				<h4>&#x1f3ac; Updates auf Version 20210415</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=5sOdcxNbn2s"></p>
 			<p>Beim letzten Update habe ich versehentlich einen sehr ärgerlichen Fehler eingebaut, der verhindert hat, dass der TP-Würfel-Knopf von Nahkampfwaffen funktioniert. Mit dieser Version wurde dies behoben.</p>
 			<p><strong>Hinweis:</strong> Wer einen der Workarounds benutzt hat, sollte die im Zuge dessen angelegten Attribute &bdquo;TP_W_Aktiv&ldquo; und &bdquo;TP_Bonus_Aktiv&ldquo; wieder löschen. Mehr Infos dazu gibt es in einem Video.</p>
 		</details>
 
 		<details>
 			<summary>
-				<h4>Updates auf Versionen 20200809 und 20210413</h4>
+				<h4>&#x1f3ac; Updates auf Versionen 20200809 und 20210413</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=rqgyaCXuMUM"></p>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=le3ys6T389o"></p>
 			<p>Es werden zwar gewisse Migrationen durchgeführt, dabei aber keine größeren Umstellungen vorgenommen. Daher gibt es hier auch keine alten Daten, die möglicherweise gerettet werden müssten. :)</p>
 		</details>
 
@@ -16649,8 +16680,9 @@
 
 		<details>
 			<summary>
-				<h4>Update auf Version 20190427</h4>
+				<h4>&#x1f3ac; Update auf Version 20190427</h4>
 			</summary>
+			<p>Video: <input type="text" class="selectable-text" style="width: 30em" value="https://www.youtube.com/watch?v=a6KadwTIcQY"></p>
 			<p>Gaben und Metatalente wurden verändert, sodass eine Migration der alten Daten notwendig wurde. Spalten für spezielle Erfahrungen (SE) wurden entfernt, da diese ausschließlich für die Steigerung relevant sind, Steigerungen aber seitens Roll20 nicht im Charakterbogen umgesetzt sein dürfen. Um die Information dauerhafter zu speichern, empfiehlt es sich die Notizen zu benutzen. Spezielle Erfahrungen in Metatalenten sind darüber hinaus nicht regelkonform.</p>
 			<h5>Gaben</h5>
 			<fieldset class="repeating_GabenTalente">
@@ -16756,7 +16788,7 @@
 	</div>
 <!-- sheet section info end -->
 <!-- sheet footer start -->
-	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240510"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
+	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240519"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
 <!-- sheet footer end -->
 </div>
 <!-- sheet end -->
@@ -22296,7 +22328,8 @@ var versionsWithMigrations = [
 		20220821,
 		20230618,
 		20240414,
-		20240510
+		20240510,
+		20240519
 ];
 
 /*
@@ -23213,6 +23246,201 @@ function migrateTo20240510(migrationChain) {
 		if (valueMap.hasOwnProperty(v["subtag1"]))
 		{
 			attrsToChange["sf_representations"] = valueMap[v["subtag1"]];
+		}
+		debugLog(caller, attrsToChange);
+		safeSetAttrs(attrsToChange, {}, function () {
+			callNextMigration(migrationChain);
+		});
+	});
+}
+
+/*
+	Migration steps:
+	- Migrate attributes to old names (full clean-up of spell name attributes will follow in the future, if that should still be necessary)
+*/
+function migrateTo20240519(migrationChain) {
+	const caller = "migrateTo20240519";
+	debugLog(caller, "Invoked.");
+	const attrMap = {
+		"z_angste_representation": "z_aengstelindern_representation",
+		"z_animato_representation": "z_animatio_representation",
+		"z_Auge_representation": "z_augedeslimbus_representation",
+		"z_Auris_representation": "z_aurisnasusoculus_representation",
+		"z_band_representation": "z_bandundfessel_representation",
+		"z_Barenruhe_representation": "z_baerenruhe_representation",
+		"z_Beherrschung_representation": "z_beherrschungbrechen_representation",
+		"z_Beschworung_representation": "z_beschwoerungvereiteln_representation",
+		"z_Bewegung_representation": "z_bewegungstoeren_representation",
+		"z_boser_representation": "z_boeserblick_representation",
+		"z_damonenbann_representation": "z_daemonenbann_representation",
+		"z_dichter_representation": "z_dichterunddenker_representation",
+		"z_eigenschaft_representation": "z_eigenschaftwiederherstellen_representation",
+		"z_eigne_representation": "z_eigneaengste_representation",
+		"z_einfluss_representation": "z_einflussbannen_representation",
+		"z_eins_representation": "z_einsmitdernatur_representation",
+		"z_elementarer_representation": "z_elementarerdiener_representation",
+		"z_erinnerung_representation": "z_erinnerungverlassedich_representation",
+		"z_flim_representation": "z_flimflam_representation",
+		"z_fluch_representation": "z_fluchderpestilenz_representation",
+		"z_gefass_representation": "z_gefaessderjahre_representation",
+		"z_granit_representation": "z_granitundmarmor_representation",
+		"z_Harmlose_representation": "z_harmlosegestalt_representation",
+		"z_hartes_representation": "z_hartesschmelze_representation",
+		"z_heilkraft_representation": "z_heilkraftbannen_representation",
+		"z_hellsicht_representation": "z_hellsichttrueben_representation",
+		"z_herbeirufung_representation": "z_herbeirufungvereiteln_representation",
+		"z_herr_representation": "z_herrueberdastierreich_representation",
+		"z_herzschlag_representation": "z_herzschlagruhe_representation",
+		"z_hilfreiche_representation": "z_hilfreichetatze_representation",
+		"z_hollenpein_representation": "z_hoellenpein_representation",
+		"z_illusion_representation": "z_illusionaufloesen_representation",
+		"z_iribaars_representation": "z_iribaarshand_representation",
+		"z_klarum_representation": "z_klarumpurum_representation",
+		"z_komm_representation": "z_kommkoboldkomm_representation",
+		"z_koerperlose_representation": "z_koerperlosereise_representation",
+		"z_krabbelnder_representation": "z_krabbelnderschrecken_representation",
+		"z_kraft_representation": "z_kraftdeserzes_representation",
+		"z_kraft_humus_representation": "z_kraftdeshumus_representation",
+		"z_krahenruf_representation": "z_kraehenruf_representation",
+		"z_krotensprung_representation": "z_kroetensprung_representation",
+		"z_lach_representation": "z_lachdichgesund_representation",
+		"z_langer_representation": "z_langerlulatsch_representation",
+		"z_last_representation": "z_lastdesalters_representation",
+		"z_levthans_representation": "z_levthansfeuer_representation",
+		"z_limbus_representation": "z_limbusversiegeln_representation",
+		"z_lunge_representation": "z_lungedesleviatan_representation",
+		"z_madas_representation": "z_madasspiegel_representation",
+		"z_magischer_representation": "z_magischerraub_representation",
+		"z_metamagie_representation": "z_metamagieneutralisieren_representation",
+		"z_metamorpho_felsenform_representation": "z_metamorphofelsenform_representation",
+		"z_metamorpho_representation": "z_metamorphogletscherform_representation",
+		"z_murks_representation": "z_murksundpatz_representation",
+		"z_objecto_representation": "z_objectoobscuro_representation",
+		"z_objekt_representation": "z_objektentzaubern_representation",
+		"z_paralys_representation": "z_paralysis_representation",
+		"z_pestilenz_representation": "z_pestilenzerspueren_representation",
+		"z_ruhe_representation": "z_ruhekoerper_representation",
+		"z_satuarias_representation": "z_satuariasherrlichkeit_representation",
+		"z_schadenszauber_representation": "z_schadenszauberbannen_representation",
+		"z_schleier_representation": "z_schleierderunwissenheit_representation",
+		"z_seelentier_representation": "z_seelentiererkennen_representation",
+		"z_staub_representation": "z_staubwandle_representation",
+		"z_stein_representation": "z_steinwandle_representation",
+		"z_Stimmen_des_Windes_representation": "z_stimmendeswindes_representation",
+		"z_sumus_representation": "z_sumuselixiere_representation",
+		"z_tempus_representation": "z_tempusstasis_representation",
+		"z_tiere_representation": "z_tierebesprechen_representation",
+		"z_tlalucs_representation": "z_tlalucsodem_representation",
+		"z_totes_representation": "z_toteshandle_representation",
+		"z_unberuhrt_representation": "z_unberuehrt_representation",
+		"z_unsichtbarer_representation": "z_unsichtbarerjaeger_representation",
+		"z_veranderung_representation": "z_veraenderungaufheben_representation",
+		"z_verstandigung_representation": "z_verstaendigungstoeren_representation",
+		"z_verwandlung_representation": "z_verwandlungbeenden_representation",
+		"z_Wand_aus_Flammen_representation": "z_wandausflammen_representation",
+		"z_warmes_representation": "z_warmesblut_representation",
+		"z_Warmes_gefriere_representation": "z_warmesgefriere_representation",
+		"z_weiches_representation": "z_weicheserstarre_representation",
+		"z_weisheit_representation": "z_weisheitderbaeume_representation",
+		"z_zorn_representation": "z_zornderelemente_representation",
+		"z_zunge_representation": "z_zungelaehmen_representation"
+	}
+	const attrsToGet = [
+		"z_aengstelindern_representation",
+		"z_animatio_representation",
+		"z_augedeslimbus_representation",
+		"z_aurisnasusoculus_representation",
+		"z_bandundfessel_representation",
+		"z_baerenruhe_representation",
+		"z_beherrschungbrechen_representation",
+		"z_beschwoerungvereiteln_representation",
+		"z_bewegungstoeren_representation",
+		"z_boeserblick_representation",
+		"z_daemonenbann_representation",
+		"z_dichterunddenker_representation",
+		"z_eigenschaftwiederherstellen_representation",
+		"z_eigneaengste_representation",
+		"z_einflussbannen_representation",
+		"z_einsmitdernatur_representation",
+		"z_elementarerdiener_representation",
+		"z_erinnerungverlassedich_representation",
+		"z_flimflam_representation",
+		"z_fluchderpestilenz_representation",
+		"z_gefaessderjahre_representation",
+		"z_granitundmarmor_representation",
+		"z_harmlosegestalt_representation",
+		"z_hartesschmelze_representation",
+		"z_heilkraftbannen_representation",
+		"z_hellsichttrueben_representation",
+		"z_herbeirufungvereiteln_representation",
+		"z_herrueberdastierreich_representation",
+		"z_herzschlagruhe_representation",
+		"z_hilfreichetatze_representation",
+		"z_hoellenpein_representation",
+		"z_illusionaufloesen_representation",
+		"z_iribaarshand_representation",
+		"z_klarumpurum_representation",
+		"z_kommkoboldkomm_representation",
+		"z_koerperlosereise_representation",
+		"z_krabbelnderschrecken_representation",
+		"z_kraftdeserzes_representation",
+		"z_kraftdeshumus_representation",
+		"z_kraehenruf_representation",
+		"z_kroetensprung_representation",
+		"z_lachdichgesund_representation",
+		"z_langerlulatsch_representation",
+		"z_lastdesalters_representation",
+		"z_levthansfeuer_representation",
+		"z_limbusversiegeln_representation",
+		"z_lungedesleviatan_representation",
+		"z_madasspiegel_representation",
+		"z_magischerraub_representation",
+		"z_metamagieneutralisieren_representation",
+		"z_metamorphofelsenform_representation",
+		"z_metamorphogletscherform_representation",
+		"z_murksundpatz_representation",
+		"z_objectoobscuro_representation",
+		"z_objektentzaubern_representation",
+		"z_paralysis_representation",
+		"z_pestilenzerspueren_representation",
+		"z_ruhekoerper_representation",
+		"z_satuariasherrlichkeit_representation",
+		"z_schadenszauberbannen_representation",
+		"z_schleierderunwissenheit_representation",
+		"z_seelentiererkennen_representation",
+		"z_staubwandle_representation",
+		"z_steinwandle_representation",
+		"z_stimmendeswindes_representation",
+		"z_sumuselixiere_representation",
+		"z_tempusstasis_representation",
+		"z_tierebesprechen_representation",
+		"z_tlalucsodem_representation",
+		"z_toteshandle_representation",
+		"z_unberuehrt_representation",
+		"z_unsichtbarerjaeger_representation",
+		"z_veraenderungaufheben_representation",
+		"z_verstaendigungstoeren_representation",
+		"z_verwandlungbeenden_representation",
+		"z_wandausflammen_representation",
+		"z_warmesblut_representation",
+		"z_warmesgefriere_representation",
+		"z_weicheserstarre_representation",
+		"z_weisheitderbaeume_representation",
+		"z_zornderelemente_representation",
+		"z_zungelaehmen_representation"
+	];
+
+	safeGetAttrs(attrsToGet, function (v) {
+		var attrsToChange = {};
+
+		for (property in attrMap)
+		{
+			let oldAttr = attrMap[property];
+			if (v[oldAttr] === 0)
+			{
+				v[oldAttr] = "";
+			}
+			attrsToChange[property] = v[oldAttr];
 		}
 		debugLog(caller, attrsToChange);
 		safeSetAttrs(attrsToChange, {}, function () {


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

## Other
### Fixes
* Fix bug (kreuvf/roll20-character-sheets#145) preventing certain spells from receiving the automatic stat replacement based on representation (5baf0f5156, 313e313029)

### Interface/Style
* Indicate updates with accompanying videos, add direct text links to the videos (2932c1735b)

### Miscellaneous
* Fixed typo (ff5529cbf0)
* Bump version number (f77ce9744c)
* Add info on latest version (ce9a4adf18)
* Regenerate sheet files (4abeaa0bb5)