### PR TITLE
Heavy gear 4e: Bug Fix Add Gear Weapon now shows traits properly, cleaned up

### DIFF
--- a/Heavy Gear 4e/HeavyGear4e.html
+++ b/Heavy Gear 4e/HeavyGear4e.html
@@ -375,16 +375,14 @@
                         <div>Equipment: Command dataglove and/or Satellite Uplink.
                         </div>
                         <div>
-                            Rank: Commanders rank up for accomplishing missions in a satisfactory way and for taking care of
-                            those who serve alongside them.
+                            Rank: Commanders rank up for accomplishing missions in a satisfactory way and for taking care of those who serve alongside them.
                         </div>
                         <span> CP: <input type="number" name="attr_archetype_cp" class="digit" value="0"> / <input type="number" name="attr_archetype_cp_max" class="digit" value="0"> </span>
 
                         <span> Special Rules </span>
                         <input type="hidden" name="attr_archetype_rank" class="archetype-rank-select"></span>
                         <div class="archetype-rank-1">
-                            R-1 : Counts PL as 1 higher when selecting and customizing vehicles that have a Comms Suite or
-                            Satellite Uplink.
+                            R-1 : Counts PL as 1 higher when selecting and customizing vehicles that have a Comms Suite or Satellite Uplink.
                         </div>
                         <div class="archetype-rank-2">
                             R-2 : The Commander can affect up to 3 recipients with an order without increasing Dif.
@@ -393,8 +391,7 @@
                             R-3 : Attempts to Jam the Commander suffer TP:1
                         </div>
                         <div class="archetype-rank-4">
-                            R-4 : The Commander treats Influence and Tactics as a single domain when issuing orders for
-                            purposes of domain bonuses
+                            R-4 : The Commander treats Influence and Tactics as a single domain when issuing orders for purposes of domain bonuses
                         </div>
                         <div class="archetype-rank-5">
                             R-5 : Drop Dif of all orders by 1.
@@ -476,8 +473,7 @@
                     </div>
                     <div class="archetype-duelist">
                         <span> Duelist </span>
-                        <div>Equipment: Southern duelists traditionally carry a rapier. Other factions may have a certain
-                            melee weapon traditional for dueling or dueling pistol.
+                        <div>Equipment: Southern duelists traditionally carry a rapier. Other factions may have a certain melee weapon traditional for dueling or dueling pistol.
                         </div>
                         <div>
                             Rank: Duelists rank up by defeating significant opponents and performing showy and often
@@ -876,7 +872,7 @@
                         <div>Equipment:<input type="text" name="attr_archetype_equipment"> </div>
                         <div>
                             Resource:<input type="text" class="infoused" name="attr_archetype_resource_name">
-                            <input type="number" name="attr_archetype_resource">/<input type="number" name="attr_archetype_resource_max"> Regain <input type="text" name="attr_archetype_resource_regain">
+                            <input type="number" name="attr_archetype_resource" value="0">/<input type="number" name="attr_archetype_resource_max" value="0"> Regain <input type="text" name="attr_archetype_resource_regain">
                         </div>
                         Rules:<fieldset class="repeating_archetype-rules">
                             <input type="text" name="attr_archetype_rules_level">
@@ -908,7 +904,7 @@
                         <div>
                             <span><input class="infoused" name="attr_personal_equipment_name" type="text"> </span>
                             <span class="pull-right">
-                                <input type="number" name="attr_personal_equipment_burden" step="0.25" />
+                                <input type="number" name="attr_personal_equipment_burden" step="0.25" value="0" />
                             </span>
                             <input type="checkbox" name="attr_personal_equipment_hide" class="sheet-toggle-show">
 
@@ -938,8 +934,14 @@
                             <span class="no-frame" name="attr_inf_weapon_name" value="Weapon">
                             </span>
                             <span class="frame" name="attr_frame_weapon_type"></span>
-                            D: <span type="number" name="attr_inf_weapon_damage" ></span>
+                            D: <span type="number" name="attr_inf_weapon_damage"></span>
+
                             Traits:
+                            <input type="text" name="attr_inf_weapon_traits" value="-" hidden>
+                            <input type="text" name="attr_inf_weapon_traits_selector_2" value="-" hidden>
+                            <input type="text" name="attr_inf_weapon_traits_selector_3" value="-" hidden>
+
+
                             <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                             <span class="sheet-body">
                                 Mode: (<input type="radio" value="2" name="attr_inf_weapon_traits_mode_selector" checked>
@@ -947,7 +949,7 @@
                                 <span type="text" name="attr_inf_weapon_traits_selector_2"></span>
                                 <input type="radio" value="3" name="attr_inf_weapon_traits_mode_selector">
                                 <span type="text" name="attr_inf_weapon_traits_selector_3"></span>)
-                                <input type="number" name="attr_inf_weapon_traits_mode_selector" hidden>,
+                                <input type="number" name="attr_inf_weapon_traits_mode_selector" value="0" hidden>,
                             </span>
                             <span type="text" name="attr_inf_weapon_traits" value=""></span>
 
@@ -957,7 +959,7 @@
                                 <span class="max-ammo" type="number" name="attr_inf_weapon_ammo_max" value="1"></span>
                             </span>
 
-                            i:<input type="checkbox" name="attr_inf_weapon_hide" class="sheet-toggle-show" >
+                            i:<input type="checkbox" name="attr_inf_weapon_hide" class="sheet-toggle-show">
                         </span>
                         <button type="action" name="act_tumble">roll</button>
                     </div>
@@ -966,7 +968,7 @@
                     <div class="sheet-body">
                         Damage: <input type="number" name="attr_inf_weapon_damage" value="0">
                         <input type="number" name="attr_inf_weapon_tn_bonus" value="0" hidden>
-                        <span class="pull-right">Burden: <input type="number" name="attr_inf_weapon_burden" step="0.25"></span>
+                        <span class="pull-right">Burden: <input type="number" name="attr_inf_weapon_burden" step="0.25" value="0"></span>
                         <span>
                             <select name="attr_inf_weapon_size" class="size">
                                 <option value="Light" selected>Light</option>
@@ -991,7 +993,7 @@
                         </span>
 
                         <p>Range: <input class="emcalc" style="--index: -11;" type="text" name="attr_inf_weapon_range">
-                            <span class="pull-right">Ammo:<input type="number" class="digit" name="attr_inf_weapon_ammo">/<input type="number" name="attr_inf_weapon_ammo_max" class="digit" value="1"></span>
+                            <span class="pull-right">Ammo:<input type="number" class="digit" name="attr_inf_weapon_ammo" value="1">/<input type="number" name="attr_inf_weapon_ammo_max" class="digit" value="1"></span>
                         </p>
                         Frame:<input type="checkbox" name="attr_inf_weapon_frame_check" value="1" class="frame-check">
                         Cumbersome:<input type="checkbox" name="attr_inf_weapon_cumbersome">
@@ -1026,21 +1028,22 @@
                         <div>
 
                             Traits:
+
                             <input type="checkbox" name="attr_inf_weapon_traits_show" />
 
                             <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                             <span class="sheet-body">
                                 Mode: (<input type="radio" value="2" name="attr_inf_weapon_traits_mode_selector" checked>
 
-                                <span type="text" name="attr_inf_weapon_traits_selector_2"></span>
-                                <input type="radio" value="3" name="attr_inf_weapon_traits_mode_selector">
-                                <span type="text" name="attr_inf_weapon_traits_selector_3"></span>)
-                                <input type="number" name="attr_inf_weapon_traits_mode_selector" hidden>
+                                <span type="text" name="attr_inf_weapon_traits_selector_2" value=" "></span>
+                                <input type="radio" value="3" name="attr_inf_weapon_traits_mode_selector" checked>
+                                <span type="text" name="attr_inf_weapon_traits_selector_3" value=" "></span>)
+                                <input type="number" name="attr_inf_weapon_traits_mode_selector" value="0" hidden>
                             </span>
-                            <span type="text" name="attr_inf_weapon_traits" value=""></span>
-                            <input type="checkbox" name="attr_inf_weapon_traits_show" class="sheet-toggle-show" hidden/>
+                            <span type="text" name="attr_inf_weapon_traits"></span>
+                            <input type="checkbox" name="attr_inf_weapon_traits_show" class="sheet-toggle-show" hidden />
                             <div class="sheet-body" style="border: #000 1px solid;">
-                                <span class="trait-box" >
+                                <span class="trait-box">
                                     <span class="trait-item">
                                         Mode:<input type="checkbox" name="attr_inf_weapon_traits_mode" value="1">
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
@@ -1053,7 +1056,7 @@
                                         Advanced:
                                         <input type="checkbox" name="attr_inf_weapon_traits_advanced" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_advanced" value="0" hidden>
-                                        <input type="number" name="attr_inf_weapon_traits_advanced_selector" value="1" hidden>                                        
+                                        <input type="number" name="attr_inf_weapon_traits_advanced_selector" value="1" hidden>
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                         <span class="sheet-body">
                                             <input type="radio" value="1" name="attr_inf_weapon_traits_advanced_selector" checked>|
@@ -1065,7 +1068,7 @@
                                     <span class="trait-item">
                                         Blast <input type="checkbox" name="attr_inf_weapon_traits_blast" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_blast" value="0" hidden>
-                                        <input type="number" name="attr_inf_weapon_traits_blast_selector" value="1"hidden>
+                                        <input type="number" name="attr_inf_weapon_traits_blast_selector" value="1" hidden>
 
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                         <span class="sheet-body">
@@ -1125,7 +1128,7 @@
                                     <span class="trait-item">
                                         Indirect <input type="checkbox" name="attr_inf_weapon_traits_indirect" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_indirect" value="0" hidden>
-                                        <input type="number" name="attr_inf_weapon_traits_indirect_selector" value="1" hidden>                                        
+                                        <input type="number" name="attr_inf_weapon_traits_indirect_selector" value="1" hidden>
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                         <span class="sheet-body">
                                             <input type="radio" value="1" name="attr_inf_weapon_traits_indirect_selector" checked>|
@@ -1413,7 +1416,7 @@
                 <h4> Armour</h4>
                 <span>Toughness <input type="number" name="attr_toughness" value="2" style="width: 2em;"> Armour
                     <input type="number" name="attr_armour" value="0" style="width: 2em;"> </span>
-                    <span> Total Damage Reduction <input name="attr_damage_reduction"></span>
+                <span> Total Damage Reduction <input name="attr_damage_reduction"></span>
                 <textarea name="attr_armour_desc" class="inputarea" rows="3"></textarea>
             </div>
         </div>
@@ -2138,15 +2141,15 @@
         <div>
             Name:<input type="text" name="attr_gear_name">
             Model:<input type="text" name="attr_gear_model">
-            PL:<input type="number" name="attr_gearPL">
-            TV:<input type="number" name="attr_gear_tv">
+            PL:<input type="number" name="attr_gearPL" value="0">
+            TV:<input type="number" name="attr_gear_tv" value="0">
         </div>
         <div>
             Actor Type: <input type="text" name="attr_gear_actor_type">
-            Height: <input type="number" name="attr_gear_height" step=".5">in
+            Height: <input type="number" name="attr_gear_height" step=".5" value="0">in
         </div>
         <div>
-            Crew:<input type="number" name="attr_gear_crew">
+            Crew:<input type="number" name="attr_gear_crew" value="1">
             <label for="mr" style="font-weight:normal; font-size: 1em;">*Movement Rate (MR):</label>
             <input type="checkbox" id="mr" name="attr_gear_mr_info" class="sheet-toggle-show-span" hidden>
             <input type="text" name="attr_gear_mr" class="em13" value="0">
@@ -2158,7 +2161,7 @@
                 F:<input type="number" name="attr_gear_mr_f" class="digit" value="0">
                 A:<input type="number" name="attr_gear_mr_a" class="digit" value="0">
             </span>
-            Armour (Arm):<input type="number" name="attr_gear_arm">
+            Armour (Arm):<input type="number" name="attr_gear_arm" value="0">
             Hull Integrity (HI):<input type="number" name="attr_gear_hi_max" value="0">
         </div>
         <div class="no-buttons">
@@ -2166,7 +2169,7 @@
                 <h4>TN Bonus: </h4>
                 <div class="infobox">
                     <span>Gunnery
-                        <p>(GU): <input type="number" name="attr_gear_gunnery_base" class="digit">
+                        <p>(GU): <input type="number" name="attr_gear_gunnery_base" class="digit" value="0">
                             Bonus: <input type="number" name="attr_gear_gunnery_bonus" class="digit" value="0">
                             Total:<span type="number" name="attr_gear_gunnery" class="digit"></span></p>
                     </span>
@@ -2182,7 +2185,7 @@
                 </div>
                 <div class="infobox">
                     <span>Pilot
-                        <p>(PI): <input type="number" name="attr_gear_pilot_base" class="digit">
+                        <p>(PI): <input type="number" name="attr_gear_pilot_base" class="digit" value="0">
                             Bonus: <input type="number" name="attr_gear_pilot_bonus" class="digit" value="0">
                             Total: <span type="number" name="attr_gear_pilot" class="digit"> </span>
                         </p>
@@ -2198,7 +2201,7 @@
                 </div>
                 <div class="infobox">
                     <span>Electronic Warfare
-                        <p>(EW): <input type="number" name="attr_gear_electronicwarfare_base" class="digit">
+                        <p>(EW): <input type="number" name="attr_gear_electronicwarfare_base" class="digit" value="0">
                             Bonus: <input type="number" name="attr_gear_electronicwarfare_bonus" class="digit" value="0">
                             Total: <span type="number" name="attr_gear_electronicwarfare" class="digit"></span>
                         </p>
@@ -2284,6 +2287,7 @@
                 </h4>
 
                 <fieldset class="repeating_gearweapon">
+                    <input type="checkbox" name="attr_gear_weapon_initalised" value="1" hidden>
                     <span type="text" name="attr_gear_weapon_size"></span>
                     <span type="text" name="attr_gear_weapon_type"></span>
                     <button type="action" name="act_tumble"> roll</button>
@@ -2306,15 +2310,15 @@
                         <span type="text" name="attr_gear_weapon_traits_selector_2"></span>
                         <input type="radio" value="3" name="attr_gear_weapon_traits_mode_selector">
                         <span type="text" name="attr_gear_weapon_traits_selector_3"></span>)
-                        <input type="number" name="attr_gear_weapon_traits_mode_selector" hidden>
+                        <input type="number" name="attr_gear_weapon_traits_mode_selector" value="0" hidden>
                     </span>
                     <span type="text" name="attr_gear_weapon_traits"></span>
                     <span type="text" name="attr_gear_weapon_traits_other"></span>
 
                     <input class="sheet-ammunition-show" type="checkbox" name="attr_gear_weapon_ammunition_show" value="1" hidden />
                     <span class="ammo-box">
-                        <input type="number" class="digit" name="attr_gear_weapon_ammo">/
-                        <span class="max-ammo" type="number" name="attr_gear_weapon_ammo_max"></span>
+                        <input type="number" class="digit" name="attr_gear_weapon_ammo" value="1">/
+                        <span class="max-ammo" type="number" name="attr_gear_weapon_ammo_max" value="1"></span>
                     </span>
                     i:<input type="checkbox" name="attr_gear_weapon_info" class="sheet-toggle-show" />
 
@@ -2329,7 +2333,7 @@
                         Code <input type="text" name="attr_gear_weapon_code" class="em8">
 
                         <span class="pull-right">
-                            Mode : <input type="number" name="attr_gear_weapon_ammo_max" value="0">
+                            Ammo: <input type="number" name="attr_gear_weapon_ammo_max" value="0">
                         </span>
                         <div>Domain:
                             <select name="attr_gear_weapon_domain">
@@ -2381,15 +2385,15 @@
                             Range: <input type="text" name="attr_gear_weapon_range" class="em8">-
                             <input type="checkbox" name="attr_gear_weapon_blitz_check" class="blitz-check" value="1">
                             <span class="no-blitz">
-                                <input type="number" name="attr_gear_weapon_range_min" class="">-
-                                <input type="number" name="attr_gear_weapon_range_med" class="">/
-                                <input type="number" name="attr_gear_weapon_range_max" class="">m
+                                <input type="number" name="attr_gear_weapon_range_min" class="" value="0">-
+                                <input type="number" name="attr_gear_weapon_range_med" class="" value="0">/
+                                <input type="number" name="attr_gear_weapon_range_max" class="" value="0">m
                             </span>
                             <span class="blitz">
                                 Blitz Range: <input type="text" name="attr_gear_weapon_blitz_range" class="em8">-
-                                <input type="number" name="attr_gear_weapon_blitz_range_min" class="">-
-                                <input type="number" name="attr_gear_weapon_blitz_range_med" class="">/
-                                <input type="number" name="attr_gear_weapon_blitz_range_max" class="">in
+                                <input type="number" name="attr_gear_weapon_blitz_range_min" class="" value="0">-
+                                <input type="number" name="attr_gear_weapon_blitz_range_med" class="" value="0">/
+                                <input type="number" name="attr_gear_weapon_blitz_range_max" class="" value="0">in
                             </span>
 
                         </div>
@@ -2732,18 +2736,47 @@
 
 
                         </div>
-                        PL <input type="number" name="attr_gear_weapon_pl">
+                        PL <input type="number" name="attr_gear_weapon_pl" value="0">
                         Location <input type="text" name="attr_gear_weapon_location" class="em8">
-                        Slots <input type="number" name="attr_gear_weapon_slots" class="digit">
+                        Slots <input type="number" name="attr_gear_weapon_slots" class="digit" value="0">
                         Aux Location <input type="text" name="attr_gear_weapon_aux_location" class="em8">
-                        Aux Slots <input type="number" name="attr_gear_weapon_slots_misc" class="digit">
+                        Aux Slots <input type="number" name="attr_gear_weapon_slots_misc" class="digit" value="0">
                         <p><span type="text" name="attr_gear_weapon_traits_desc" value=""></span> </p>
                         <textarea class="inputarea" name="attr_gear_weapon_notes"></textarea>
 
 
                     </div>
                 </fieldset>
-                Add Weapon Code: <input type="text" name="attr_gear_weapon_code" class="em8"> lv:<input type="number" name="attr_gear_weapon_lvl" class="digit" max="5" min="0">
+                Add Weapon Code: <input type="text" name="attr_gear_weapon_code" class="em8"> lv:<input type="number" name="attr_gear_weapon_lvl" class="digit" max="5" min="0" value="3">
+                Domain: <select name="attr_gear_weapon_domain">
+                    <option value="1">Athletics </option>
+                    <option value="2">Awareness</option>
+                    <option value="3">Business</option>
+                    <option value="4">Craft</option>
+                    <option value="5">Culture</option>
+                    <option value="6">Electronic Warfare</option>
+                    <option value="7">Electronics</option>
+                    <option value="8" selected>Gunnery</option>
+                    <option value="9">Hard Science</option>
+                    <option value="10">Influence</option>
+                    <option value="11">Institutions</option>
+                    <option value="12">Investigation</option>
+                    <option value="13">Mechanics</option>
+                    <option value="14">Medicine</option>
+                    <option value="15">Melee</option>
+                    <option value="16">Pilot</option>
+                    <option value="17">Showmanship</option>
+                    <option value="18">Socialscience</option>
+                    <option value="19">Survival</option>
+                    <option value="20">Tactics</option>
+                </select>
+
+                Gear Bonus:<select name="attr_gear_weapon_gear_domain_tn">
+                    <option value="1" selected>Gunnery</option>
+                    <option value="2">Pilot</option>
+                    <option value="3">Electronic Warfare</option>
+                </select>
+                (<input type="checkbox" name="attr_gear_weapon_skill_familiar" value="1"> F)
                 <button type="action" name="act_gear_weapon_stat">Add New Weapon</button>
             </div>
             <div class="">
@@ -2798,11 +2831,11 @@
             <div>
                 <h4> Location <span class="pull-right">Slots </span> </h4>
             </div>
-            <div> Torso <span class="pull-right"><input type="number" name="attr_slots_torso">/<input type="number" name="attr_slots_torso_max"> </span> </div>
-            <div> Right Manip <span class="pull-right"><input type="number" name="attr_slots_l_manip">/<input type="number" name="attr_slotsLManip_max"></span></div>
-            <div> Left Manip <span class="pull-right"><input type="number" name="attr_slots_r_manip">/<input type="number" name="attr_slots_r_manip_max"></span></div>
-            <div> Right Shoulder <span class="pull-right"><input type="number" name="attr_slots_l_shoulder">/<input type="number" name="attr_slotss_l_shoulder_max"></span></div>
-            <div> Left Shoulder <span class="pull-right"><input type="number" name="attr_slots_r_shoulder">/<input type="number" name="attr_slots_r_shoulder_max"></span></div>
+            <div> Torso <span class="pull-right"><input type="number" name="attr_slots_torso" value="0">/<input type="number" name="attr_slots_torso_max" value="0"> </span> </div>
+            <div> Right Manip <span class="pull-right"><input type="number" name="attr_slots_l_manip" value="0">/<input type="number" name="attr_slotsLManip_max" value="0"></span></div>
+            <div> Left Manip <span class="pull-right"><input type="number" name="attr_slots_r_manip" value="0">/<input type="number" name="attr_slots_r_manip_max" value="0"></span></div>
+            <div> Right Shoulder <span class="pull-right"><input type="number" name="attr_slots_l_shoulder" value="0">/<input type="number" name="attr_slotss_l_shoulder_max" value="0"></span></div>
+            <div> Left Shoulder <span class="pull-right"><input type="number" name="attr_slots_r_shoulder" value="0">/<input type="number" name="attr_slots_r_shoulder_max" value="0"></span></div>
             <div class="infobox">
                 <h4>Maintainace</h4>
                 <span>Type:<select name="attr_gear_maintainance_type">
@@ -2833,7 +2866,7 @@
                 <textarea class="inputarea" name="attr_gear_maintainance_desc"></textarea>
                 <h4>Repairs</h4>
                 <span> <input name="attr_gear_maintainance_repairs" type="number" class="digit">/
-                    <input type="number" name="attr_gear_maintainance_repairs_max" class="digit"> hours. TB: <span name="attr_gear_maintainance_tech"> </span></span> </span>
+                    <input type="number" name="attr_gear_maintainance_repairs_max" class="digit" value="0"> hours. TB: <span name="attr_gear_maintainance_tech"> </span></span> </span>
                 <textarea class="inputarea" name="attr_gear_maintainance_repairs_desc"></textarea>
             </div>
         </div>
@@ -2844,8 +2877,8 @@
                     <div class="sheet-body">
                         <div>
                             Location <input type="text" name="attr_gear_equipment_traits_location">
-                            Slots<input type="number" name="attr_gear_equipment_traits_slots">
-                            PL<input type="number" name="attr_gear_equipment_traits_pl">
+                            Slots<input type="number" name="attr_gear_equipment_traits_slots" value="0">
+                            PL<input type="number" name="attr_gear_equipment_traits_pl" value="0">
                         </div>
                         <textarea class="inputarea" name="attr_gear_equipment_traits_desc"></textarea>
                     </div>
@@ -3487,7 +3520,7 @@
                         <div>Equipment:<input type="text" name="attr_archetype_equipment"> </div>
                         <div>
                             Resource:<input type="text" class="infoused" name="attr_archetype_resource_name">
-                            <input type="number" name="attr_archetype_resource">/<input type="number" name="attr_archetype_resource_max"> Regain <input type="text" name="attr_archetype_resource_regain">
+                            <input type="number" name="attr_archetype_resource" value="0">/<input type="number" name="attr_archetype_resource_max" value="0"> Regain <input type="text" name="attr_archetype_resource_regain">
                         </div>
                         Rules:<fieldset class="repeating_archetype-rules">
                             <input type="text" name="attr_archetype_rules_level">
@@ -3520,11 +3553,11 @@
         </div>
         <div> Vehicle Name:<input type="text" name="attr_character_name">
             Type:<input type="text" name="attr_gear_actor_type">
-            TV <input type="number" name="attr_gear_tv">
-            Crew: <input type="number" name="attr_gear_crew">
-            HT <input type="number" name="attr_gear_height" step=".5">in
+            TV <input type="number" name="attr_gear_tv" value="0">
+            Crew: <input type="number" name="attr_gear_crew" value="1">
+            HT <input type="number" name="attr_gear_height" step=".5" value="0">in
             MR:<input type="text" name="attr_gear_mr" class="em13">
-            Armour <input type="number" name="attr_gear_arm">
+            Armour <input type="number" name="attr_gear_arm" value="0">
             HI :<input type="number" name="attr_gear_hi_max" value="0">
         </div>
 
@@ -3625,7 +3658,7 @@
 
 
 
-                    </select> lv: <input type="number" name="attr_gear_damage_lvl" class="digit" min="0">
+                    </select> lv: <input type="number" name="attr_gear_damage_lvl" class="digit" min="0" value="0">
                     <button type="action" name="act_gear_damage_stat">Add New Damage</button> </span>
             </div>
             <h4>Gear Damage Notes</h4> <textarea class="inputarea" name="attr_gear_damage_desc" rows="3"></textarea>
@@ -3646,6 +3679,7 @@
                     </h4>
 
                     <fieldset class="repeating_gearweapon">
+                        <input type="checkbox" name="attr_gear_weapon_initalised" value="1" hidden>
                         <span type="text" name="attr_gear_weapon_size"></span>
                         <span type="text" name="attr_gear_weapon_type"></span>
                         <button type="action" name="act_tumble"> roll</button>
@@ -3668,15 +3702,15 @@
                             <span type="text" name="attr_gear_weapon_traits_selector_2"></span>
                             <input type="radio" value="3" name="attr_gear_weapon_traits_mode_selector">
                             <span type="text" name="attr_gear_weapon_traits_selector_3"></span>)
-                            <input type="number" name="attr_gear_weapon_traits_mode_selector" hidden>
+                            <input type="number" name="attr_gear_weapon_traits_mode_selector" value="0" hidden>
                         </span>
                         <span type="text" name="attr_gear_weapon_traits"></span>
                         <span type="text" name="attr_gear_weapon_traits_other"></span>
 
                         <input class="sheet-ammunition-show" type="checkbox" name="attr_gear_weapon_ammunition_show" value="1" hidden />
                         <span class="ammo-box">
-                            <input type="number" class="digit" name="attr_gear_weapon_ammo">/
-                            <span class="max-ammo" type="number" name="attr_gear_weapon_ammo_max"></span>
+                            <input type="number" class="digit" name="attr_gear_weapon_ammo" value="0">/
+                            <span class="max-ammo" type="number" name="attr_gear_weapon_ammo_max" value="0"></span>
                         </span>
                         i:<input type="checkbox" name="attr_gear_weapon_info" class="sheet-toggle-show" />
 
@@ -3691,7 +3725,7 @@
                             Code <input type="text" name="attr_gear_weapon_code" class="em8">
 
                             <span class="pull-right">
-                                Mode : <input type="number" name="attr_gear_weapon_ammo_max" value="0">
+                                Ammo: <input type="number" name="attr_gear_weapon_ammo_max" value="0">
                             </span>
                             <div>
                                 <select name="attr_gear_weapon_domain">
@@ -3742,14 +3776,14 @@
                                 Range: <input type="text" name="attr_gear_weapon_range" class="em8">-
                                 <input type="checkbox" name="attr_gear_weapon_blitz_check" class="blitz-check" value="1" hidden>
                                 <span class="no-blitz">
-                                    <input type="number" name="attr_gear_weapon_range_min" class="">-
-                                    <input type="number" name="attr_gear_weapon_range_med" class="">/
-                                    <input type="number" name="attr_gear_weapon_range_max" class="">m
+                                    <input type="number" name="attr_gear_weapon_range_min" class="" value="0">-
+                                    <input type="number" name="attr_gear_weapon_range_med" class="" value="0">/
+                                    <input type="number" name="attr_gear_weapon_range_max" class="" value="0">m
                                 </span>
                                 <span class="blitz">
-                                    Blitz: <input type="number" name="attr_gear_weapon_blitz_range_min" class="">-
-                                    <input type="number" name="attr_gear_weapon_blitz_range_med" class="">/
-                                    <input type="number" name="attr_gear_weapon_blitz_range_max" class="">in
+                                    Blitz: <input type="number" name="attr_gear_weapon_blitz_range_min" class="" value="0">-
+                                    <input type="number" name="attr_gear_weapon_blitz_range_med" class="" value="0">/
+                                    <input type="number" name="attr_gear_weapon_blitz_range_max" class="" value="0">in
                                 </span>
                             </div>
 
@@ -4088,19 +4122,50 @@
 
 
                             </div>
-                            PL <input type="number" name="attr_gear_weapon_pl">
+                            PL <input type="number" name="attr_gear_weapon_pl" value="0">
                             Location <input type="text" name="attr_gear_weapon_location" class="em8">
-                            Slots <input type="number" name="attr_gear_weapon_slots" class="digit">
+                            Slots <input type="number" name="attr_gear_weapon_slots" class="digit" value="0">
                             Aux Location <input type="text" name="attr_gear_weapon_aux_location" class="em8">
-                            Aux Slots <input type="number" name="attr_gear_weapon_slots_misc" class="digit">
+                            Aux Slots <input type="number" name="attr_gear_weapon_slots_misc" class="digit" value="0">
                             <p><span type="text" name="attr_gear_weapon_traits_desc" value=""></span> </p>
                             <textarea class="inputarea" name="attr_gear_weapon_notes"></textarea>
 
 
                         </div>
                     </fieldset>
-                    Add Weapon Code: <input type="text" name="attr_gear_weapon_code" class="em8"> lv:<input type="number" name="attr_gear_weapon_lvl" class="digit" max="5" min="0">
+
+                    Add Weapon Code: <input type="text" name="attr_gear_weapon_code" class="em8"> lv:<input type="number" name="attr_gear_weapon_lvl" class="digit" max="5" min="0" value="3">
+                    Domain: <select name="attr_gear_weapon_domain">
+                        <option value="1">Athletics </option>
+                        <option value="2">Awareness</option>
+                        <option value="3">Business</option>
+                        <option value="4">Craft</option>
+                        <option value="5">Culture</option>
+                        <option value="6">Electronic Warfare</option>
+                        <option value="7">Electronics</option>
+                        <option value="8" selected>Gunnery</option>
+                        <option value="9">Hard Science</option>
+                        <option value="10">Influence</option>
+                        <option value="11">Institutions</option>
+                        <option value="12">Investigation</option>
+                        <option value="13">Mechanics</option>
+                        <option value="14">Medicine</option>
+                        <option value="15">Melee</option>
+                        <option value="16">Pilot</option>
+                        <option value="17">Showmanship</option>
+                        <option value="18">Socialscience</option>
+                        <option value="19">Survival</option>
+                        <option value="20">Tactics</option>
+                    </select>
+
+                    Gear Bonus:<select name="attr_gear_weapon_gear_domain_tn">
+                        <option value="1" selected>Gunnery</option>
+                        <option value="2">Pilot</option>
+                        <option value="3">Electronic Warfare</option>
+                    </select>
+                    (<input type="checkbox" name="attr_gear_weapon_skill_familiar" value="1"> F)
                     <button type="action" name="act_gear_weapon_stat">Add New Weapon</button>
+
                 </div>
                 <div class="">
                     <h3>Electronic Systems </h3>
@@ -4156,8 +4221,8 @@
                         <div class="sheet-body">
                             <div>
                                 Location <input type="text" name="attr_gear_equipment_traits_location">
-                                Slots<input type="number" name="attr_gear_equipment_traits_slots">
-                                PL<input type="number" name="attr_gear_equipment_traits_pl">
+                                Slots<input type="number" name="attr_gear_equipment_traits_slots" value="0">
+                                PL<input type="number" name="attr_gear_equipment_traits_pl" value="0">
                             </div>
                             <textarea class="inputarea" name="attr_gear_equipment_traits_desc"></textarea>
                         </div>
@@ -4180,28 +4245,28 @@
     <div class="background">
         <div class="char-image">
             <img class="portrait" name="attr_character_avatar">
-            <span>HT <input type="number" name="attr_height_m" step="0.01">m /<input type="number" name="attr_height_ft" step="0.01">ft </span>
-            <span>WT <input type="number" name="attr_weight_kg" step="0.01">kg /<input type="number" name="attr_weight_lbs" step="0.01">lbs </span>
+            <span>HT <input type="number" name="attr_height_m" step="0.01" value="0">m /<input type="number" name="attr_height_ft" step="0.01" value="0">ft </span>
+            <span>WT <input type="number" name="attr_weight_kg" step="0.01" value="0">kg /<input type="number" name="attr_weight_lbs" step="0.01" value="0">lbs </span>
             <div>
 
             </div>
         </div>
-        <div class="background-info"> 
+        <div class="background-info">
             <div>Name:<input type="text" name="attr_character_name">
                 Temperment:<input type="text" name="attr_gear_actor_type">
-                TV <input type="number" name="attr_gear_tv">
-             </div>
-            <div>MR:<input type="text" name="attr_gear_mr" class="em13">
-            Range: <input type="text" name="attr_creature_range" class="em13">  </div>
-            
-            
-            <span>Toughness <input type="number" name="attr_toughness" value="2" style="width: 2em;"> 
-            Armour <input type="number" name="attr_gear_arm">
-            Sys<input type="number" class="digit" name="attr_damage_system_max" value="0">
-            She<input type="number" class="digit" name="attr_damage_shell_max" value="0">
-            <div> Description
-                <textarea class="inputarea" name="attr_desc"></textarea>
+                TV <input type="number" name="attr_gear_tv" value="0">
             </div>
+            <div>MR:<input type="text" name="attr_gear_mr" class="em13">
+                Range: <input type="text" name="attr_creature_range" class="em13"> </div>
+
+
+            <span>Toughness <input type="number" name="attr_toughness" value="2" style="width: 2em;">
+                Armour <input type="number" name="attr_gear_arm" value="0">
+                Sys<input type="number" class="digit" name="attr_damage_system_max" value="0">
+                She<input type="number" class="digit" name="attr_damage_shell_max" value="0">
+                <div> Description
+                    <textarea class="inputarea" name="attr_desc"></textarea>
+                </div>
 
         </div>
     </div>
@@ -4216,7 +4281,7 @@
             <span>Skill <input type="number" name="attr_gear_gunnery_skill" class="digit" value="2">
                 Expertise: <input type="number" name="attr_gear_gunnery_expertise" class="digit" value="0" min="0" max="3">
                 <button type="action" name="act_geartumble_gunnery">Roll</button></span>
-                <p></p> Use for attacking
+            <p></p> Use for attacking
         </div>
         <div class="infobox">
             <span>PI: <input type="number" name="attr_gear_pilot_base" class="digit" value="0">
@@ -4226,7 +4291,7 @@
             <span>Skill <input type="number" name="attr_gear_pilot_skill" class="digit" value="2">
                 Expertise: <input type="number" name="attr_gear_pilot_expertise" class="digit" value="0" min="0" max="3">
                 <button type="action" name="act_geartumble_pilot">Roll</button> </span>
-                <p></p>Use for dodging
+            <p></p>Use for dodging
         </div>
         <div class="infobox">
             <span>EW: <input type="number" name="attr_gear_electronicwarfare_base" class="digit" value="0">
@@ -4314,7 +4379,7 @@
 
 
 
-                    </select> lv: <input type="number" name="attr_damage_lvl" class="digit" min="0">
+                    </select> lv: <input type="number" name="attr_damage_lvl" class="digit" min="0" value="0">
                     <button type="action" name="act_damage_stat">Add New Damage</button> </span>
                 <h4>Damage Notes</h4> <textarea class="inputarea" name="attr_damage_desc" rows="3"></textarea>
             </div>
@@ -4330,36 +4395,36 @@
                             <span class="no-frame" name="attr_inf_weapon_name" value="Weapon">
                             </span>
                             <span class="frame" name="attr_frame_weapon_type"></span>
-                            D: <span type="number" name="attr_inf_weapon_damage" ></span>
+                            D: <span type="number" name="attr_inf_weapon_damage"></span>
                             Traits:
                             <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                             <span class="sheet-body">
                                 Mode: (<input type="radio" value="2" name="attr_inf_weapon_traits_mode_selector" checked>
-    
+
                                 <span type="text" name="attr_inf_weapon_traits_selector_2"></span>
                                 <input type="radio" value="3" name="attr_inf_weapon_traits_mode_selector">
                                 <span type="text" name="attr_inf_weapon_traits_selector_3"></span>)
-                                <input type="number" name="attr_inf_weapon_traits_mode_selector" hidden>,
+                                <input type="number" name="attr_inf_weapon_traits_mode_selector" value="0" hidden>,
                             </span>
                             <span type="text" name="attr_inf_weapon_traits" value=""></span>
-    
+
                             <input class="sheet-ammunition-show" type="checkbox" name="attr_inf_weapon_ammunition_show" value="1" hidden />
                             <span class="ammo-box">
                                 <input type="number" class="digit" name="attr_inf_weapon_ammo" value="1">/
                                 <span class="max-ammo" type="number" name="attr_inf_weapon_ammo_max" value="1"></span>
                             </span>
-    
-                            i:<input type="checkbox" name="attr_inf_weapon_hide" class="sheet-toggle-show" >
+
+                            i:<input type="checkbox" name="attr_inf_weapon_hide" class="sheet-toggle-show">
                         </span>
                         <button type="action" name="act_tumble">roll</button>
                     </div>
-    
+
                     <input type="checkbox" name="attr_inf_weapon_hide" class="sheet-toggle-show" hidden>
                     <div class="sheet-body">
                         Damage: <input type="number" name="attr_inf_weapon_damage" value="0">
                         <input type="number" name="attr_inf_weapon_tn_bonus" value="0" hidden>
 
-                        <span class="pull-right">Burden: <input type="number" name="attr_inf_weapon_burden" step="0.25"></span>
+                        <span class="pull-right">Burden: <input type="number" name="attr_inf_weapon_burden" step="0.25" value="0"></span>
                         <span>
                             <select name="attr_inf_weapon_size" class="size">
                                 <option value="Light" selected>Light</option>
@@ -4383,9 +4448,9 @@
                                 </select>
                             </span>
                         </span>
-    
+
                         <p>Range: <input class="emcalc" style="--index: -11;" type="text" name="attr_inf_weapon_range">
-                            <span class="pull-right">Ammo:<input type="number" class="digit" name="attr_inf_weapon_ammo">/<input type="number" name="attr_inf_weapon_ammo_max" class="digit" value="1"></span>
+                            <span class="pull-right">Ammo:<input type="number" class="digit" name="attr_inf_weapon_ammo" value="1">/<input type="number" name="attr_inf_weapon_ammo_max" class="digit" value="1"></span>
                         </p>
                         Frame:<input type="checkbox" name="attr_inf_weapon_frame_check" value="1" class="frame-check">
                         Cumbersome:<input type="checkbox" name="attr_inf_weapon_cumbersome">
@@ -4413,30 +4478,30 @@
                                 <option value="19">Survival</option>
                                 <option value="20">Tactics</option>
                             </select>
-    
+
                         </span>
                         <span>Skill:<input type="number" name="attr_inf_skill_level" class="digit" value="0" min="0" max="5">(<input type="checkbox" name="attr_inf_weapon_skill_familiar" value="1">F)
                         </span>
-                        <span>Tn Bonus:<input type="number" name="attr_inf_weapon_tn_bonus" value="0" > (Will need to put in TN bonus from GU)
+                        <span>Tn Bonus:<input type="number" name="attr_inf_weapon_tn_bonus" value="0"> (Will need to put in TN bonus from GU)
                         </span>
                         <div>
-    
+
                             Traits:
                             <input type="checkbox" name="attr_inf_weapon_traits_show" />
-    
+
                             <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                             <span class="sheet-body">
                                 Mode: (<input type="radio" value="2" name="attr_inf_weapon_traits_mode_selector" checked>
-    
+
                                 <span type="text" name="attr_inf_weapon_traits_selector_2"></span>
                                 <input type="radio" value="3" name="attr_inf_weapon_traits_mode_selector">
                                 <span type="text" name="attr_inf_weapon_traits_selector_3"></span>)
-                                <input type="number" name="attr_inf_weapon_traits_mode_selector" hidden>
+                                <input type="number" name="attr_inf_weapon_traits_mode_selector" value="0" hidden>
                             </span>
                             <span type="text" name="attr_inf_weapon_traits" value=""></span>
-                            <input type="checkbox" name="attr_inf_weapon_traits_show" class="sheet-toggle-show" hidden/>
+                            <input type="checkbox" name="attr_inf_weapon_traits_show" class="sheet-toggle-show" hidden />
                             <div class="sheet-body" style="border: #000 1px solid;">
-                                <span class="trait-box" >
+                                <span class="trait-box">
                                     <span class="trait-item">
                                         Mode:<input type="checkbox" name="attr_inf_weapon_traits_mode" value="1">
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
@@ -4449,7 +4514,7 @@
                                         Advanced:
                                         <input type="checkbox" name="attr_inf_weapon_traits_advanced" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_advanced" value="0" hidden>
-                                        <input type="number" name="attr_inf_weapon_traits_advanced_selector" value="1" hidden>                                        
+                                        <input type="number" name="attr_inf_weapon_traits_advanced_selector" value="1" hidden>
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                         <span class="sheet-body">
                                             <input type="radio" value="1" name="attr_inf_weapon_traits_advanced_selector" checked>|
@@ -4457,12 +4522,12 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_advanced_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Blast <input type="checkbox" name="attr_inf_weapon_traits_blast" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_blast" value="0" hidden>
-                                        <input type="number" name="attr_inf_weapon_traits_blast_selector" value="1"hidden>
-    
+                                        <input type="number" name="attr_inf_weapon_traits_blast_selector" value="1" hidden>
+
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                         <span class="sheet-body">
                                             <input type="radio" value="1" name="attr_inf_weapon_traits_blast_selector" checked>|
@@ -4470,7 +4535,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_blast_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Brace <input type="checkbox" name="attr_inf_weapon_traits_brace" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_brace" value="0" hidden>
@@ -4504,8 +4569,8 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_frag_selector">
                                         </span>
                                     </span>
-    
-    
+
+
                                     <span class="trait-item">
                                         Haywire <input type="checkbox" name="attr_inf_weapon_traits_haywire" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_haywire" value="0" hidden>
@@ -4517,11 +4582,11 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_haywire_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Indirect <input type="checkbox" name="attr_inf_weapon_traits_indirect" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_indirect" value="0" hidden>
-                                        <input type="number" name="attr_inf_weapon_traits_indirect_selector" value="1" hidden>                                        
+                                        <input type="number" name="attr_inf_weapon_traits_indirect_selector" value="1" hidden>
                                         <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                         <span class="sheet-body">
                                             <input type="radio" value="1" name="attr_inf_weapon_traits_indirect_selector" checked>|
@@ -4529,7 +4594,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_indirect_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Missile <input type="checkbox" name="attr_inf_weapon_traits_missile" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_missile" value="0" hidden>
@@ -4541,7 +4606,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_missile_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Muscle Powered <input type="checkbox" name="attr_inf_weapon_traits_musclepowered" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_musclepowered" value="0" hidden>
@@ -4553,8 +4618,8 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_musclepowered_selector">
                                         </span>
                                     </span>
-    
-    
+
+
                                     <span class="trait-item">
                                         Non-Lethal <input type="checkbox" name="attr_inf_weapon_traits_nonlethal" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_nonlethal" value="0" hidden>
@@ -4566,7 +4631,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_nonlethal_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Poison <input type="checkbox" name="attr_inf_weapon_traits_poison" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_poison" value="0" hidden>
@@ -4578,7 +4643,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_poison_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Placed <input type="checkbox" name="attr_inf_weapon_traits_placed" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_placed" value="0" hidden>
@@ -4590,7 +4655,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_placed_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Precise <input type="checkbox" name="attr_inf_weapon_traits_precise" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_precise" value="0" hidden>
@@ -4602,7 +4667,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_precise_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Reach <input type="checkbox" name="attr_inf_weapon_traits_reach" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_reach" value="0" hidden>
@@ -4614,7 +4679,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_reach_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Silent <input type="checkbox" name="attr_inf_weapon_traits_silent" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_silent" value="0" hidden>
@@ -4626,7 +4691,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_silent_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Slashing <input type="checkbox" name="attr_inf_weapon_traits_slashing" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_slashing" value="0" hidden>
@@ -4638,7 +4703,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_slashing_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Shot <input type="checkbox" name="attr_inf_weapon_traits_shot" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_shot" value="0" hidden>
@@ -4650,7 +4715,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_shot_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Shock <input type="checkbox" name="attr_inf_weapon_traits_shock" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_shock" value="0" hidden>
@@ -4662,7 +4727,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_shock_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Smoke <input type="checkbox" name="attr_inf_weapon_traits_smoke" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_smoke" value="0" hidden>
@@ -4674,7 +4739,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_smoke_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Spray <input type="checkbox" name="attr_inf_weapon_traits_spray" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_spray" value="0" hidden>
@@ -4686,7 +4751,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_spray_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Stun <input type="checkbox" name="attr_inf_weapon_traits_stun" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_stun" value="0" hidden>
@@ -4698,7 +4763,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_stun_selector">
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Thrown <input type="checkbox" name="attr_inf_weapon_traits_thrown" value="1">
                                         <input type="number" name="attr_inf_weapon_traits_thrown" value="0" hidden>
@@ -4710,9 +4775,9 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_thrown_selector">
                                         </span>
                                     </span>
-    
+
                                 </span>
-    
+
                                 <div class="trait-box">
                                     <span class="trait-item">
                                         AoE: <input type="number" name="attr_inf_weapon_traits_aoe" class="digit" value="0" min="0">
@@ -4734,7 +4799,7 @@
                                             <input type="radio" value="3" name="attr_inf_weapon_traits_ap_selector">)
                                         </span>
                                     </span>
-    
+
                                     <span class="trait-item">
                                         Burst:<input type="number" name="attr_inf_weapon_traits_burst" class="digit" value="0" min="0">
                                         <input type="number" name="attr_inf_weapon_traits_burst_selector" value="1" hidden>
@@ -4798,10 +4863,10 @@
                                 </div>
                             </div>
                         </div>
-    
+
                         Mods: <textarea class="inputarea" name="attr_inf_weapon_mods"> </textarea>
-    
-    
+
+
                     </div>
                     </span>
                 </fieldset>
@@ -4833,552 +4898,552 @@
     </select>
     <span>Change Bars on Change tabs <input type="checkbox" name="attr_change_bars" class="sheet-block-switch">
         <div class="sheet-block-a">
-    Bar 1: <select name="attr_bar1">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-    Bar 2: <input type="text" name="attr_bar2" hidden>
-    <select name="attr_bar2">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
+            Bar 1: <select name="attr_bar1">
+                <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                <option value="damage_shell">Shell Damage</option>
+                <option value="damage_system">System Damage</option>
+                <option value="damage_total">Total Damage</option>
+                <option value="damage_reduction">Total Damage Reduction</option>
+                <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                <option value="gear_hi">Hull Integrity</option>
+                <option value="gear_arm">Armour</option>
+            </select>
+            Bar 2: <input type="text" name="attr_bar2" hidden>
+            <select name="attr_bar2">
+                <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                <option value="damage_shell">Shell Damage</option>
+                <option value="damage_system">System Damage</option>
+                <option value="damage_total">Total Damage</option>
+                <option value="damage_reduction">Total Damage Reduction</option>
+                <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                <option value="gear_hi">Hull Integrity</option>
+                <option value="gear_arm">Armour</option>
+            </select>
 
-    Bar 3: <input type="text" name="attr_bar3" hidden>
-    <select name="attr_bar3">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-</div>
-<div class="sheet-block-b">
-    <div>
-        Character:
-    Bar 1: <select name="attr_character_bar1">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-    Bar 2: 
-    <select name="attr_character_bar2">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-    Bar 3: 
-    <select name="attr_character_bar3">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-    </div>
-    <div>
-        Gear:
-    Bar 1: <select name="attr_gear_bar1">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-    Bar 2: <input type="text" name="attr_gear_bar2" hidden>
-    <select name="attr_gear_bar2">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-    Bar 3: <input type="text" name="attr_gear_bar3" hidden>
-    <select name="attr_gear_bar3">
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
-        <option value="damage_shell">Shell Damage</option>
-        <option value="damage_system">System Damage</option>
-        <option value="damage_total">Total Damage</option>
-        <option value="damage_reduction">Total Damage Reduction</option>
-        <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
-        <option value="gear_hi">Hull Integrity</option>
-        <option value="gear_arm">Armour</option>
-    </select>
-    </div>
-    
-</div>
-    Bar1: <span name="attr_a1_bar"></span>
-    Bar2: <span name="attr_a2_bar"></span>
-    Bar3: <span name="attr_a3_bar"></span>
-    Change <span name="attr_change_bars"></span>
-    Optional Rules
-    <span>No Archetypes : <input type="checkbox" name="attr_optional_archetype">
-    </span>
-    <div>
-    <h2> Notes for the GM</h2>
-    <textarea name="attr_admin_gmnotes"></textarea>
-    Downtime
-    <textarea name="attr_admin_downtime"></textarea>
-        <h3>Current Issues</h3>
-        <p> Gear Weapon TN bonus only updates when changing domains</p>
-        <p></p>
-
-
-
-    </div>
-    Version Changes:
-    <span>Ver:<span name="attr_load_version"></span> </span>
-    <p>
-        <span> Wiki: https://wiki.roll20.net/Heavy_Gear_4th_Edition </span>
-    <div>
-        <h3>Sheet is still in development. It is recomended you create a copy of your game after each session, as some data may be lost </h3>
-        If data is missing, check below, it may be there.
-        <h3>Personal Weapons</h3>
-        <fieldset class="repeating_weapon">
-            <div><span name="attr_weapon_size"></span>
-                <span>
-                    <input type="checkbox" name="attr_weapon_frame_check" class="frame-check" hidden>
-                    <span class="no-frame" name="attr_weapon_name">
-                    </span>
-                    <span class="frame" name="attr_frame_weapon_type"></span>
-                    i:<input type="checkbox" name="attr_weapon_hide" class="sheet-toggle-show" checked>
-                </span>
-                <span class="pull-right"> <input type="number" class="digit" name="attr_weapon_ammo">/<span name="attr_weapon_ammo_max"></span></span>
-                <button type="action" name="act_tumble">roll</button>
+            Bar 3: <input type="text" name="attr_bar3" hidden>
+            <select name="attr_bar3">
+                <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                <option value="damage_shell">Shell Damage</option>
+                <option value="damage_system">System Damage</option>
+                <option value="damage_total">Total Damage</option>
+                <option value="damage_reduction">Total Damage Reduction</option>
+                <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                <option value="gear_hi">Hull Integrity</option>
+                <option value="gear_arm">Armour</option>
+            </select>
+        </div>
+        <div class="sheet-block-b">
+            <div>
+                Character:
+                Bar 1: <select name="attr_character_bar1">
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                    <option value="damage_shell">Shell Damage</option>
+                    <option value="damage_system">System Damage</option>
+                    <option value="damage_total">Total Damage</option>
+                    <option value="damage_reduction">Total Damage Reduction</option>
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                    <option value="gear_hi">Hull Integrity</option>
+                    <option value="gear_arm">Armour</option>
+                </select>
+                Bar 2:
+                <select name="attr_character_bar2">
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                    <option value="damage_shell">Shell Damage</option>
+                    <option value="damage_system">System Damage</option>
+                    <option value="damage_total">Total Damage</option>
+                    <option value="damage_reduction">Total Damage Reduction</option>
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                    <option value="gear_hi">Hull Integrity</option>
+                    <option value="gear_arm">Armour</option>
+                </select>
+                Bar 3:
+                <select name="attr_character_bar3">
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                    <option value="damage_shell">Shell Damage</option>
+                    <option value="damage_system">System Damage</option>
+                    <option value="damage_total">Total Damage</option>
+                    <option value="damage_reduction">Total Damage Reduction</option>
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                    <option value="gear_hi">Hull Integrity</option>
+                    <option value="gear_arm">Armour</option>
+                </select>
+            </div>
+            <div>
+                Gear:
+                Bar 1: <select name="attr_gear_bar1">
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                    <option value="damage_shell">Shell Damage</option>
+                    <option value="damage_system">System Damage</option>
+                    <option value="damage_total">Total Damage</option>
+                    <option value="damage_reduction">Total Damage Reduction</option>
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                    <option value="gear_hi">Hull Integrity</option>
+                    <option value="gear_arm">Armour</option>
+                </select>
+                Bar 2: <input type="text" name="attr_gear_bar2" hidden>
+                <select name="attr_gear_bar2">
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                    <option value="damage_shell">Shell Damage</option>
+                    <option value="damage_system">System Damage</option>
+                    <option value="damage_total">Total Damage</option>
+                    <option value="damage_reduction">Total Damage Reduction</option>
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                    <option value="gear_hi">Hull Integrity</option>
+                    <option value="gear_arm">Armour</option>
+                </select>
+                Bar 3: <input type="text" name="attr_gear_bar3" hidden>
+                <select name="attr_gear_bar3">
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Character</option>
+                    <option value="damage_shell">Shell Damage</option>
+                    <option value="damage_system">System Damage</option>
+                    <option value="damage_total">Total Damage</option>
+                    <option value="damage_reduction">Total Damage Reduction</option>
+                    <option disabled style="background:gray;font-weight:bold;color:white;">&nbsp;&nbsp;&nbsp;&nbsp; Gear </option>
+                    <option value="gear_hi">Hull Integrity</option>
+                    <option value="gear_arm">Armour</option>
+                </select>
             </div>
 
-            <input type="checkbox" name="attr_weapon_hide" class="sheet-toggle-show" hidden>
-            <div class="sheet-body">
-                Damage: <input type="number" name="attr_weapon_damage">
-                <span class="pull-right">Burden: <input class="digit" type="number" name="attr_weapon_burden" step="0.25"></span>
-                <span>
-                    <select name="attr_weapon_size" class="size">
-                        <option value="Light" selected>Light</option>
-                        <option value="Medium">Medium</option>
-                        <option value="Heavy">Heavy</option>
-                    </select>
-                    <input type="checkbox" name="attr_weapon_frame_check" class="frame-check" hidden>
-                    <span class="no-frame"> <input class="infoused" type="text" name="attr_weapon_name" value="weapon">
-                    </span>
-                    <span class="frame">
-                        <select name="attr_frame_weapon_type" class="size">
-                            <option value="Assault Rifle">Assault Rifle</option>
-                            <option value="Auto Shotgun">Auto Shotgun</option>
-                            <option value="Carbine">Carbine</option>
-                            <option value="Rifle">Rifle</option>
-                            <option value="Machine Pistol">Machine Pistol</option>
-                            <option value="Pistol/Revolver">Pistol/Revolver</option>
-                            <option value="Shotgun">Shotgun</option>
-                            <option value="Sniper Rifle">Sniper Rifle</option>
-                        </select>
-                    </span>
-                </span>
-
-                <p>Range: <input class="emcalc" style="--index: -11;" type="text" name="attr_weapon_range">
-                    <span class="pull-right">Mode:<input type="number" name="attr_weapon_ammo_max" class="digit"></span>
-                </p>
-                Frame:<input type="checkbox" name="attr_weapon_frame_check" class="frame-check">
-                Cumbersome:<input type="checkbox" name="attr_weapon_cumbersome">
-                PL: <input type="number" name="attr_weapon_pl" class="digit">
-                <div>
-
-                    Traits <input type="text" name="attr_inf_weapon_traits" value="">
-                    <input type="checkbox" name="attr_inf_weapon_traits_show" class="sheet-toggle-show" />
-                    <div class="sheet-body">
-                        <span class="trait-box">
-                            <span class="trait-item">
-                                Mode:<input type="checkbox" name="attr_inf_weapon_traits_mode" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <span type="text" name="attr_inf_weapon_traits_selector_2"> </span> OR
-                                    <span type="text" name="attr_inf_weapon_traits_selector_3"> </span>
-                                </span>
-                            </span>
-                            <span class="trait-item">
-                                Advanced:
-                                <input type="checkbox" name="attr_inf_weapon_traits_advanced" value="1">
-
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_advanced_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_advanced_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_advanced_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Blast <input type="checkbox" name="attr_inf_weapon_traits_blast" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_blast_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_blast_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_blast_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Brace <input type="checkbox" name="attr_inf_weapon_traits_Brace" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_brace_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_brace_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_brace_selector">
-                                </span>
-                            </span>
-                            <span class="trait-item">
-                                Corrosion <input type="checkbox" name="attr_inf_weapon_traits_corrosion" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_corrosion_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_corrosion_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_corrosion_selector">
-                                </span>
-                            </span>
-                            <span class="trait-item">
-                                Frag <input type="checkbox" name="attr_inf_weapon_traits_frag" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_frag_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_frag_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_frag_selector">
-                                </span>
-                            </span>
+        </div>
+        Bar1: <span name="attr_a1_bar"></span>
+        Bar2: <span name="attr_a2_bar"></span>
+        Bar3: <span name="attr_a3_bar"></span>
+        Change <span name="attr_change_bars"></span>
+        Optional Rules
+        <span>No Archetypes : <input type="checkbox" name="attr_optional_archetype">
+        </span>
+        <div>
+            <h2> Notes for the GM</h2>
+            <textarea name="attr_admin_gmnotes"></textarea>
+            Downtime
+            <textarea name="attr_admin_downtime"></textarea>
+            <h3>Current Issues</h3>
+            <p> Gear Weapon TN bonus only updates when changing domains</p>
+            <p></p>
 
 
-                            <span class="trait-item">
-                                Haywire <input type="checkbox" name="attr_inf_weapon_traits_haywire" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_haywire_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_haywire_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_haywire_selector">
-                                </span>
-                            </span>
 
-                            <span class="trait-item">
-                                Indirect <input type="checkbox" name="attr_inf_weapon_traits_indirect" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_indirect_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_indirect_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_indirect_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Missile <input type="checkbox" name="attr_inf_weapon_traits_missile" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_missile_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_missile_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_missile_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Muscle Powered <input type="checkbox" name="attr_inf_weapon_traits_musclepowered" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_musclepowered_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_musclepowered_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_musclepowered_selector">
-                                </span>
-                            </span>
-
-
-                            <span class="trait-item">
-                                Non-Lethal <input type="checkbox" name="attr_inf_weapon_traits_nonlethal" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_nonlethal_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_nonlethal_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_nonlethal_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Poison <input type="checkbox" name="attr_inf_weapon_traits_poison" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_poison_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_poison_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_poison_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Placed <input type="checkbox" name="attr_inf_weapon_traits_placed" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_placed_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_placed_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_placed_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Precise <input type="checkbox" name="attr_inf_weapon_traits_precise" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_precise_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_precise_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_precise_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Reach <input type="checkbox" name="attr_inf_weapon_traits_reach" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_reach_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_reach_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_reach_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Silent <input type="checkbox" name="attr_inf_weapon_traits_silent" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_silent_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_silent_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Slashing <input type="checkbox" name="attr_inf_weapon_traits_slashing" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_slashing_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_slashing_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Shot <input type="checkbox" name="attr_inf_weapon_traits_shot" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_shot_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_shot_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_shot_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Shock <input type="checkbox" name="attr_inf_weapon_traits_shock" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_shock_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_shock_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_shock_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Smoke <input type="checkbox" name="attr_inf_weapon_traits_smoke" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_smoke_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_smoke_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_smoke_selector">
-                                </span>
-                            </span>
-                            <span class="trait-item">
-                                Spray <input type="checkbox" name="attr_inf_weapon_traits_spray" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_spray_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_spray_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_spray_selector">
-                                </span>
-                            </span>
-
-
-                            <span class="trait-item">
-                                Stun <input type="checkbox" name="attr_inf_weapon_traits_stun" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_stun_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_stun_selector">
-                                </span>
-                            </span>
-
-                            <span class="trait-item">
-                                Thrown <input type="checkbox" name="attr_inf_weapon_traits_thrown" value="1">
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_thrown_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_thrown_selector">
-                                </span>
-                            </span>
-
+        </div>
+        Version Changes:
+        <span>Ver:<span name="attr_load_version"></span> </span>
+        <p>
+            <span> Wiki: https://wiki.roll20.net/Heavy_Gear_4th_Edition </span>
+        <div>
+            <h3>Sheet is still in development. It is recomended you create a copy of your game after each session, as some data may be lost </h3>
+            If data is missing, check below, it may be there.
+            <h3>Personal Weapons</h3>
+            <fieldset class="repeating_weapon">
+                <div><span name="attr_weapon_size"></span>
+                    <span>
+                        <input type="checkbox" name="attr_weapon_frame_check" class="frame-check" hidden>
+                        <span class="no-frame" name="attr_weapon_name">
                         </span>
+                        <span class="frame" name="attr_frame_weapon_type"></span>
+                        i:<input type="checkbox" name="attr_weapon_hide" class="sheet-toggle-show" checked>
+                    </span>
+                    <span class="pull-right"> <input type="number" class="digit" name="attr_weapon_ammo" value="1">/<span name="attr_weapon_ammo_max"></span></span>
+                    <button type="action" name="act_tumble">roll</button>
+                </div>
 
-                        <div class="trait-box">
-                            <span class="trait-item">
-                                AoE: <input type="number" name="attr_inf_weapon_traits_aoe" class="digit" value="0" min="0">m
-                                <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
-                                    <span class="sheet-body">
-                                        -(<input type="number" name="attr_inf_weapon_traits_aoe_l" class="digit" value="0">m/
-                                        <input type="number" name="attr_inf_weapon_traits_aoe_m" class="digit" value="0">m/
-                                        <input type="number" name="attr_inf_weapon_traits_aoe_h" class="digit" value="0">m)
-                                    </span> </span>
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_aoe_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_aoe_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_aoe_selector">
-                                </span>
-                            </span>
-                            <span class="trait-item">
-                                AP:<input type="number" name="attr_inf_weapon_traits_ap" class="digit" value="0">
-                                <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
-                                    <span class="sheet-body">
-                                        -<input type="number" name="attr_inf_weapon_traits_ap_l" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_ap_m" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_ap_h" class="digit" value="0">
-                                    </span></span>
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_ap_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_ap_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_ap_selector">
-                                </span>
-                            </span>
+                <input type="checkbox" name="attr_weapon_hide" class="sheet-toggle-show" hidden>
+                <div class="sheet-body">
+                    Damage: <input type="number" name="attr_weapon_damage" value="0">
+                    <span class="pull-right">Burden: <input class="digit" type="number" name="attr_weapon_burden" step="0.25"></span>
+                    <span>
+                        <select name="attr_weapon_size" class="size">
+                            <option value="Light" selected>Light</option>
+                            <option value="Medium">Medium</option>
+                            <option value="Heavy">Heavy</option>
+                        </select>
+                        <input type="checkbox" name="attr_weapon_frame_check" class="frame-check" hidden>
+                        <span class="no-frame"> <input class="infoused" type="text" name="attr_weapon_name" value="weapon">
+                        </span>
+                        <span class="frame">
+                            <select name="attr_frame_weapon_type" class="size">
+                                <option value="Assault Rifle">Assault Rifle</option>
+                                <option value="Auto Shotgun">Auto Shotgun</option>
+                                <option value="Carbine">Carbine</option>
+                                <option value="Rifle">Rifle</option>
+                                <option value="Machine Pistol">Machine Pistol</option>
+                                <option value="Pistol/Revolver">Pistol/Revolver</option>
+                                <option value="Shotgun">Shotgun</option>
+                                <option value="Sniper Rifle">Sniper Rifle</option>
+                            </select>
+                        </span>
+                    </span>
 
-                            <span class="trait-item">
-                                Burst:<input type="number" name="attr_inf_weapon_traits_burst" class="digit" value="0" min="0">
-                                <span>
-                                    <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
+                    <p>Range: <input class="emcalc" style="--index: -11;" type="text" name="attr_weapon_range">
+                        <span class="pull-right">Ammo:<input type="number" name="attr_weapon_ammo_max" class="digit" value="0"></span>
+                    </p>
+                    Frame:<input type="checkbox" name="attr_weapon_frame_check" class="frame-check">
+                    Cumbersome:<input type="checkbox" name="attr_weapon_cumbersome">
+                    PL: <input type="number" name="attr_weapon_pl" class="digit" value="0">
+                    <div>
+
+                        Traits <input type="text" name="attr_inf_weapon_traits" value="">
+                        <input type="checkbox" name="attr_inf_weapon_traits_show" class="sheet-toggle-show" />
+                        <div class="sheet-body">
+                            <span class="trait-box">
+                                <span class="trait-item">
+                                    Mode:<input type="checkbox" name="attr_inf_weapon_traits_mode" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                     <span class="sheet-body">
-                                        -<input type="number" name="attr_inf_weapon_traits_burst_l" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_burst_m" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_burst_h" class="digit" value="0">
-                                    </span></span>
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_burst_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_burst_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_burst_selector">
-                                </span>
-                            </span>
-                            <span class="trait-item">
-                                Demo:<input type="number" name="attr_inf_weapon_traits_demo" class="digit" value="0">
-                                <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
-                                    <span class="sheet-body">
-                                        -<input type="number" name="attr_inf_weapon_traits_demo_l" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_demo_m" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_demo_h" class="digit" value="0">
+                                        <span type="text" name="attr_inf_weapon_traits_selector_2"> </span> OR
+                                        <span type="text" name="attr_inf_weapon_traits_selector_3"> </span>
                                     </span>
                                 </span>
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_demo_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_demo_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_demo_selector">
-                                </span>
-                            </span>
-                            <span class="trait-item">
-                                Fire:<input type="number" name="attr_inf_weapon_traits_fire" class="digit" value="0" min="0">
-                                <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
+                                <span class="trait-item">
+                                    Advanced:
+                                    <input type="checkbox" name="attr_inf_weapon_traits_advanced" value="1">
+
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
                                     <span class="sheet-body">
-                                        -<input type="number" name="attr_inf_weapon_traits_fire_l" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_fire_m" class="digit" value="0">/
-                                        <input type="number" name="attr_inf_weapon_traits_fire_h" class="digit" value="0">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_advanced_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_advanced_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_advanced_selector">
                                     </span>
                                 </span>
-                                <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
-                                <span class="sheet-body">
-                                    <input type="radio" value="1" name="attr_inf_weapon_traits_fire_selector" checked>|
-                                    <input type="radio" value="2" name="attr_inf_weapon_traits_fire_selector">
-                                    <input type="radio" value="3" name="attr_inf_weapon_traits_fire_selector">
+
+                                <span class="trait-item">
+                                    Blast <input type="checkbox" name="attr_inf_weapon_traits_blast" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_blast_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_blast_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_blast_selector">
+                                    </span>
                                 </span>
+
+                                <span class="trait-item">
+                                    Brace <input type="checkbox" name="attr_inf_weapon_traits_Brace" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_brace_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_brace_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_brace_selector">
+                                    </span>
+                                </span>
+                                <span class="trait-item">
+                                    Corrosion <input type="checkbox" name="attr_inf_weapon_traits_corrosion" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_corrosion_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_corrosion_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_corrosion_selector">
+                                    </span>
+                                </span>
+                                <span class="trait-item">
+                                    Frag <input type="checkbox" name="attr_inf_weapon_traits_frag" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_frag_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_frag_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_frag_selector">
+                                    </span>
+                                </span>
+
+
+                                <span class="trait-item">
+                                    Haywire <input type="checkbox" name="attr_inf_weapon_traits_haywire" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_haywire_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_haywire_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_haywire_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Indirect <input type="checkbox" name="attr_inf_weapon_traits_indirect" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_indirect_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_indirect_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_indirect_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Missile <input type="checkbox" name="attr_inf_weapon_traits_missile" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_missile_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_missile_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_missile_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Muscle Powered <input type="checkbox" name="attr_inf_weapon_traits_musclepowered" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_musclepowered_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_musclepowered_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_musclepowered_selector">
+                                    </span>
+                                </span>
+
+
+                                <span class="trait-item">
+                                    Non-Lethal <input type="checkbox" name="attr_inf_weapon_traits_nonlethal" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_nonlethal_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_nonlethal_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_nonlethal_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Poison <input type="checkbox" name="attr_inf_weapon_traits_poison" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_poison_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_poison_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_poison_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Placed <input type="checkbox" name="attr_inf_weapon_traits_placed" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_placed_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_placed_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_placed_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Precise <input type="checkbox" name="attr_inf_weapon_traits_precise" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_precise_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_precise_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_precise_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Reach <input type="checkbox" name="attr_inf_weapon_traits_reach" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_reach_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_reach_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_reach_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Silent <input type="checkbox" name="attr_inf_weapon_traits_silent" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_silent_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_silent_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Slashing <input type="checkbox" name="attr_inf_weapon_traits_slashing" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_slashing_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_slashing_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Shot <input type="checkbox" name="attr_inf_weapon_traits_shot" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_shot_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_shot_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_shot_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Shock <input type="checkbox" name="attr_inf_weapon_traits_shock" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_shock_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_shock_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_shock_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Smoke <input type="checkbox" name="attr_inf_weapon_traits_smoke" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_smoke_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_smoke_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_smoke_selector">
+                                    </span>
+                                </span>
+                                <span class="trait-item">
+                                    Spray <input type="checkbox" name="attr_inf_weapon_traits_spray" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_spray_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_spray_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_spray_selector">
+                                    </span>
+                                </span>
+
+
+                                <span class="trait-item">
+                                    Stun <input type="checkbox" name="attr_inf_weapon_traits_stun" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_stun_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_stun_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Thrown <input type="checkbox" name="attr_inf_weapon_traits_thrown" value="1">
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_silent_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_thrown_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_thrown_selector">
+                                    </span>
+                                </span>
+
                             </span>
-                        </div>
-                        <div>
-                            <p>
-                                See Desc <input type="checkbox" name="attr_inf_weapon_traits_see_desc" value="1">
-                                <input type="text" name="attr_inf_weapon_traits_desc" value="">
-                            </p>
-                            <p>
-                                Other: <input type="text" name="attr_inf_weapon_traits_other" value="">
-                            </p>
-                            Old Traits: <input class="infoused" type="text" name="attr_weapon_trait">
+
+                            <div class="trait-box">
+                                <span class="trait-item">
+                                    AoE: <input type="number" name="attr_inf_weapon_traits_aoe" class="digit" value="0" min="0">m
+                                    <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
+                                        <span class="sheet-body">
+                                            -(<input type="number" name="attr_inf_weapon_traits_aoe_l" class="digit" value="0">m/
+                                            <input type="number" name="attr_inf_weapon_traits_aoe_m" class="digit" value="0">m/
+                                            <input type="number" name="attr_inf_weapon_traits_aoe_h" class="digit" value="0">m)
+                                        </span> </span>
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_aoe_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_aoe_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_aoe_selector">
+                                    </span>
+                                </span>
+                                <span class="trait-item">
+                                    AP:<input type="number" name="attr_inf_weapon_traits_ap" class="digit" value="0">
+                                    <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
+                                        <span class="sheet-body">
+                                            -<input type="number" name="attr_inf_weapon_traits_ap_l" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_ap_m" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_ap_h" class="digit" value="0">
+                                        </span></span>
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_ap_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_ap_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_ap_selector">
+                                    </span>
+                                </span>
+
+                                <span class="trait-item">
+                                    Burst:<input type="number" name="attr_inf_weapon_traits_burst" class="digit" value="0" min="0">
+                                    <span>
+                                        <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
+                                        <span class="sheet-body">
+                                            -<input type="number" name="attr_inf_weapon_traits_burst_l" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_burst_m" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_burst_h" class="digit" value="0">
+                                        </span></span>
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_burst_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_burst_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_burst_selector">
+                                    </span>
+                                </span>
+                                <span class="trait-item">
+                                    Demo:<input type="number" name="attr_inf_weapon_traits_demo" class="digit" value="0">
+                                    <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
+                                        <span class="sheet-body">
+                                            -<input type="number" name="attr_inf_weapon_traits_demo_l" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_demo_m" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_demo_h" class="digit" value="0">
+                                        </span>
+                                    </span>
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_demo_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_demo_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_demo_selector">
+                                    </span>
+                                </span>
+                                <span class="trait-item">
+                                    Fire:<input type="number" name="attr_inf_weapon_traits_fire" class="digit" value="0" min="0">
+                                    <span> <input type="checkbox" name="attr_inf_weapon_traits_single" class="sheet-toggle-show-span" hidden />
+                                        <span class="sheet-body">
+                                            -<input type="number" name="attr_inf_weapon_traits_fire_l" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_fire_m" class="digit" value="0">/
+                                            <input type="number" name="attr_inf_weapon_traits_fire_h" class="digit" value="0">
+                                        </span>
+                                    </span>
+                                    <input type="checkbox" name="attr_inf_weapon_traits_mode" value="1" class="sheet-toggle-show-span" hidden />
+                                    <span class="sheet-body">
+                                        <input type="radio" value="1" name="attr_inf_weapon_traits_fire_selector" checked>|
+                                        <input type="radio" value="2" name="attr_inf_weapon_traits_fire_selector">
+                                        <input type="radio" value="3" name="attr_inf_weapon_traits_fire_selector">
+                                    </span>
+                                </span>
+                            </div>
+                            <div>
+                                <p>
+                                    See Desc <input type="checkbox" name="attr_inf_weapon_traits_see_desc" value="1">
+                                    <input type="text" name="attr_inf_weapon_traits_desc" value="">
+                                </p>
+                                <p>
+                                    Other: <input type="text" name="attr_inf_weapon_traits_other" value="">
+                                </p>
+                                Old Traits: <input class="infoused" type="text" name="attr_weapon_trait">
+                            </div>
                         </div>
                     </div>
+                    <span>
+                        <select name="attr_weapon_domain">
+                            <option value="1">Athletics</option>
+                            <option value="2">Awareness</option>
+                            <option value="3">Business</option>
+                            <option value="4">Craft</option>
+                            <option value="5">Culture</option>
+                            <option value="6">Electronic Warfare</option>
+                            <option value="7">Electronics</option>
+                            <option value="8">Gunnery</option>
+                            <option value="9">Hard Science</option>
+                            <option value="10">Influence</option>
+                            <option value="11">Institutions</option>
+                            <option value="12">Investigation</option>
+                            <option value="13">Mechanics</option>
+                            <option value="14">Medicine</option>
+                            <option value="15">Melee</option>
+                            <option value="16">Pilot</option>
+                            <option value="17">Showmanship</option>
+                            <option value="18">Socialscience</option>
+                            <option value="19">Survival</option>
+                            <option value="20">Tactics</option>
+                        </select>
+                        <span type="number" name="attr_weapon_expertise" value="0"></span>
+                    </span>
+                    <span>Skill:<input type="number" name="attr_skill_level" class="digit" value="0" min="0" max="5">(<input type="checkbox" name="attr_skill_familiar" value="1">F)
+
+                    </span>
+                    <textarea class="inputarea" name="attr_weapon_mods"> </textarea>
+
+
                 </div>
-                <span>
-                    <select name="attr_weapon_domain">
-                        <option value="1">Athletics</option>
-                        <option value="2">Awareness</option>
-                        <option value="3">Business</option>
-                        <option value="4">Craft</option>
-                        <option value="5">Culture</option>
-                        <option value="6">Electronic Warfare</option>
-                        <option value="7">Electronics</option>
-                        <option value="8">Gunnery</option>
-                        <option value="9">Hard Science</option>
-                        <option value="10">Influence</option>
-                        <option value="11">Institutions</option>
-                        <option value="12">Investigation</option>
-                        <option value="13">Mechanics</option>
-                        <option value="14">Medicine</option>
-                        <option value="15">Melee</option>
-                        <option value="16">Pilot</option>
-                        <option value="17">Showmanship</option>
-                        <option value="18">Socialscience</option>
-                        <option value="19">Survival</option>
-                        <option value="20">Tactics</option>
-                    </select>
-                    <span type="number" name="attr_weapon_expertise" value="0"></span>
-                </span>
-                <span>Skill:<input type="number" name="attr_skill_level" class="digit" value="0" min="0" max="5">(<input type="checkbox" name="attr_skill_familiar" value="1">F)
-
-                </span>
-                <textarea class="inputarea" name="attr_weapon_mods"> </textarea>
-
-
-            </div>
-            </span>
-        </fieldset>
-    </div>
+    </span>
+    </fieldset>
+</div>
 </div>
 
 <datalist id="archetypelist">
@@ -6091,13 +6156,17 @@ const findDomainLower = (domain = 0) => {
         domain = domain;
     };
     return domain;
+
 };
 
 //when stat button pushed, lookup weapon attributes
-const statGearWeapon = (input = "",arm = 0,lvl = 2, underslungWeapon = 0) => {
+const statGearWeapon = (input = "",arm = 0, lvl = 3, underslungWeapon = 0, domain = 8, domainTn = 1,familiar = 0) => {
     let gearweapon = gearWeaponLookup(input);
         gearweapon.code = input;
         gearweapon.lvl = lvl;
+        gearweapon.familiar = familiar;
+        gearweapon.geardomain = domain;
+        gearweapon.geardomainTn = domainTn;
         let damage = 0;
         let minusArray = [];
         let extraOther = [];
@@ -6136,7 +6205,7 @@ const statGearWeapon = (input = "",arm = 0,lvl = 2, underslungWeapon = 0) => {
         if (gearweapon.traits == undefined) {
             gearweapon.traits = [""];
         }
-        //if gearweapontraits is an array call decao
+        //if gearweapontraits is an array call decap
         if (Array.isArray(gearweapon.traits)) {
             gearweapon.traits = deCapitalise(gearweapon.traits);
         } else {
@@ -6276,14 +6345,9 @@ const statGearWeapon = (input = "",arm = 0,lvl = 2, underslungWeapon = 0) => {
         console.log("arc:"+gearweapon.arc);
         gearweapon.blitz = convertBlitz(gearweapon.range);
         console.log("blitz:"+gearweapon.blitz);
-        gearweapon.geardomain = 0;
-        if (gearweapon.mode == "M"){
-            gearweapon.geardomain = 2;
-        } else {
-            gearweapon.geardomain = 1;
-        }
         var newrowid = generateRowID();
         var newrowattrs = {};
+        var intialise = {};
         //set code
         if (underslungWeapon == 1){
             gearweapon.ammunition = gearweapon.ammunition/2;
@@ -6300,6 +6364,7 @@ const statGearWeapon = (input = "",arm = 0,lvl = 2, underslungWeapon = 0) => {
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_damage"] = gearweapon.damage;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_catagory"] = gearweapon.catagory;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_domain"] = gearweapon.geardomain;
+        newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_gear_domain_tn"] = gearweapon.geardomainTn;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_slots"] = gearweapon.slots;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_slots_misc"] = gearweapon.aux;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_location"] = gearweapon.location;
@@ -6309,9 +6374,10 @@ const statGearWeapon = (input = "",arm = 0,lvl = 2, underslungWeapon = 0) => {
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_traits_desc"] = gearweapon.desc;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_size"] = gearweapon.size;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_skill_level"] = gearweapon.lvl;
+        newrowattrs["repeating_gearweapon_" + newrowid + "_gear_skill_familiar"] = gearweapon.familiar;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_arc"] = gearweapon.arc;
         newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_traits_other"] = gearweapon.other;
-        
+
         if (gearweapon.desc !== "") {
             newrowattrs["repeating_gearweapon_" + newrowid + "_gear_weapon_traits_see_desc"] = 1;
         }
@@ -6332,8 +6398,7 @@ const statGearWeapon = (input = "",arm = 0,lvl = 2, underslungWeapon = 0) => {
             }
         });
     //console.log("newrowattrs:"+newrowattrs);
-    setAttrs(newrowattrs, {silent: true}, underslungcheck(gearweapon,arm,lvl));
-   
+    setAttrs(newrowattrs, {silent: true}, underslungcheck(gearweapon,arm,lvl, ));
 }
 
 function underslungcheck(gearweapon,arm,lvl) {
@@ -6343,11 +6408,14 @@ function underslungcheck(gearweapon,arm,lvl) {
 }
 
 on('clicked:gear_weapon_stat', function() {
-    getAttrs(["gear_weapon_code","gear_arm","gear_weapon_lvl"], function(v) {
+    getAttrs(["gear_weapon_code","gear_arm","gear_weapon_lvl","gear_weapon_domain","gear_weapon_gear_domain_tn","gear_weapon_skill_familiar"], function(v) {
         let input = v["gear_weapon_code"];
-        let lvl = v["gear_weapon_lvl"];
+        let lvl = parseInt(v["gear_weapon_lvl"]);
         let arm = parseInt(v["gear_arm"]);
-        statGearWeapon(input,arm,lvl,0);
+        let domain = parseInt(v["gear_weapon_domain"]);
+        let domainTn = parseInt(v["gear_weapon_gear_domain_tn"]);
+        let familiar = parseInt(v["gear_weapon_skill_familiar"]);
+        statGearWeapon(input,arm,lvl,0,domain,domainTn,familiar);
     });
 }); 
 
@@ -6400,7 +6468,7 @@ const gearWeaponLookup = (string) => {
     }
     switch (weaponcode) {
         case "AAC":
-        gearweapon = {type:"Anti-Air Cannon ", range :"60-180/360",size: sizeletter, l:6,m:7, h:8, traits:["Burst:1","Flak"], catagory:"D", slots:2, aux:1, location:"Manip", ammunition:5, pl:1, desc:""};
+        gearweapon = {type:"Anti-Air Cannon", range :"60-180/360",size: sizeletter, l:6,m:7, h:8, traits:["Burst:1","Flak"], catagory:"D", slots:2, aux:1, location:"Manip", ammunition:5, pl:1, desc:""};
         break;
         case "AAM":
         gearweapon = {type:"Anti-Air Missile", range :"60-360/720",size: sizeletter, l:7,m:8, h:9, traits:["Flak"," Guided","Limited Ammo"], catagory:"D,I", slots:3, aux:0, location:"Shoulder, Torso", ammunition:3, pl:3, desc:""};
@@ -6423,7 +6491,7 @@ const gearWeaponLookup = (string) => {
         case "ATM":
         gearweapon = {type:"Anti-Tank Missile", range :"60-360/720",size: sizeletter, l:8,m:9, h:10, traits:["AP:2/3/4","Guided","Limited Ammo"], catagory:"D,I", slots:2, aux:2, location:"Shoulder, Torso", ammunition:2, pl:5, desc:""};
         break;
-        case "VG":
+        case "AVG":
         gearweapon = {type:"Anti-Vehicle Grenade", range :"30-60/90",size: sizeletter, l:4,m:5, h:6, traits:["AP:2/4/6","Limited Ammo"], catagory:"D", slots:2, aux:0, location:"Manip", ammunition:4, pl:3, desc:""};
         break;
         case "AVM":
@@ -7090,7 +7158,7 @@ infWeaponTraits.forEach(function (trait) {
 //changes gear weapon traits to a string of traits that each gear weapon 
 gearWeaponTraits.forEach(function (trait) {
     on('change:repeating_gearweapon:gear_weapon_traits_'+trait+' change:repeating_gearweapon:gear_weapon_traits_'+trait+'_selector \
-        change:repeating_gearweapon:gear_weapon_traits_'+trait+'_selector_2 change:repeating_gearweapon:gear_weapon_traits_'+trait+'_selector_3', function() {
+        change:repeating_gearweapon:gear_weapon_traits_'+trait+'_selector_2 change:repeating_gearweapon:gear_weapon_traits_'+trait+'_selector_3 change:repeating_gearweapon:gear_weapon_initalised', function() {
         //console.log("change:repeating_gearweapon:gear_weapon_traits_"+trait);
         let traitList = {};
         let selectList = {};
@@ -9055,8 +9123,7 @@ extras: everything after the fields parameter is optional and can be in any orde
         }); 
     };
 
+
+    //data
+
 </script>
-
-
-
-


### PR DESCRIPTION
Fixed Add New Gear Weapon not displaying traits and update valueless inputs

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description


**Reissued Pull request after auto-update bug**

Values added to inputs that lacked initial values
Bug fix: Gear Weapon Traits now update when weapons are created with Add New Weapon button


