### PR TITLE
BugFix for Dark Mode for Open Legend Sheet

### DIFF
--- a/Open Legend/Open Legend.css
+++ b/Open Legend/Open Legend.css
@@ -1720,8 +1720,8 @@ input[type=checkbox].sheet-tab-hide:checked ~ .sheet-show-hide {
 .sheet-rolltemplate-openLegendNormal .inlinerollresult,
 .sheet-rolltemplate-openLegendModern .inlinerollresult {
     color: #111111;
-    background-color: transparent;
-    border: none;
+    background-color: transparent !important;
+    border: none !important;
 }
 
 .sheet-rolltemplate-openLegend .inlinerollresult.fullcrit,
@@ -1730,8 +1730,8 @@ input[type=checkbox].sheet-tab-hide:checked ~ .sheet-show-hide {
 .sheet-rolltemplate-openLegend-effect .inlinerollresult.fullcrit,
 .sheet-rolltemplate-openLegendNormal .inlinerollresult.fullcrit,
 .sheet-rolltemplate-openLegendModern .inlinerollresult.fullcrit {
-    background-color: transparent;
-    border: none;
+    background-color: transparent !important;
+    border: none !important;
 }
 
 .sheet-rolltemplate-openLegend .inlinerollresult.fullfail,
@@ -1740,8 +1740,8 @@ input[type=checkbox].sheet-tab-hide:checked ~ .sheet-show-hide {
 .sheet-rolltemplate-openLegend-effect .inlinerollresult.fullfail,
 .sheet-rolltemplate-openLegendNormal .inlinerollresult.fullfail,
 .sheet-rolltemplate-openLegendModern .inlinerollresult.fullfail {
-    background-color: transparent;
-    border: none;
+    background-color: transparent !important;
+    border: none !important;
 }
 
 .sheet-rolltemplate-openLegend .inlinerollresult.importantroll,
@@ -1750,6 +1750,6 @@ input[type=checkbox].sheet-tab-hide:checked ~ .sheet-show-hide {
 .sheet-rolltemplate-openLegend-effect .inlinerollresult.importantroll,
 .sheet-rolltemplate-openLegendNormal .inlinerollresult.importantroll,
 .sheet-rolltemplate-openLegendModern .inlinerollresult.importantroll {
-    background-color: transparent;
-    border: none;
+    background-color: transparent !important;
+    border: none !important;
 }


### PR DESCRIPTION
Fixes a giant purple block from appearing on dark mode Roll20.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description
This adds !important to the ends of some of the CSS to force the night mode not to alter the inline roll template within the sheet rolls. Otherwise the night mode adds a large purple box blocking view of parts of the roll template. This is a fix intended to be replaced later  on with a proper one once I understand more fully how the night mode replacement works. A very minor update.