### PR TITLE
[Prowlers-and-Paragons-UE] UI fix for Transformation Power and Summoning Power

### DIFF
--- a/Prowlers_and_Paragons_Ultimate_Edition/prowlersnparagons.html
+++ b/Prowlers_and_Paragons_Ultimate_Edition/prowlersnparagons.html
@@ -52,11 +52,11 @@
 	<div class="sheet-header" style='width: 9.5%'>
 		<div class="sheet-section-name ">
 			<input type='checkbox' checked class='sheet-hideedge-toggle' name='attr_calculate_edge' value='1' style='display: none;' />
-			<button type='roll' class="roll-edge sheet-hideedge" name="act_edgebutton" title="Display edge in chat" value='&{template:default} {{name=@{character_name}}} {{Edge: = [[@{edgebox} ]] }}'>
+			<button type='roll' class="roll-edge sheet-hideedge" name="act_edgebutton" title="Display edge in chat" value='&{template:default} {{name=@{character_name}}} {{Edge: = [[@{edgebox} &{tracker}]] }}'>
 				EDGE
 			</button>
 			<input type='checkbox' checked class='sheet-hideedge-toggle' name='attr_calculate_edge' value='1' style='display: none;' />
-			<button type='roll' class="roll-edge sheet-showedge" name="act_edgebutton" title="Display edge in chat" value='&{template:default} {{name=@{character_name}}} {{Edge: = [[@{edge_manual} ]] }}'>
+			<button type='roll' class="roll-edge sheet-showedge" name="act_edgebutton" title="Display edge in chat" value='&{template:default} {{name=@{character_name}}} {{Edge: = [[@{edge_manual} &{tracker}]] }}'>
 				EDGE
 			</button>
 			<button type='roll' class='tokenaction' name='roll_rolledge' style='display: none;' value='&{template:default} {{name=@{character_name}}} {{edge=[[@{edgebox} &{tracker}]] }}'></button>
@@ -1304,21 +1304,21 @@
 								<input type='number' class='sheet-skills'  name="attr_summoningthreat" style='width: 25px; text-align: right;'>
 								Summoning Threat
 								<br><input type="checkbox" name="attr_summoning_pro_animals_narrow" value="1" title="1 hero point per rank"/>
-								PRO: animals (narrow selection)
+								PRO: animals, narrow selection (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_animals_wide" value="2" title="2 hero points per rank"/>
-								PRO: animals (wide variety)
+								PRO: animals (wide variety) (+2 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_automatons" value="1" title="1 hero point per rank"/>
-								PRO: automatons
+								PRO: automatons (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_duplicates" value="2" title="2 hero points per rank"/>
-								PRO: duplicates
+								PRO: duplicates (+2 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_shooters" value="1" title="1 hero point per rank"/>
-								PRO: shooters
+								PRO: shooters (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_unique_minor" value="1" title="1 hero point per rank"/>
-								PRO: unique (minor advantage)
+								PRO: unique (minor advantage) (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_unique_moderate" value="2" title="2 hero points per rank"/>
-								PRO: unique (moderate advantage)
+								PRO: unique (moderate advantage) (+2 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_unique_major" value="4" title="4 hero points per rank"/>
-								PRO: unique (major advantage)
+								PRO: unique (major advantage) (+4 per rank)
 							</div>
 						</div>
 						<div>
@@ -1429,7 +1429,7 @@
 							<div class='sheet-col sheet-hide' style='width: 100%;'>
 								Transformation type: 
 								<select name="attr_transformationtype" style='width:240px;'>
-									<option value="animalforms" selected="selected">animal forms</option><option value="doppleganger">doppleganger</option><option value="objectforms">object forms</option><option value="shapeshifting">shapeshifting</option>
+									<option value="animalforms" selected="selected">animal forms</option><option value="doppelganger">doppelganger</option><option value="objectforms">object forms</option><option value="shapeshifting">shapeshifting</option>
 								</select>
 								<input type="checkbox" hidden class="sheet-toggle sheet-left" name="attr_transformation-show" value="animalforms"/>
 								<div class='sheet-hide'>
@@ -2086,21 +2086,21 @@
 								<input type='number' class='sheet-skills'  name="attr_summoningthreat" style='width: 25px; text-align: right;'>
 								Summoning Threat
 								<br><input type="checkbox" name="attr_summoning_pro_animals_narrow" value="1" title="1 hero point per rank"/>
-								PRO: animals (narrow selection)
+								PRO: animals, narrow selection (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_animals_wide" value="2" title="2 hero points per rank"/>
-								PRO: animals (wide variety)
+								PRO: animals (wide variety) (+2 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_automatons" value="1" title="1 hero point per rank"/>
-								PRO: automatons
+								PRO: automatons (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_duplicates" value="2" title="2 hero points per rank"/>
-								PRO: duplicates
+								PRO: duplicates (+2 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_shooters" value="1" title="1 hero point per rank"/>
-								PRO: shooters
+								PRO: shooters (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_unique_minor" value="1" title="1 hero point per rank"/>
-								PRO: unique (minor advantage)
+								PRO: unique (minor advantage) (+1 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_unique_moderate" value="2" title="2 hero points per rank"/>
-								PRO: unique (moderate advantage)
+								PRO: unique (moderate advantage) (+2 per rank)
 								<br><input type="checkbox" name="attr_summoning_pro_unique_major" value="4" title="4 hero points per rank"/>
-								PRO: unique (major advantage)
+								PRO: unique (major advantage) (+4 per rank)
 							</div>
 						</div>
 						<div>
@@ -2211,7 +2211,7 @@
 							<div class='sheet-col sheet-hide' style='width: 100%;'>
 								Transformation type: 
 								<select name="attr_transformationtype" style='width:240px;'>
-									<option value="animalforms" selected="selected">animal forms</option><option value="doppleganger">doppleganger</option><option value="objectforms">object forms</option><option value="shapeshifting">shapeshifting</option>
+									<option value="animalforms" selected="selected">animal forms</option><option value="doppelganger">doppelganger</option><option value="objectforms">object forms</option><option value="shapeshifting">shapeshifting</option>
 								</select>	
 								<input type="checkbox" hidden class="sheet-toggle sheet-left" name="attr_transformation-show" value="animalforms"/>
 								<div class='sheet-hide'>
@@ -2893,7 +2893,7 @@
 	});	
 	
 	// Reveal the procons specific to a super trait in the right column
-	on("change:repeating_supertraitsother:power change:repeating_supertraitsother:formtype change:repeating_supertraitsother_transformationtype", function() {
+	on("change:repeating_supertraitsother:power change:repeating_supertraitsother:formtype change:repeating_supertraitsother:transformationtype", function() {
 		var output = {};
 		getAttrs(["repeating_supertraitsother_power", "repeating_supertraitsother_formtype", "repeating_supertraitsother_transformationtype"], function(values) {
 			output['repeating_supertraitsother_procon-show'] = values.repeating_supertraitsother_power;
@@ -3729,7 +3729,7 @@
 					if (values[id + '_transformationtype'] == 'animalforms') {
 						procontotal += Number(values[id + '_transformation_pro_enhanced']) + Number(values[id + '_transformation_con_onlyxbroad']) + Number(values[id + '_transformation_con_onlyxnarrow']);
 					}
-					if (values[id + '_transformationtype'] == 'doppleganger') {
+					if (values[id + '_transformationtype'] == 'doppelganger') {
 						costperrank = 6;
 						output[id + '_traitrank'] = 0;
 						rankspurchased = 1;


### PR DESCRIPTION
Fixed the PRO/CONs for the animal form showing up regardless of which transformation type is selected. 
Fixed Doppelganger spelling: Doppleganger -> Doppelganger 
Edge sheet button now invokes &tracker
Summoning power now shows PRO costs in text.

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




