### PR TITLE
RolemasterUnified Official: Urgent fix for ~ behaviour change

### DIFF
--- a/RolemasterUnified_Official/rolemasterunified.html
+++ b/RolemasterUnified_Official/rolemasterunified.html
@@ -8738,7 +8738,7 @@ function changeTalentPurchase(ev) {
       const tiers = parseIntDefault(tdata.data.Tiers, 1);
       const cost = parseIntDefault(tdata.data.Cost, 0);
       const costpertier = parseIntDefault(tdata.data['Cost per Tier'], cost);
-      console.log("change talen purchase", tiers, cost, costpertier, tdata);
+      console.log("change talent purchase", tiers, cost, costpertier, tdata);
       let list = []
       if (tiers > 1) {
 	showChoices([`${basename} .talent_tier_show`])
@@ -8768,10 +8768,12 @@ function changeTalentPurchase(ev) {
 }
 
 function changeTalentPurchaseTier(ev) {
-  let cost = parseIntDefault(ev.newValue.split("~")[1], -111);
+   // Workaround for the Roll20 API change that added expansion ids to
+   // strings randomly.
+  const str = ev.newValue?.replace(/\?expansion=\d*$/, "") || "";
+  let cost = parseIntDefault(str.split("~")[1], -111) || -111;
   if (cost == -111) {
-    console.log(ev.newValue.split("~"));
-    rmuerror("Unable to extract cost from ", ev.newValue);
+    rmuerror("Unable to extract cost from ", ev.newValue, str);
     cost = 0;
   }
   RMUCosts.update(ev.sourceSection, cost, 1);
@@ -9271,6 +9273,20 @@ onCheck("mancerfinish:levelup", (ev) => {
   })
 
   addPendingFunction("LevelupFinish: update all skills", RMUSkills.updateAllSkills);
+  addPendingFunction("LevelupFinish: Set HP/PP", () => {
+    getAttrsPending(["bodydevelopment_bonus", "powerdevelopment_bonus"], (data) => {
+      updates = {}
+      if (data.bodydevelopment_bonus) {
+	updates.hp = data.bodydevelopment_bonus;
+	updates.hp_max = data.bodydevelopment_bonus;
+      }
+      if (data.powerdevelopment_bonus) {
+	updates.pp = data.powerdevelopment_bonus;
+	updates.pp_max = data.powerdevelopment_bonus;
+      }
+      setAttrsPending(updates);
+    });
+  });
   addPendingFunction("LevelupFinish: Front page", updateFrontPage);
   addPendingFunction("LevelupFinish: Finish cmancer (roll20)", finishCharactermancer)
   pendingInfo();
@@ -10050,7 +10066,10 @@ function optionEncode(aname) {
   return getTranslationByKey(aname) + '~' + aname;
 }
 
-function optionDecode(str) {
+function optionDecode(dirty) {
+  // Workaround for the Roll20 API change that added expansion ids to
+  // strings randomly.
+  const str = dirty.replace(/\?expansion=\d*$/, "");
   if (!str.includes("~")) {
     console.log("optionDecode doesn't have a ~: ", str);
     return str;
@@ -10080,9 +10099,11 @@ function optionDecodeMaybe(str) {
   if (!str || !str.includes("~")) {
     return str;
   }
-  return str.split("~")[1];
+ // Workaround for the Roll20 API change that added expansion ids to
+  // strings randomly.
+  const str2 = str?.replace(/\?expansion=\d*$/, "");
+  return str2.split("~")[1];
 }
-
 
 const weaponGroups = ['meleeweaponsgroup','rangedweaponsgroup','unarmedgroup','shieldgroup'];
 

--- a/RolemasterUnified_Official/sheet.json
+++ b/RolemasterUnified_Official/sheet.json
@@ -8,5 +8,5 @@
   "legacy": false,
   "printable": true,
   "compendium": "RMU",
-  "version": "1726553860"
+  "version": "1726720015"
 }

--- a/RolemasterUnified_Official/updates.md
+++ b/RolemasterUnified_Official/updates.md
@@ -1,3 +1,15 @@
+# 2024-9-19
+
+Urgent fix for a roll20 API change.  Some of the values in fields from the
+charactermancer started getting expansion ids shoved on the return values.
+(if they contain a ~).
+
+So before we look parse the string, remove any expansion ids on the end.
+
+
+Sheet updates:
+- Force HP and PP to max on levelup
+
 # 2024-9-17
 
 Miscalenous bug fix week!


### PR DESCRIPTION
Urgent fix for a roll20 API change.  Some of the values in fields from the charactermancer started getting expansion ids shoved on the return values. (if they contain a ~).

So before we look parse the string, remove any expansion ids on the end.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [x] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




