### PR TITLE
[Warhammer 4e Character Sheet] 1.72b fixes

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,6 +81,13 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+
+June 28th 2024 v1.72b
+
+- Fix issue with Failed Melee test not showing Dual Wield and Furious Assault text and follow up buttons. They now display irrelevant of roll outcome.
+- Recorrected Minor Miscast Rapture, from 1d10 to 1 bleed condition.
+
+
 May 29th 2024 v1.72a
 
 - New Crit tables now work as normal with Strike to Injure (UiA version).

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -31418,7 +31418,7 @@
 		<div class="spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="row footer">
-			<div class="col-1 small-label center">Sheet version 1.72 : May 25th 2024 | by Djjus & Pote</div>
+			<div class="col-1 small-label center">Sheet version 1.72b : June 28th 2024 | by Djjus & Pote</div>
 		</div>
 			</div>
 		</div>
@@ -33453,6 +33453,19 @@
 								</div>
 							</div>
 						{{/^rollGreater() test target}}
+						{{#rollGreater() test target}}
+							{{#RTdualwield}}{{#rollGreater() dualwield 0}}						
+							<div class="row">
+								<div class="no-yellow-bg">
+									<div class="col-100-100" style="color: black; font-size: 9px; padding-left: 3px; line-height: 10px" data-i18n="CUSTOM-MODIFIERS">Custom & Situational Bonus:</div>						
+
+								<div class="col-1 center pad-l-md pad-r-md rt-slmod" style="color: #858585">+{{dualwield}}SL <span  data-i18n="DUAL-WIELDER"></span> <span class="chat-button-ripostedmg" style="height: 10px" data-i18n-title="USE-DW" >{{RTdualwield}}</span></div>
+								</div>
+							</div>
+							{{/rollGreater() dualwield 0}}{{/RTdualwield}}
+						{{/rollGreater() test target}}
+						
+						
 					{{/rollGreater() sitmod 0}}
 
 					{{#rollGreater() sitfail 0}}
@@ -35340,9 +35353,9 @@
 											<div class="col-100-100" style="color: black; font-size: 9px; padding-left: 3px; line-height: 10px" data-i18n="EFFECTS">Effects</div>
 										{{/RTfuriousassault}} {{/^rollGreater() test target}} {{/rollGreater() furiousassault 0}}{{/rollTotal() tiring 0}} {{/rollTotal() trip 0}} {{/rollTotal() distract 0}}{{/rollTotal() usedmagic 0}}{{/rollTotal() wrap 0}} {{/rollTotal() fast 0}} {{/rollTotal() hack 0}} {{/rollTotal() slow 0}} {{/rollTotal() penetrating 0}}
 
-										{{#rollGreater() furiousassault 0}} {{#^rollGreater() test target}} {{#RTfuriousassault}}
+										{{#rollGreater() furiousassault 0}} {{#RTfuriousassault}}
 											<div class="col-1 pad-l-md pad-r-md rt-effects" style="color: #858585"><span data-i18n="FURIOUS-ASSAULT-EFFECT"></span> <span class="chat-button-ripostedmg center" style="height: 10px" data-i18n-title="USE-FURIOUS-ASSAULT" >{{RTfuriousassault}}</span></div>
-										{{/RTfuriousassault}} {{/^rollGreater() test target}} {{/rollGreater() furiousassault 0}}
+										{{/RTfuriousassault}} {{/rollGreater() furiousassault 0}}
 										{{#^rollTotal() tiring 0}}
 											<div class="col-100-100 pad-l-md pad-r-md rt-effects" style="margin-right: 3px;color: #858585"><span data-i18n="TIRING">Tiring</span></div>
 										{{/^rollTotal() tiring 0}}
@@ -51824,5 +51837,3 @@ on('clicked:resetQuickPray', function(event){
 });
 		
 </script>
-
-

--- a/Warhammer 4e Character Sheet/translation.json
+++ b/Warhammer 4e Character Sheet/translation.json
@@ -760,7 +760,7 @@
 	"MINOR10": "<b>Driven to Distraction:</b> If engaged in combat, gain the Surprised Condition. Otherwise, you are completely startled, your heart racing, and unable to concentrate for a few moments.",
 	"MINOR11": "<b>Unholy Visions:</b>  Fleeting visions of profane and unholy acts harass you. Receive a Blinded Condition; pass a Challenging (+0) Cool Test or gain another.",
 	"MINOR12": "<b>Hexeyes:</b>  Your eyes turn an unnatural colour associated with your Lore for 1d10 hours. While your eyes are discoloured, you have 1 Blinded Condition that cannot be resolved by any means.",
-	"MINOR13": "<b>Rupture:</b> Your nose, eyes, and ears bleed profusely. Gain 1d10 Bleeding Conditions.",
+	"MINOR13": "<b>Rupture:</b> Your nose, eyes, and ears bleed profusely. Gain a Bleeding Condition.",
 	"MINOR14": "<b>Fell Whispers:</b> Pass a Routine (+20) Willpower Test or gain 1 Corruption point.",
 	"MINOR15": "<b>The Horror!:</b> Pass a Hard (–20) Cool Test or gain 1 Broken Condition.",
 	"MINOR16": "<b>Curse of Corruption:</b> Gain 1 Corruption point.",


### PR DESCRIPTION

- [ ] The pull request title clearly contains the name of the sheet I am editing.
- [ ] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [ ] The pull request makes changes to files in only one sub-folder.
- [ ] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Fix issue with Failed Melee test not showing Dual Wield and Furious Assault text and follow up buttons. They now display irrelevant of roll outcome.
- Recorrected Minor Miscast Rapture, from 1d10 to 1 bleed condition.



