### PR TITLE
[Lancer RPG (1.8)] Bugfix and Additional Mech Data for Frame Selection

### DIFF
--- a/LANCER RPG (1.8)/LANCER.html
+++ b/LANCER RPG (1.8)/LANCER.html
@@ -13,6 +13,16 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 				frame_heat = 6;
 				frame_repairs = 5;
 				break;
+			case "CHOMOLUNGMA":
+				frame_hp = 10;
+				frame_heat = 6;
+				frame_repairs = 4;
+				break;
+			case "SAGARMATHA":
+				frame_hp = 8;
+				frame_heat = 6;
+				frame_repairs = 4;
+				break;
 			case "BLACKBEARD":
 				frame_hp = 12;
 				frame_heat = 4;
@@ -28,6 +38,16 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 				frame_heat = 5;
 				frame_repairs = 5;
 				break;
+			case "EMPAKAAI":
+				frame_hp = 10;
+				frame_heat = 6;
+				frame_repairs = 4;
+				break;
+			case "KIDD":
+				frame_hp = 6;
+				frame_heat = 4;
+				frame_repairs = 5;
+				break;
 			case "LANCASTER":
 				frame_hp = 6;
 				frame_heat = 6;
@@ -40,6 +60,11 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 				break;
 			case "RALEIGH":
 				frame_hp = 10;
+				frame_heat = 5;
+				frame_repairs = 5;
+				break;
+			case "STÖRTEBEKER":
+				frame_hp = 8;
 				frame_heat = 5;
 				frame_repairs = 5;
 				break;
@@ -78,6 +103,11 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 				frame_heat = 4;
 				frame_repairs = 3;
 				break;
+			case "EMPEROR":
+				frame_hp = 2;
+				frame_heat = 5;
+				frame_repairs = 2;
+				break;
 			case "METALMARK":
 				frame_hp = 8;
 				frame_heat = 5;
@@ -93,20 +123,40 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 				frame_heat = 4;
 				frame_repairs = 3;
 				break;
+			case "ORCHIS":
+				frame_hp = 8;
+				frame_heat = 6;
+				frame_repairs = 4;
+				break;
 			case "SWALLOWTAIL":
 				frame_hp = 6;
 				frame_heat = 4;
 				frame_repairs = 5;
 				break;
+			case "SWALLOWTAIL (RANGER VARIANT)":
+				frame_hp = 6;
+				frame_heat = 4;
+				frame_repairs = 5;
+				break;
+			case "VICEROY":
+				frame_hp = 8;
+				frame_heat = 6;
+				frame_repairs = 4;
+				break;
 			case "WHITE WITCH":
 				frame_hp = 7;
 				frame_heat = 4;
 				frame_repairs = 5;
-				breakl
+				break;
 			case "BALOR":
 				frame_hp = 12;
 				frame_heat = 4;
 				frame_repairs = 4;
+				break;
+			case "CALENDULA":
+				frame_hp = 7;
+				frame_heat = 6;
+				frame_repairs = 3;
 				break;
 			case "GOBLIN":
 				frame_hp = 6;
@@ -153,6 +203,11 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 				frame_heat = 8;
 				frame_repairs = 4;
 				break;
+			case "ENKIDU":
+				frame_hp = 10;
+				frame_heat = 8;
+				frame_repairs = 5;
+				break;
 			case "GENGHIS":
 				frame_hp = 6;
 				frame_heat = 10;
@@ -185,6 +240,11 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 				break;
 			case "TOKUGAWA":
 				frame_hp = 8;
+				frame_heat = 8;
+				frame_repairs = 4;
+				break;
+			case "'WORLDKILLER' GENGHIS MK I":
+				frame_hp = 6;
 				frame_heat = 8;
 				frame_repairs = 4;
 				break;
@@ -929,13 +989,19 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 							<select style="width:150px;height:25px;padding:0px;background:#eee;margin:0px;font-weight:normal" class="onederline" name="attr_frame_class"> <!--FRAME dropdown select-->
 								<optgroup label="GMS">
 									<option value="EVEREST">EVEREST</option>
+									<option value="CHOMOLUNGMA">CHOMOLUNGMA</option>
+									<option value="SAGARMATHA">SAGARMATHA</option>
 								</optgroup>
 								<optgroup label="IPS-NORTHSTAR">
 									<option value="BLACKBEARD">BLACKBEARD</option>
+									<option value="CALIBAN">CALIBAN</option>
 									<option value="DRAKE">DRAKE</option>
+									<option value="EMPAKAAI">EMPAKAAI</option>
+									<option value="KIDD">KIDD</option>
 									<option value="LANCASTER">LANCASTER</option>
 									<option value="NELSON">NELSON</option>
 									<option value="RALEIGH">RALEIGH</option>
+									<option value="STÖRTEBEKER">STÖRTEBEKER</option>
 									<option value="TORTUGA">TORTUGA</option>
 									<option value="VLAD">VLAD</option>
 									<option value="ZHENG">ZHENG</option>
@@ -945,14 +1011,19 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 									<option value="BLACK WITCH">BLACK WITCH</option>
 									<option value="DEATH'S HEAD">DEATH'S HEAD</option>
 									<option value="DUSK WING">DUSK WING</option>
+									<option value="EMPEROR">EMPEROR</option>
 									<option value="METALMARK">METALMARK</option>
 									<option value="MONARCH">MONARCH</option>
 									<option value="MOURNING CLOAK">MOURNING CLOAK</option>
+									<option value="ORCHIS">ORCHIS</option>
 									<option value="SWALLOWTAIL">SWALLOWTAIL</option>
+									<option value="SWALLOWTAIL (RANGER VARIANT)">SWALLOWTAIL (RANGER VARIANT)</option>
+									<option value="VICEROY">VICEROY</option>
 									<option value="WHITE WITCH">WHITE WITCH</option>
 								</optgroup>
 								<optgroup label="HORUS">
 									<option value="BALOR">BALOR</option>
+									<option value="CALENDULA">CALENDULA</option>
 									<option value="GOBLIN">GOBLIN</option>
 									<option value="GORGON">GORGON</option>
 									<option value="HYDRA">HYDRA</option>
@@ -964,6 +1035,7 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 								</optgroup>
 								<optgroup label="HARRISON ARMORY">
 									<option value="BARBAROSSA">BARBAROSSA</option>
+									<option value="ENKIDU">ENKIDU</option>
 									<option value="GENGHIS">GENGHIS</option>
 									<option value="ISKANDER">ISKANDER</option>
 									<option value="NAPOLEON">NAPOLEON</option>
@@ -971,6 +1043,7 @@ on("sheet:opened change:acc_diff change:frame_save_target change:frame_class cha
 									<option value="SHERMAN">SHERMAN</option>
 									<option value="SUNZI">SUNZI</option>
 									<option value="TOKUGAWA">TOKUGAWA</option>
+									<option value="'WORLDKILLER' GENGHIS MK I">'WORLDKILLER' GENGHIS MK I</option>
 								</optgroup>
 								<optgroup label="HOMEBREW">
 									<option value="HOMEBREW">HOMEBREW</option>


### PR DESCRIPTION
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Fixed White Witch missing semicolon.
Made IPS-N Caliban selectable in Frame list.

Added data for other official mech frames from expansions:
GMS Chomolungma
GMS Sagarmatha
IPS-N Empakaai
IPS-N Kidd
IPS-N Störtebeker
SSC Emperor
SSC Orchis
SSC Swallowtail (Ranger Variant)
SSC Viceroy
Horus Calendula
HA Enkidu
HA 'Worldkiller' Genghis MK I