### PR TITLE
[GURPS] 2.20.0

### DIFF
--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -4359,7 +4359,7 @@
 
 				<!-- current version notes: 2.20.0 -->
 				<ul>
-					<li><b>BUGFIX:</b> Fixed bug where all rolls was showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.</li>
+					<li><b>BUGFIX:</b> Fixed bug where all rolls were showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.</li>
 				</ul>
 				
 				<label class="check"><input type="checkbox" name="attr_announcements_hide" value="1">&nbsp;<b><span data-i18n="hide-until-next-update">Hide until next update</span></b></label>
@@ -21373,7 +21373,7 @@ Select the indent level of the spell. This is handy to help show the spell belon
 
 			<!-- current version notes: 2.20.0 -->
 			<ul>
-				<li><b>BUGFIX:</b> Fixed bug where all rolls was showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.</li>
+				<li><b>BUGFIX:</b> Fixed bug where all rolls were showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.</li>
 			</ul>
 
 

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -4357,20 +4357,9 @@
 					<input type="text" name="attr_announcement_version" readonly="readonly" value="0" title="GURPS Character Sheet Version" />
 				</h4>
 
-				<!-- current version notes: 2.19.0 -->
+				<!-- current version notes: 2.20.0 -->
 				<ul>
-					<li><b>NEW:</b> Combat > Your Hit Locations Tab. Added a note for <b>Large-Area Injury</b>. If you apply a hit location template, there is now a <b>Large-Area</b> hit location.</li>
-					<li><b>ENHANCEMENT:</b> Roll Modifiers Toolbox for Melee attacks. Added a modifier for attacking through unfriendly hex. B388.</li>
-					<li><b>ENHANCEMENT:</b> Roll Modifiers Toolbox for Active Defenses. Added a modifier for attack from a side hex. B390.</li>
-					<li><b>ENHANCEMENT:</b> Tools > General > Drinking and Intoxication Tool. If drinks consumed is less than ST/4, the die button is replaced by the text "No roll needed." Requested by Demented Avenger.</li>
-					<li><b>ENHANCEMENT:</b> Active Defenses. Added a new field for weight of the parrying weapon and tool to calculate weapon breakage. B376.</li>
-					<li><b>ENHANCEMENT:</b> Melee Attacks. Added a new field for weight of the attacking weapon and tool to show the parrying weapon's breaking point. B376.</li>
-					<li><b>BUGFIX:</b> Skill roll was not setting values for max 9, and summary.</li>
-					<li><b>BUGFIX:</b> Technique skill roll was not setting values for max 9, and summary.</li>
-					<li><b>BUGFIX:</b> Defense roll was not setting values summary.</li>
-					<li><b>BUGFIX:</b> Melee skill roll was not setting values for max 9, summary, hit location, maneuver, and all-out attack.</li>
-					<li><b>BUGFIX:</b> Ranged skill roll was not setting values for max 9, summary, hit location, maneuver, and all-out attack.</li>
-					<li><b>BUGFIX:</b> Fixed the styling for the <b>Duplicate</b> button for melee and ranged attacks.</li>
+					<li><b>BUGFIX:</b> Fixed bug where all rolls was showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.</li>
 				</ul>
 				
 				<label class="check"><input type="checkbox" name="attr_announcements_hide" value="1">&nbsp;<b><span data-i18n="hide-until-next-update">Hide until next update</span></b></label>
@@ -13479,7 +13468,7 @@ visualize what it will look like in chat.
 										<input type="text" name="attr_skill" title="Macro: @{NAME|repeating_melee_$[row #]_skill}" />
 									</div>
 									<div class="cell col6">
-										<button type="action" name="act_skillroll" class="button-roll-template btn ui-draggable" value="@{roll}&{template:skillRoll} {{sheetStyle=@{chatstyle}}} {{type=Melee Attack}} {{selected=@{selected_token_macro}}} {{target1=@{target_token_macro}}} {{characterName=@{character_name}}} {{rollResult=[[3d6cs<1cf>6]]}} {{useModTool=[[1]]}} {{showNotes=[[1]]}} {{useCriticalPlusTen=[[@{use_critical_plus_10}]]}} {{popupModifier=@{popup_modifier}}} {{activeDefense=[[0]]}} {{isSkillRoll=[[1]]}} {{showHitLabel=[[1]]}} {{notesTitlePrefix=Weapon}} {{showRawDefenseNotes=[[@{show_raw_defensive_notes}]]}} {{rollModifier=[[@{melee_roll_modifier}]]}} {{displayRollModifierSummary=[[@{display_roll_modifier_summary}]]}} {{rollModifierSummary=@{melee_roll_modifier_summary}}} {{quickModShow=[[@{melee_quick_mod_show_in_roll}]]}} {{quickModTotal=[[@{melee_quick_mod_total}]]}} {{quickModSummary=@{melee_quick_mod_summary}}}" />
+										<button type="action" name="act_skillroll" class="button-roll-template btn ui-draggable" value="@{roll}&{template:skillRoll} {{sheetStyle=@{chatstyle}}} {{type=Melee Attack}} {{selected=@{selected_token_macro}}} {{target1=@{target_token_macro}}} {{characterName=@{character_name}}} {{rollResult=[[3d6cs<1cf>6]]}} {{useModTool=[[1]]}} {{showNotes=[[1]]}} {{useCriticalPlusTen=[[@{use_critical_plus_10}]]}} {{popupModifier=@{popup_modifier}}} {{activeDefense=[[0]]}} {{isSkillRoll=[[1]]}} {{showHitLabel=[[1]]}} {{notesTitlePrefix=Weapon}} {{showRawDefenseNotes=[[@{show_raw_defensive_notes}]]}} {{rollModifier=[[@{melee_roll_modifier}]]}} {{displayRollModifierSummary=[[@{display_roll_modifier_summary}]]}} {{rollModifierSummary=@{melee_roll_modifier_summary}}} {{quickModShow=[[@{melee_quick_mod_show_in_roll}]]}} {{quickModTotal=[[@{melee_quick_mod_total}]]}} {{quickModSummary=@{melee_quick_mod_summary}}} {{weightSystem=@{weight_system}}}" />
 									</div>
 								</div> <!-- .row -->
 
@@ -21382,7 +21371,14 @@ Select the indent level of the spell. This is handy to help show the spell belon
 
 			<p>Pull Request: <span name="attr_latest_changes"></span></p>
 
-			<!-- current version notes: 2.19.0 -->
+			<!-- current version notes: 2.20.0 -->
+			<ul>
+				<li><b>BUGFIX:</b> Fixed bug where all rolls was showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.</li>
+			</ul>
+
+
+			<h4>Version: 2.19.0</h4>
+			<p>Pull Request: 6/12/2024</p>
 			<ul>
 				<li><b>NEW:</b> Combat > Your Hit Locations Tab. Added a note for <b>Large-Area Injury</b>. If you apply a hit location template, there is now a <b>Large-Area</b> hit location.</li>
 				<li><b>ENHANCEMENT:</b> Roll Modifiers Toolbox for Melee attacks. Added a modifier for attacking through unfriendly hex. B388.</li>
@@ -26467,13 +26463,13 @@ B378
 				{{/popupModifier}}
 
 				<!-- parrying weapon breakage -->
-				{#parryingWeaponWeight}
+				{{#parryingWeaponWeight}}
 				<tr>
 					<td colspan="2">
-						If parrying weapon is {{parryingWeaponWeight}} <span name="attr_weight_system"></span> or less, check for breakage. B376.
+						If parrying weapon is {{parryingWeaponWeight}} {{weightSystem}} or less, check for breakage. B376.
 					</td>
 				</tr>
-				{/parryingWeaponWeight}
+				{{/parryingWeaponWeight}}
 
 				<!-- quick modifiers -->
 				{{#rollTotal() quickModShow 1}}
@@ -26979,9 +26975,9 @@ B378
 	
 	const noop = function () { }; // do nothing callback function.
 	
-	const version = "2.19.0";
+	const version = "2.20.0";
 	
-	const latestChangesDate = "6/11/2024";
+	const latestChangesDate = "6/18/2024";
 	
 	let modCascade = true;
 	


### PR DESCRIPTION
Fixed bug where all rolls was showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

- BUGFIX: Fixed bug where all rolls were showing the note "If parrying weapon is or less, check for breakage. B376." Reported by Niccy_Everson and Cal Godot.

