### PR TITLE
BattleTech A Time of War 3rd Printing Update - Removal of tiered skills

### DIFF
--- a/BattleTech-A-Time-of-War/BattleTech-A-Time-of-War.html
+++ b/BattleTech-A-Time-of-War/BattleTech-A-Time-of-War.html
@@ -944,6 +944,15 @@ const skillsList = {
             "archery": "Archery",
         },
     },
+    "art": {
+        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
+        "targetNumber": 9,
+        "complexity": "CA",
+        "subSkills": true,
+        "displayName": {
+            "art": "Art",
+        },
+    },
     "artillery": {
         "linkedAttributes": [INTELLIGENCE_LINK, WILL_LINK, ],
         "targetNumber": 8,
@@ -969,6 +978,15 @@ const skillsList = {
         "subSkills": false,
         "displayName": {
             "climbing": "Climbing",
+        },
+    },
+    "computers": {
+        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
+        "targetNumber": 9,
+        "complexity": "CA",
+        "subSkills": false,
+        "displayName": {
+            "computers": "Computers",
         },
     },
     "communications": {
@@ -1055,6 +1073,15 @@ const skillsList = {
             "gunnery_turret": "Gunnery/Turret",
         },
     },
+    "interest": {
+        "linkedAttributes": [INTELLIGENCE_LINK, WILL_LINK, ],
+        "targetNumber": 9,
+        "complexity": "CA",
+        "subSkills": true,
+        "displayName": {
+            "interest": "Interest",
+        },
+    },
     "interrogation": {
         "linkedAttributes": [WILL_LINK, CHARISMA_LINK, ],
         "targetNumber": 9,
@@ -1091,6 +1118,15 @@ const skillsList = {
             "leadership": "Leadership",
         },
     },
+    "martial": {
+        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
+        "targetNumber": 8,
+        "complexity": "SA",
+        "subSkills": false,
+        "displayName": {
+            "martial_arts": "Martial Arts",
+        },
+    },
     "medtech": {
         "linkedAttributes": [INTELLIGENCE_LINK, ],
         "targetNumber": 7,
@@ -1099,6 +1135,15 @@ const skillsList = {
         "displayName": {
             "medtech_general": "MedTech/General",
             "medtech_veterinary": "MedTech/Veterinary",
+        },
+    },
+    "melee": {
+        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
+        "targetNumber": 8,
+        "complexity": "SA",
+        "subSkills": false,
+        "displayName": {
+            "melee_weapons": "Melee Weapons",
         },
     },
     "navigation": {
@@ -1147,6 +1192,17 @@ const skillsList = {
             "piloting_rail_vehicle": "Piloting/Rail Vehicle",
             "piloting_sea_vehicle": "Piloting/Sea Vehicle",
             "piloting_spacecraft": "Piloting/Spacecraft",
+        },
+    },
+    "prestidigitation": {
+        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
+        "targetNumber": 8,
+        "complexity": "SA",
+        "subSkills": false,
+        "displayName": {
+            "prestidigitation_pick_pocket": "Prestidigitation/Pick Pocket",
+            "prestidigitation_quickdraw": "Prestidigitation/Quickdraw",
+            "prestidigitation_sleight_of_hand": "Prestidigitation/Sleight of Hand",
         },
     },
     "protocol": {
@@ -1337,133 +1393,6 @@ const skillsList = {
     },
 };
 
-const tieredSkillsBasic = {
-    "art": {
-        "linkedAttributes": [DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "CB",
-        "subSkills": true,
-        "displayName": {
-            "art": "Art",
-        },
-    },
-    "computers": {
-        "linkedAttributes": [INTELLIGENCE_LINK, ],
-        "targetNumber": 8,
-        "complexity": "CB",
-        "subSkills": false,
-        "displayName": {
-            "computers": "Computers",
-        },
-    },
-    "interest": {
-        "linkedAttributes": [INTELLIGENCE_LINK, ],
-        "targetNumber": 8,
-        "complexity": "CB",
-        "subSkills": true,
-        "displayName": {
-            "interest": "Interest",
-        },
-    },
-    "martial": {
-        "linkedAttributes": [REFLEX_LINK, ],
-        "targetNumber": 7,
-        "complexity": "SB",
-        "subSkills": false,
-        "displayName": {
-            "martial_arts": "Martial Arts",
-        },
-    },
-    "melee": {
-        "linkedAttributes": [DEXTERITY_LINK, ],
-        "targetNumber": 7,
-        "complexity": "SB",
-        "subSkills": false,
-        "displayName": {
-            "melee_weapons": "Melee Weapons",
-        },
-    },
-    "prestidigitation": {
-        "linkedAttributes": [DEXTERITY_LINK, ],
-        "targetNumber": 7,
-        "complexity": "SB",
-        "subSkills": false,
-        "displayName": {
-            "prestidigitation_pick_pocket": "Prestidigitation/Pick Pocket",
-            "prestidigitation_quickdraw": "Prestidigitation/Quickdraw",
-            "prestidigitation_sleight_of_hand": "Prestidigitation/Sleight of Hand",
-        },
-    },
-};
-
-const tieredSkillsAdvanced = {
-    "art": {
-        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
-        "targetNumber": 9,
-        "complexity": "CA",
-        "subSkills": true,
-        "displayName": {
-            "art": "Art",
-        },
-    },
-    "computers": {
-        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
-        "targetNumber": 9,
-        "complexity": "CA",
-        "subSkills": false,
-        "displayName": {
-            "computers": "Computers",
-        },
-    },
-    "interest": {
-        "linkedAttributes": [INTELLIGENCE_LINK, WILL_LINK, ],
-        "targetNumber": 9,
-        "complexity": "CA",
-        "subSkills": true,
-        "displayName": {
-            "interest": "Interest",
-        },
-    },
-    "martial": {
-        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "SA",
-        "subSkills": false,
-        "displayName": {
-            "martial_arts": "Martial Arts",
-        },
-    },
-    "melee": {
-        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "SA",
-        "subSkills": false,
-        "displayName": {
-            "melee_weapons": "Melee Weapons",
-        },
-    },
-    "prestidigitation": {
-        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "SA",
-        "subSkills": false,
-        "displayName": {
-            "prestidigitation_pick_pocket": "Prestidigitation/Pick Pocket",
-            "prestidigitation_quickdraw": "Prestidigitation/Quickdraw",
-            "prestidigitation_sleight_of_hand": "Prestidigitation/Sleight of Hand",
-        },
-    },
-};
-
-const tieredSkills = [
-    "art",
-    "computers",
-    "interest",
-    "martial",
-    "melee",
-    "prestidigitation",
-];
-
 const calculateSkillLevel = (skillXP, learningSpeedModifier) => {
     const learningSpeedPercentageModifier = 1 + 0.2 * learningSpeedModifier;
 
@@ -1502,16 +1431,8 @@ const getSkillDisplayName = (skill, skillDisplayNameKey, subSkill) => {
     return skill.displayName[skillDisplayNameKey]
 };
 
-const getSkill = (skillName, skillLevel, tieredSkill) => {
-    if (tieredSkill) {
-        if (skillLevel <= 3) {
-            return tieredSkillsBasic[skillName]
-        } else {
-            return tieredSkillsAdvanced[skillName]
-        }
-    } else {
-        return skillsList[skillName]
-    }
+const getSkill = (skillName) => {
+  return skillsList[skillName]
 };
 
 const sheetOpened = () => {
@@ -1587,11 +1508,7 @@ const skillXPChanged = ({
 
         skillAttributesToSet[skillLevel] = calculateSkillLevel(Number(newValue), values.learning_speed);
 
-        const skillData = getSkill(
-            skillNameLookupKey,
-            skillAttributesToSet[skillLevel],
-            tieredSkills.includes(skillNameLookupKey)
-        );
+        const skillData = getSkill(skillNameLookupKey);
 
         skillAttributesToSet["repeating_skills_" + skillId + "skill_tnc"] = skillData.targetNumber + "/" + skillData.complexity;
         skillAttributesToSet["repeating_skills_" + skillId + "target_number"] = skillData.targetNumber;
@@ -1736,11 +1653,6 @@ const migrateFrom2To3 = () => {
 
                 if (skillFirstName in skillsList) {
                     skillData = skillsList[skillFirstName];
-                } else if (skillFirstName in tieredSkillsBasic) {
-                    skillData = tieredSkillsBasic[skillFirstName];
-                } else if (skillFirstName.substring(0, skillFirstName.length - 1) in tieredSkillsBasic) {
-                    skillData = tieredSkillsBasic[skillFirstName.substring(0, skillFirstName.length - 1)];
-                    parsedSkillName = parsedSkillName.substring(0, parsedSkillName.length - 1);
                 } else {
                     console.error("Unable to migrate skill data. Old values are: " + JSON.stringify(oldSkillValues));
                     skillsUpdated++;
@@ -1802,7 +1714,3 @@ const migrateFrom2To3 = () => {
 };
 
 </script>
-
-
-
-

--- a/BattleTech-A-Time-of-War/development/src/domain/skills/skills-list.js
+++ b/BattleTech-A-Time-of-War/development/src/domain/skills/skills-list.js
@@ -66,6 +66,15 @@ export const skillsList = {
             "archery": "Archery",
         },
     },
+    "art": {
+        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
+        "targetNumber": 9,
+        "complexity": "CA",
+        "subSkills": true,
+        "displayName": {
+            "art": "Art",
+        },
+    },
     "artillery": {
         "linkedAttributes": [INTELLIGENCE_LINK, WILL_LINK, ],
         "targetNumber": 8,
@@ -91,6 +100,15 @@ export const skillsList = {
         "subSkills": false,
         "displayName": {
             "climbing": "Climbing",
+        },
+    },
+    "computers": {
+        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
+        "targetNumber": 9,
+        "complexity": "CA",
+        "subSkills": false,
+        "displayName": {
+            "computers": "Computers",
         },
     },
     "communications": {
@@ -177,6 +195,15 @@ export const skillsList = {
             "gunnery_turret": "Gunnery/Turret",
         },
     },
+    "interest": {
+        "linkedAttributes": [INTELLIGENCE_LINK, WILL_LINK, ],
+        "targetNumber": 9,
+        "complexity": "CA",
+        "subSkills": true,
+        "displayName": {
+            "interest": "Interest",
+        },
+    },
     "interrogation": {
         "linkedAttributes": [WILL_LINK, CHARISMA_LINK, ],
         "targetNumber": 9,
@@ -213,6 +240,15 @@ export const skillsList = {
             "leadership": "Leadership",
         },
     },
+    "martial": {
+        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
+        "targetNumber": 8,
+        "complexity": "SA",
+        "subSkills": false,
+        "displayName": {
+            "martial_arts": "Martial Arts",
+        },
+    },
     "medtech": {
         "linkedAttributes": [INTELLIGENCE_LINK, ],
         "targetNumber": 7,
@@ -221,6 +257,15 @@ export const skillsList = {
         "displayName": {
             "medtech_general": "MedTech/General",
             "medtech_veterinary": "MedTech/Veterinary",
+        },
+    },
+    "melee": {
+        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
+        "targetNumber": 8,
+        "complexity": "SA",
+        "subSkills": false,
+        "displayName": {
+            "melee_weapons": "Melee Weapons",
         },
     },
     "navigation": {
@@ -269,6 +314,17 @@ export const skillsList = {
             "piloting_rail_vehicle": "Piloting/Rail Vehicle",
             "piloting_sea_vehicle": "Piloting/Sea Vehicle",
             "piloting_spacecraft": "Piloting/Spacecraft",
+        },
+    },
+    "prestidigitation": {
+        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
+        "targetNumber": 8,
+        "complexity": "SA",
+        "subSkills": false,
+        "displayName": {
+            "prestidigitation_pick_pocket": "Prestidigitation/Pick Pocket",
+            "prestidigitation_quickdraw": "Prestidigitation/Quickdraw",
+            "prestidigitation_sleight_of_hand": "Prestidigitation/Sleight of Hand",
         },
     },
     "protocol": {
@@ -458,130 +514,3 @@ export const skillsList = {
         },
     },
 }
-
-export const tieredSkillsBasic = {
-    "art": {
-        "linkedAttributes": [DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "CB",
-        "subSkills": true,
-        "displayName": {
-            "art": "Art",
-        },
-    },
-    "computers": {
-        "linkedAttributes": [INTELLIGENCE_LINK, ],
-        "targetNumber": 8,
-        "complexity": "CB",
-        "subSkills": false,
-        "displayName": {
-            "computers": "Computers",
-        },
-    },
-    "interest": {
-        "linkedAttributes": [INTELLIGENCE_LINK, ],
-        "targetNumber": 8,
-        "complexity": "CB",
-        "subSkills": true,
-        "displayName": {
-            "interest": "Interest",
-        },
-    },
-    "martial": {
-        "linkedAttributes": [REFLEX_LINK, ],
-        "targetNumber": 7,
-        "complexity": "SB",
-        "subSkills": false,
-        "displayName": {
-            "martial_arts": "Martial Arts",
-        },
-    },
-    "melee": {
-        "linkedAttributes": [DEXTERITY_LINK, ],
-        "targetNumber": 7,
-        "complexity": "SB",
-        "subSkills": false,
-        "displayName": {
-            "melee_weapons": "Melee Weapons",
-        },
-    },
-    "prestidigitation": {
-        "linkedAttributes": [DEXTERITY_LINK, ],
-        "targetNumber": 7,
-        "complexity": "SB",
-        "subSkills": false,
-        "displayName": {
-            "prestidigitation_pick_pocket": "Prestidigitation/Pick Pocket",
-            "prestidigitation_quickdraw": "Prestidigitation/Quickdraw",
-            "prestidigitation_sleight_of_hand": "Prestidigitation/Sleight of Hand",
-        },
-    },
-}
-
-export const tieredSkillsAdvanced = {
-    "art": {
-        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
-        "targetNumber": 9,
-        "complexity": "CA",
-        "subSkills": true,
-        "displayName": {
-            "art": "Art",
-        },
-    },
-    "computers": {
-        "linkedAttributes": [DEXTERITY_LINK, INTELLIGENCE_LINK, ],
-        "targetNumber": 9,
-        "complexity": "CA",
-        "subSkills": false,
-        "displayName": {
-            "computers": "Computers",
-        },
-    },
-    "interest": {
-        "linkedAttributes": [INTELLIGENCE_LINK, WILL_LINK, ],
-        "targetNumber": 9,
-        "complexity": "CA",
-        "subSkills": true,
-        "displayName": {
-            "interest": "Interest",
-        },
-    },
-    "martial": {
-        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "SA",
-        "subSkills": false,
-        "displayName": {
-            "martial_arts": "Martial Arts",
-        },
-    },
-    "melee": {
-        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "SA",
-        "subSkills": false,
-        "displayName": {
-            "melee_weapons": "Melee Weapons",
-        },
-    },
-    "prestidigitation": {
-        "linkedAttributes": [REFLEX_LINK, DEXTERITY_LINK, ],
-        "targetNumber": 8,
-        "complexity": "SA",
-        "subSkills": false,
-        "displayName": {
-            "prestidigitation_pick_pocket": "Prestidigitation/Pick Pocket",
-            "prestidigitation_quickdraw": "Prestidigitation/Quickdraw",
-            "prestidigitation_sleight_of_hand": "Prestidigitation/Sleight of Hand",
-        },
-    },
-}
-
-export const tieredSkills = [
-    "art",
-    "computers",
-    "interest",
-    "martial",
-    "melee",
-    "prestidigitation",
-]

--- a/BattleTech-A-Time-of-War/development/src/sheet-worker.js
+++ b/BattleTech-A-Time-of-War/development/src/sheet-worker.js
@@ -8,9 +8,7 @@ import {
     getSkillDisplayName
 } from './skills'
 import {
-    skillsList,
-    tieredSkillsBasic,
-    tieredSkills
+    skillsList
 } from './domain/skills/skills-list'
 
 const sheetOpened = () => {
@@ -86,11 +84,7 @@ const skillXPChanged = ({
 
         skillAttributesToSet[skillLevel] = calculateSkillLevel(Number(newValue), values.learning_speed)
 
-        const skillData = getSkill(
-            skillNameLookupKey,
-            skillAttributesToSet[skillLevel],
-            tieredSkills.includes(skillNameLookupKey)
-        )
+        const skillData = getSkill(skillNameLookupKey)
 
         skillAttributesToSet["repeating_skills_" + skillId + "skill_tnc"] = skillData.targetNumber + "/" + skillData.complexity
         skillAttributesToSet["repeating_skills_" + skillId + "target_number"] = skillData.targetNumber
@@ -237,11 +231,6 @@ const migrateFrom2To3 = () => {
 
                 if (skillFirstName in skillsList) {
                     skillData = skillsList[skillFirstName]
-                } else if (skillFirstName in tieredSkillsBasic) {
-                    skillData = tieredSkillsBasic[skillFirstName]
-                } else if (skillFirstName.substring(0, skillFirstName.length - 1) in tieredSkillsBasic) {
-                    skillData = tieredSkillsBasic[skillFirstName.substring(0, skillFirstName.length - 1)]
-                    parsedSkillName = parsedSkillName.substring(0, parsedSkillName.length - 1)
                 } else {
                     console.error("Unable to migrate skill data. Old values are: " + JSON.stringify(oldSkillValues))
                     skillsUpdated++

--- a/BattleTech-A-Time-of-War/development/src/skills.js
+++ b/BattleTech-A-Time-of-War/development/src/skills.js
@@ -2,10 +2,7 @@ import {
     linkedAttributeDisplayNames
 } from './attributes'
 import {
-    skillsList,
-    tieredSkills,
-    tieredSkillsBasic,
-    tieredSkillsAdvanced
+    skillsList
 } from './domain/skills/skills-list'
 
 const skillXPChanged = ({
@@ -29,11 +26,7 @@ const skillXPChanged = ({
 
         skillAttributesToSet[skillLevel] = calculateSkillLevel(Number(newValue), values.learning_speed)
 
-        const skillData = getSkill(
-            skillNameLookupKey,
-            skillAttributesToSet[skillLevel],
-            tieredSkills.includes(skillNameLookupKey)
-        )
+        const skillData = getSkill(skillNameLookupKey)
 
         skillAttributesToSet["repeating_skills_" + skillId + "skill_tnc"] = skillData.targetNumber + "/" + skillData.complexity
         skillAttributesToSet["repeating_skills_" + skillId + "target_number"] = skillData.targetNumber
@@ -93,14 +86,6 @@ export const getSkillDisplayName = (skill, skillDisplayNameKey, subSkill) => {
     return skill.displayName[skillDisplayNameKey]
 }
 
-export const getSkill = (skillName, skillLevel, tieredSkill) => {
-    if (tieredSkill) {
-        if (skillLevel <= 3) {
-            return tieredSkillsBasic[skillName]
-        } else {
-            return tieredSkillsAdvanced[skillName]
-        }
-    } else {
-        return skillsList[skillName]
-    }
+export const getSkill = (skillName) => {
+    return skillsList[skillName]
 }

--- a/BattleTech-A-Time-of-War/development/test/skills.test.js
+++ b/BattleTech-A-Time-of-War/development/test/skills.test.js
@@ -8,33 +8,9 @@ import {
     getSkillDisplayName
 } from '../src/skills'
 
-// Get normal or tiered skill
-test('should get basic tiered skill', () => {
-    expect(getSkill('computers', 3, true)).toStrictEqual({
-        "linkedAttributes": ["intelligence_link", ],
-        "targetNumber": 8,
-        "complexity": "CB",
-        "subSkills": false,
-        "displayName": {
-            "computers": "Computers",
-        },
-    })
-})
-
-test('should get advanced tiered skill', () => {
-    expect(getSkill('martial', 4, true)).toStrictEqual({
-        "linkedAttributes": ["reflex_link", "dexterity_link", ],
-        "targetNumber": 8,
-        "complexity": "SA",
-        "subSkills": false,
-        "displayName": {
-            "martial_arts": "Martial Arts",
-        },
-    })
-})
-
-test('should get normal skill', () => {
-    expect(getSkill('leadership', 7, false)).toStrictEqual({
+// Get skill
+test('should get skill', () => {
+    expect(getSkill('leadership')).toStrictEqual({
         "linkedAttributes": ["will_link", "charisma_link", ],
         "targetNumber": 8,
         "complexity": "SA",


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

The 3rd printing of A Time of War removes tiered skills, making them work just like regular skills, with the "advanced" level being treated as the standard. I'm fairly certain that this change doesn't actually necessitate updating the sheet version or changing the migration script for older versions, as it doesn't actually change the data format of the sheet, just the behavior for what were previously tiered skills.


