### PR TITLE
Update Dragon Age RPG.htmln. New Feature & Bugfix

### DIFF
--- a/Dragon Age RPG/Dragon Age RPG.html
+++ b/Dragon Age RPG/Dragon Age RPG.html
@@ -226,7 +226,7 @@
 				<table class='sheet-characterinfotable'>
 					<tr>
 						<td class='sheet-blackbox'><span data-i18n="name-u">NAME</span></td>
-						<td><input class='sheet-basicinfotextbox' type='text' name='attr_char_name' /></td>
+						<td><input class='sheet-basicinfotextbox' type='text' name='attr_character_name' /></td>
 					</tr>
 				</table>
 				<table class='sheet-characterinfotable'>
@@ -363,9 +363,9 @@
 							</tr>
 							<tr>
 								<td><input type='text' class='sheet-weaponnametext' name='attr_Weapon_Name_display' placeholder='Battle Axe' data-i18n-placeholder="battle-axe"/></td>
-								<td><button type='roll' value='/em @{char_name} uses @{Weapon_Name_display} to attack: [[{2d6, d6[Dragon Die]} + @{Weapon_Attack_display}]]' name='roll_Weapon_Attack_Check_display'></button></td>
+								<td><button type='roll' value='/em @{character_name} uses @{Weapon_Name_display} to attack: [[{2d6, d6[Dragon Die]} + @{Weapon_Attack_display}]]' name='roll_Weapon_Attack_Check_display'></button></td>
 								<td><input type='text' class='sheet-weaponatacktext' name='attr_Weapon_Attack_display' value='0' /></td>
-								<td><button type='roll' value='/em @{char_name} does [[@{Weapon_Damage_display}]] damage with @{Weapon_Name_display}' name='roll_Weapon_Damage_Check_display' ></button></td>
+								<td><button type='roll' value='/em @{character_name} does [[@{Weapon_Damage_display}]] damage with @{Weapon_Name_display}' name='roll_Weapon_Damage_Check_display' ></button></td>
 								<td><input type='text' class='sheet-weapondamagetext' name='attr_Weapon_Damage_display' placeholder='2d6' /></td>
 							</tr>
 							<tr>
@@ -376,9 +376,9 @@
 							<table class='sheet-weaponstable'>
 								<tr>
 									<td><input type='text' class='sheet-weaponnametext' name='attr_Weapon_Name' placeholder='Battle Axe' data-i18n-placeholder="battle-axe" /></td>
-									<td><button type='roll' value='/em @{char_name} uses @{Weapon_Name} to attack: [[{2d6, d6[Dragon Die]} + @{Weapon_Attack}]]' name='roll_Weapon_Attack_Check'></button></td>
+									<td><button type='roll' value='/em @{character_name} uses @{Weapon_Name} to attack: [[{2d6, d6[Dragon Die]} + @{Weapon_Attack}]]' name='roll_Weapon_Attack_Check'></button></td>
 									<td><input type='text' class='sheet-weaponatacktext' name='attr_Weapon_Attack' value='0' /></td>
-									<td><button type='roll' value='/em @{char_name} does [[@{Weapon_Damage}]] damage with @{Weapon_Name}' name='roll_Weapon_Damage_Check' ></button></td>
+									<td><button type='roll' value='/em @{character_name} does [[@{Weapon_Damage}]] damage with @{Weapon_Name}' name='roll_Weapon_Damage_Check' ></button></td>
 									<td><input type='text' class='sheet-weapondamagetext' name='attr_Weapon_Damage' placeholder='2d6' /></td>
 								</tr>
 								<tr>
@@ -411,9 +411,9 @@
 					</tr>
 					<tr>
 						<td><input type='text' class='sheet-weaponnametext' name='attr_ranged_Weapon_Name_display' placeholder='Short Bow' data-i18n-placeholder="short-bow" /></td>
-						<td><button type='roll' value='/em @{char_name} uses @{ranged_Weapon_Name_display} to attack: [[{2d6, d6[Dragon Die]} + @{ranged_Weapon_Attack_display}]]' name='roll_ranged_Weapon_Attack_Check_display'></button></td>
+						<td><button type='roll' value='/em @{character_name} uses @{ranged_Weapon_Name_display} to attack: [[{2d6, d6[Dragon Die]} + @{ranged_Weapon_Attack_display}]]' name='roll_ranged_Weapon_Attack_Check_display'></button></td>
 						<td><input type='text' class='sheet-weaponatacktext' name='attr_ranged_Weapon_Attack_display' value='0' /></td>
-						<td><button type='roll' value='/em @{char_name} does [[@{ranged_Weapon_Damage_display}]] damage with @{Weapon_Name_display}' name='roll_Weapon_Damage_Check_display' ></button></td>
+						<td><button type='roll' value='/em @{character_name} does [[@{ranged_Weapon_Damage_display}]] damage with @{Weapon_Name_display}' name='roll_Weapon_Damage_Check_display' ></button></td>
 						<td><input type='text' class='sheet-weapondamagetext' name='attr_ranged_Weapon_Damage_display' placeholder='1d6+1' /></td>
 						<td><input type='text' class='sheet-weaponrangetext' name='attr_ranged_Weapon_Short_Range_display' placeholder='16' title='Short Range' data-i18n-title="short-range" /></td>
 						<td><input type='text' class='sheet-weaponrangetext' name='attr_ranged_Weapon_Long_Range_display' placeholder='32' title='Long Range' data-i18n-title="long-range" /></td>
@@ -427,9 +427,9 @@
 					<table class='sheet-weaponstable'>
 						<tr>
 							<td><input type='text' class='sheet-weaponnametext' name='attr_ranged_Weapon_Name' placeholder='Short Bow' data-i18n-placeholder="short-bow" /></td>
-							<td><button type='roll' value='/em @{char_name} uses @{ranged_Weapon_Name} to attack: [[{2d6, d6[Dragon Die]} + @{ranged_Weapon_Attack}]]' name='roll_ranged_Weapon_Attack_Check'></button></td>
+							<td><button type='roll' value='/em @{character_name} uses @{ranged_Weapon_Name} to attack: [[{2d6, d6[Dragon Die]} + @{ranged_Weapon_Attack}]]' name='roll_ranged_Weapon_Attack_Check'></button></td>
 							<td><input type='text' class='sheet-weaponatacktext' name='attr_ranged_Weapon_Attack' value='0' /></td>
-							<td><button type='roll' value='/em @{char_name} does [[@{ranged_Weapon_Damage}]] damage with @{Weapon_Name}' name='roll_Weapon_Damage_Check' ></button></td>
+							<td><button type='roll' value='/em @{character_name} does [[@{ranged_Weapon_Damage}]] damage with @{Weapon_Name}' name='roll_Weapon_Damage_Check' ></button></td>
 							<td><input type='text' class='sheet-weapondamagetext' name='attr_ranged_Weapon_Damage' placeholder='1d6+1' /></td>
 							<td><input type='text' class='sheet-weaponrangetext' name='attr_ranged_Weapon_Short_Range' placeholder='16' title='Short Range' data-i18n-title="short-range" /></td>
 							<td><input type='text' class='sheet-weaponrangetext' name='attr_ranged_Weapon_Long_Range' placeholder='32' title='Long Range' data-i18n-title="long-range" /></td>
@@ -500,7 +500,7 @@
 				<td><input type='text' class='sheet-timetext' name='attr_Casting_Time_display' /></td>
 				<td><input type='number' class='sheet-natext' name='attr_Spell_TN_display' value='0' /></td>
 				<td><input type='text' class='sheet-vstext' name='attr_Vs_Test_display' /></td>
-				<td><button type='roll' value='/em @{char_name} tries to cast @{Spell_Name_display}: [[{2d6, d6[Dragon Die]} + (@{Magic} + @{Spell_School_display})]]' name='roll_Spell_display'></button></td>
+				<td><button type='roll' value='/em @{character_name} tries to cast @{Spell_Name_display}: [[{2d6, d6[Dragon Die]} + (@{Magic} + @{Spell_School_display})]]' name='roll_Spell_display'></button></td>
 			</tr>
 			<tr>
 				<td colspan='6'>
@@ -525,7 +525,7 @@
 					<td><input type='text' class='sheet-timetext' name='attr_Casting_Time' /></td>
 					<td><input type='number' class='sheet-natext' name='attr_Spell_TN' value='0' /></td>
 					<td><input type='text' class='sheet-vstext' name='attr_Vs_Test' /></td>
-					<td><button type='roll' value='/em @{char_name} tries to cast @{Spell_Name}: [[{2d6, d6[Dragon Die]} + (@{Magic} + @{Spell_School})]]' name='roll_Spell'></button></td>
+					<td><button type='roll' value='/em @{character_name} tries to cast @{Spell_Name}: [[{2d6, d6[Dragon Die]} + (@{Magic} + @{Spell_School})]]' name='roll_Spell'></button></td>
 				</tr>
 				<tr>
 					<td colspan='6'>
@@ -548,7 +548,7 @@
 					<td class='blackbox'><span data-i18n="character-u">CHARACTER</span></td>
 				</tr>
 				<tr>
-					<td><span name='attr_char_name'></span></td>
+					<td><span name='attr_character_name'></span></td>
 				</tr>
 			</table>
 		</div>


### PR DESCRIPTION
Modified the char_name attribute to character_name, so the sheet name will now be synchronised.  

<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

New Feature : The sheet's name will now have the same name as the character. Updated automatically thanks to the "attr_character_name" avalaible on Roll20;

Bugfix : Fixed a bug where the repeatable ranged weapon wouldn't display the correct name due to a bad attribute calling in the roll button. (Was @{Weapon_Name} instead of @{ranged_Weapon_Name} 
