### PR TITLE
fix Dark Heresy rolls for Dark Mode

### DIFF
--- a/Dark_Heresy/DarkHeresyStyle.css
+++ b/Dark_Heresy/DarkHeresyStyle.css
@@ -627,6 +627,12 @@
 	background: url(https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Dark_Heresy/img/rolltemplate_bg.png) top left repeat;
 }
 
+@media (prefers-color-scheme: dark) {
+	.sheet-rolltemplate-dh1ed table {
+		background: none;
+	}
+}
+	
 .sheet-rolltemplate-dh1ed .sheet-rolltemplate-spacer {
 	max-width : 100%;
 	height    : auto;
@@ -673,6 +679,12 @@
 	padding-left: 10px;
 	font-size   : 15px;
 	color       : rgb(80, 80, 80);
+}
+	
+@media (prefers-color-scheme: dark) {
+	.sheet-rolltemplate-dh1ed td {
+		color: initial;
+	}
 }
 
 .sheet-rolltemplate-dh1ed td:last-child {


### PR DESCRIPTION
# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

<!-- Please check any that apply: -->

- [ ] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Rolls in Dark Mode are unreadable due to the custom background image and font color.
This fix simply disables the problematic styles if Dark Mode is enabled.


