### PR TITLE
Dragon Warriors: Bugfix and feature additions, updates sheet to version 2.01

### DIFF
--- a/Dragon Warriors/Dragon Warriors Revised.css
+++ b/Dragon Warriors/Dragon Warriors Revised.css
@@ -42,6 +42,7 @@
   padding: var(--padding); /* Consistent padding */
   font-size: inherit; /* Inherit font size from the root */
   box-sizing: border-box;
+  font-family: 'Cormorant Unicase', serif;  
 }
 
 .sheet-auto-expand {
@@ -255,7 +256,7 @@
 }
 
 .ui-dialog .charsheet img.icon.shield {
-  width: 98%;
+  width: 95%;
 }
 
 .ui-dialog .charsheet img.icon.hand,
@@ -280,10 +281,12 @@
 /* Styling for header images */
 .ui-dialog .charsheet img.headerimage {
   width: 100%;
+  height: auto;
 }
         
 .ui-dialog .charsheet img.icon.sword {
-  width: 60%;
+  width: 98%;
+  height: auto;
 }
 /* Additional image styling */
 .ui-dialog .charsheet img.icon.bow {
@@ -1298,17 +1301,16 @@
       display: grid;
       grid-template-areas: 
         "common common common"
-        "primaryattributes afattributes finalcombatattributes"
-        "finalattackdefenceattributes afattributes finalcombatattributes"
-        "evasionattribute  hpattributes finalcombatattributes"
-        "stealthperceptionattributes hpattributes finalcombatattributes"
-        "mamdattributes hpattributes finalcombatattributes"
-        "gapfillimg mpattributes classcombatabilities";
-      
-      /* Set all columns to equal width (1fr) */
-      grid-template-columns: 1fr 1fr 1fr;
-      grid-template-rows: auto; /* Automatically adjust row height */
+        "primaryattributes finalattackdefenceattributes afattributes"
+        "finalmeleecombatattributes finalrangedcombatattributes hpattributes"
+        "finalmeleecombatattributes finalrangedcombatattributes stealthperceptionattributes"
+        "finalmeleecombatattributes finalrangedcombatattributes evasionattribute"
+        "classcombatabilities mpattributes mamdattributes";
+        /* Set all columns to equal width (1fr) */
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-rows: auto; 
       gap: 10px; /* Space between grid items */
+      box-sizing: border-box;
     }
     
         .common {
@@ -1375,6 +1377,7 @@
           padding: var(--padding);
           border-radius: var(--border-radius);
           border: 5px double var(--border-color); /* Double-line border */
+          box-sizing: border-box;
         }
         
             .primaryattributes h2 {
@@ -1461,6 +1464,7 @@
           padding: var(--padding);
           border-radius: var(--border-radius);
           border: 5px double var(--border-color); /* Double-line border */
+          box-sizing: border-box;
         }
         
             .finalattackdefenceattributes h2 {
@@ -1527,6 +1531,7 @@
           padding: var(--padding);
           border-radius: var(--border-radius);
           border: 5px double var(--border-color); /* Double-line border */
+          box-sizing: border-box;
         }
         
             .evasionattribute h2 {
@@ -1558,6 +1563,7 @@
             padding: var(--padding);
             border-radius: var(--border-radius);
             border: 5px double var(--border-color); /* Double-line border */
+            box-sizing: border-box;
         }
                 
             .mamdattributes h2 {
@@ -1596,6 +1602,7 @@
             padding: var(--padding);
             border-radius: var(--border-radius);
             border: 5px double var(--border-color); /* Double-line border */
+            box-sizing: border-box;
         }
 
             .stealthperceptionattributes h2 {
@@ -1635,9 +1642,9 @@
                 margin: 0 5px;
             }
 
-        .gapfillimg {
-            grid-area: gapfillimg;
-        }
+        /* .gapfillimg { */
+        /*    grid-area: gapfillimg; */
+       /*  } */
         
         .hpattributes {
           grid-area: hpattributes;
@@ -1647,6 +1654,7 @@
           padding: var(--padding);
           border-radius: var(--border-radius);
           border: 5px double var(--border-color); /* Double-line border */
+          box-sizing: border-box;
         }
         
             .hpattributes h2 {
@@ -1660,20 +1668,20 @@
         .afattributes {
             display: grid;
             grid-area: afattributes;
-            grid-template-columns: 1fr 1fr; /* Adjust column widths */
+            grid-template-columns: 1fr 2fr; /* Adjust column widths */
             grid-template-areas: 
                 "afattribheader afattribheader"
-                "imgshieldcol aftype"
-                "imgshieldcol aftypeinput"
-                "imgshieldcol afname"
+                "aftype aftypeinput"
                 "imgshieldcol afinput"
-                "shieldbox shieldbox"
-                "shieldtogglebox shieldtogglebox";
+                "imgshieldcol shieldtogglebox"
+                "imgshieldcol frontshieldhidden";
             gap: 5px;
             background-color: var(--primary-bg-color);
             padding: var(--padding);
             border-radius: var(--border-radius);
-            border: 5px double var(--border-color); /* Double-line border */
+            border: 5px double var(--border-color);
+            box-sizing: border-box;
+            align-items: start; /* Vertically aligns the content */
         }
         
             .afattributes h2 {
@@ -1686,62 +1694,42 @@
             /* Assign grid areas based on class names */
             .afattributes .imgshieldcol {
                 grid-area: imgshieldcol;
-                display: flex;
-                justify-content: center;
-                align-items: center;
+                width: 98%;
             }
             
             .afattributes .aftype {
                 grid-area: aftype;
-                display: flex;
-                align-items: center;
             }
             
             .afattributes .aftypeinput {
                 grid-area: aftypeinput;
-            }
-            
-            .afattributes .afname {
-                grid-area: afname;
-                display: flex;
-                align-items: center;
+                width: 98%;
             }
             
             .afattributes .afinput {
                 grid-area: afinput;
             }
             
-            .afattributes .shieldbox {
-                grid-area: shieldbox;
-                display: flex;
-                align-items: center;
-            }
-            
             .shieldtogglebox {
                 grid-area: shieldtogglebox;
             }
+                .shieldtogglebox select.shield {
+                    width: 98%;
+                }
             
-            .afattributes .shieldhidden {
-                grid-area: shieldhidden;
-                grid-template-areas:
-                "shielddie shieldbutton";
+            .shieldhidden {
+                grid-area: frontshieldhidden;
             }
-                .shielddie {
-                    grid-area: shielddie;
-                }
-                
-                .shieldbutton {
-                    grid-area: shieldbutton;
-                }
-            
-        .finalcombatattributes {
-          grid-area: finalcombatattributes;
+
+        .finalmeleecombatattributes {
+          grid-area: finalmeleecombatattributes;
           display: grid;
           gap: 5px;
           background-color: var(--primary-bg-color); /* Make sure this matches your design */
           padding: var(--padding);
           border-radius: var(--border-radius);
           border: 5px double var(--border-color); /* Double-line border */
+          box-sizing: border-box;
           grid-template-columns: 1fr 1fr; /* Ensures all elements stack in a single column */
           grid-template-areas: 
           "finalcombatheader finalcombatheader"
@@ -1749,23 +1737,47 @@
           "equippedweaponbox equippedweaponbox"
           "abrbox abrbox"
           "damagebox damagebox"
-          "swordimage swordimage"
-          "rangedattack1 rangedattack1"
-          "equippedrangedweaponbox equippedrangedweaponbox"
-          "equippedammobox equippedammobox"
-          "rangedabrbox rangedabrbox"
-          "rangeddamagebox rangeddamagebox"
-          "bowimage rangedweaponranges"
-
+          "meleeothereffects meleeothereffects"
+          "swordimage swordimage";
         }
-            .finalcombatattributes h2 {
+        
+        .finalrangedcombatattributes {
+            grid-area: finalrangedcombatattributes;
+            display: grid;
+            gap: 5px;
+            background-color: var(--primary-bg-color); /* Make sure this matches your design */
+            padding: var(--padding);
+            border-radius: var(--border-radius);
+            border: 5px double var(--border-color); /* Double-line border */
+            grid-template-columns: 1fr 1fr; /* Ensures all elements stack in a single column */
+            box-sizing: border-box;
+            grid-template-areas: 
+                "finalcombatheader finalcombatheader"
+                "rangedattack1 rangedattack1"
+                "equippedrangedweaponbox equippedrangedweaponbox"
+                "equippedammobox equippedammobox"
+                "rangedabrbox rangedabrbox"
+                "rangeddamagebox rangeddamagebox"
+                "bowimage rangedweaponranges";
+        }
+        
+            .finalmeleecombatattributes h2 {
                 grid-area: finalcombatheader;
                 text-align: center;
                 font-size: 19px;
                 margin-bottom: 10px;
+                grid-row: 1;
+            }
+            
+            .finalrangedcombatattributes h2 {
+                grid-area: finalcombatheader;
+                text-align: center;
+                font-size: 19px;
+                margin-bottom: 10px;
+                grid-row: 1;
             }
 
-        
+
             .meleeattack1 {
                 grid-area: meleeattack1;
             }
@@ -1780,6 +1792,10 @@
                     
             .damagebox {
                 grid-area: damagebox;
+            }
+            
+            .meleeothereffects {
+                grid-area: meleeothereffects;
             }
                     
             .rangedattack1 {
@@ -1822,7 +1838,9 @@
           padding: var(--padding);
           border-radius: var(--border-radius);
           border: 5px double var(--border-color); /* Double-line border */
+          grid-template-rows: max-content;
           grid-template-columns: 1fr; /* Ensures all elements stack in a single column */
+          box-sizing: border-box;
           grid-template-areas:
             "classcombatabilitiesheader"
             "skills_known"
@@ -1841,17 +1859,59 @@
             }
             
             .melee {
+                display: grid;
                 grid-area: melee;
+                grid-template-rows: max-content;
+                grid-template-columns: 1fr; /* Ensures all elements stack in a single column */
+                grid-template-areas:
+                    "barbarianmelee"
+                    "knightmelee"
+                    "warlockmelee"
+                    "assassinmelee"
+                    "huntermelee"
+                    "knavemelee"
+                    "elementalistmelee"
+                    "mysticmelee"
+                    "priestmelee"
+                    "demonologistmelee"
+                    "nomelee";
             }
             
-                .melee h2 {
-                    grid-row: 1;
-                    grid-column: 1 / -1;
-                    text-align: center;
-                    font-size: 19px;
-                    margin-bottom: 10px;
-                }
-            
+            .barbarianmelee {
+                grid-area: barbarianmelee;
+            }
+            .knightmelee {
+                grid-area: knightmelee;
+            }
+            .warlockmelee {
+                grid-area: warlockmelee;
+            }
+            .assassinmelee {
+                grid-area: assassinmelee;
+            }
+            .huntermelee {
+                grid-area: huntermelee;
+            }
+            .knavemelee {
+                grid-area: knavemelee;
+            }
+            .elementalistmelee {
+                grid-area: elementalistmelee;
+            }
+            .mysticmelee {
+                grid-area: mysticmelee;
+            }
+            .priestmelee {
+                grid-area: priestmelee;
+            }
+            .demonologistmelee {
+                grid-area: demonologistmelee;
+            }
+            .nomelee {
+                grid-area: nomelee;
+            }
+
+
         .mpattributes {
           grid-area: mpattributes;
           display: grid;
@@ -1861,6 +1921,7 @@
           border-radius: var(--border-radius);
           border: 5px double var(--border-color); /* Double-line border */
           grid-template-columns: 1fr; /* Ensures all elements stack in a single column */
+          box-sizing: border-box;
           grid-template-areas:
           "mpattribheader"
           "mpattributeshidden"
@@ -2471,48 +2532,68 @@
             border: 5px double var(--border-color); /* Double-line border */
             grid-template-columns: 1fr;
             grid-template-areas:
-            "spells";
-        }
-        
-            .spells {
-                grid-area: spells;
+                "sorcerer"
+                "mystic"
+                "warlock"
+                "elementalist"
+                "demonologist"
+                "noncaster" ;
             }
-            
-          .spell-entry {
-            border: 1px solid var(--border-color);
-            border-radius: var(--border-radius);
-            padding: 10px;
-            margin-bottom: 10px; 
-            background-color: var(--primary-bg-color);
-          }
-          
-          .spell-entry > div {  /* Targets the direct children divs within .spell-entry */
-            margin-bottom: 5px; 
-          }
-          
-          .spell_name, 
-          .spell_range, 
-          .spell_duration,
-          .spell_replaces,
-          .spell_rarity,
-          .spell_origin {
-            font-weight: bold; 
-          }
         
-          .spell_name {  /* Style the spell name */
-            font-size: 22px; /* Increased font size */
-            font-weight: 700; /* Bolder font weight */
-          }
-          
-          .spell_desc p {
-            font-size: 18px; /* Reduced font size for descriptions */
-            font-family: 'Macondo', serif; 
-          }
-          
-          .spell_darkness p {
-            font-size: 18px; /* Reduced font size for darkness descriptions */
-            font-family: 'Macondo', serif;
-          }  
+                .sorcerer_spell_list {
+                    grid-area: sorcerer;
+                }
+                .mystic_spell_list {
+                    grid-area: mystic;
+                }
+                .warlock_spell_list {
+                    grid-area: warlock;
+                }
+                .elementalist_spell_list {
+                    grid-area: elementalist;
+                }
+                .demonologist_spell_list {
+                    grid-area: demonologist;
+                }
+                 .noncaster {
+                     grid-area: noncaster;
+                 }
+            
+                  .spell-entry {
+                    border: 1px solid var(--border-color);
+                    border-radius: var(--border-radius);
+                    padding: 10px;
+                    margin-bottom: 10px; 
+                    background-color: var(--primary-bg-color);
+                  }
+                  
+                  .spell-entry > div {  /* Targets the direct children divs within .spell-entry */
+                    margin-bottom: 5px; 
+                  }
+                  
+                  .spell_name, 
+                  .spell_range, 
+                  .spell_duration,
+                  .spell_replaces,
+                  .spell_rarity,
+                  .spell_origin {
+                    font-weight: bold; 
+                  }
+                
+                  .spell_name {  /* Style the spell name */
+                    font-size: 22px; /* Increased font size */
+                    font-weight: 700; /* Bolder font weight */
+                  }
+                  
+                  .spell_desc p {
+                    font-size: 18px; /* Reduced font size for descriptions */
+                    font-family: 'Macondo', serif; 
+                  }
+                  
+                  .spell_darkness p {
+                    font-size: 18px; /* Reduced font size for darkness descriptions */
+                    font-family: 'Macondo', serif;
+                  }  
   
   /* Grid layout for inventory section */
     .inventory {
@@ -2576,13 +2657,13 @@
             border-radius: var(--border-radius);
             border: 5px double var(--border-color); /* Double-line border */
             grid-template-areas:
-            "armheader armheader"
-            "armourtypelist armourtypelist"
-            "basearmourdetails basearmourdetails"
-            "subheader subheader"
-            "armourproficiencypenalties armourproficiencypenalties"
-            "skullimage shieldtogglebox";
-            
+                "armheader armheader"
+                "armourtypelist armourtypelist"
+                "basearmourdetails basearmourdetails"
+                "subheader subheader"
+                "armourproficiencypenalties armourproficiencypenalties"
+                "skullimage shieldtogglebox"
+                "inventoryshieldhidden inventoryshieldhidden" ;
         }
         
             /* Full-width headings */
@@ -2619,18 +2700,8 @@
             }
             
             .armour .shieldhidden {
-                grid-area: shieldhidden;
-                grid-template-areas:
-                "shielddie"
-                "shieldbutton";
+                grid-area: inventoryshieldhidden;
             }
-                .shielddie {
-                    grid-area: shielddie;
-                }
-                .shieldbutton {
-                    grid-area: shieldbutton;
-                }
-
                     
         /* General Section Styling */
         .money {
@@ -3061,10 +3132,13 @@ input.element-toggle3[value="Earth"] ~ div.earth_spell_list,
 input.element-toggle3[value="Water"] ~ div.water_spell_list,
 input.element-toggle3[value="Fire"] ~ div.fire_spell_list,
 input.element-toggle3[value="Darkness"] ~ div.darkness_spell_list,
-input.profession-toggle[value="Elementalist"] ~ div.spelllist,
-input.profession-toggle[value="Warlock"] ~ div.spelllist,
-input.profession-toggle[value="Demonologist"] ~ div.spelllist,
-input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.spelllist {
+input.profession-toggle[value="Demonologist"] ~ div.demonologist_spell_list,
+input.profession-toggle[value="Demonologist"] ~ div.demonologist_sorcerer_spells,
+input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.sorcerer_spell_list,
+input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.mystic_spell_list,
+input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.warlock_spell_list,
+input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.elementalist_spell_list,
+input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.demonologist_spell_list {
   display: grid;
 }
 
@@ -3091,7 +3165,7 @@ input.profession-toggle[value="Elementalist"] ~ div.customskills,
 input.profession-toggle[value="Knave"] ~ div.customskills,
 input.profession-toggle[value="Priest"] ~ div.customskills,
 input.profession-toggle[value="Demonologist"] ~ div.customskills,
-input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ divs,
+input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.knight,
 input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.barbarianskills,
 input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.assassinskills,
 input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.hunterskills,
@@ -3104,18 +3178,6 @@ input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([valu
 input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.demonologistskills,
 input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([value="Warlock"]):not([value="Assassin"]):not([value="Knave"]):not([value="Hunter"]):not([value="Priest"]):not([value="Mystic"]):not([value="Elementalist"]):not([value="Demonologist"]):not([value="Sorcerer"]):not([value=""]) ~ div.customskills {
   display: grid; /* Displays the element as a grid layout */
-}
-
-.charsheet input.rollhp-toggle:checked ~ div.rollbasehpbuttoncontainer,
-.charsheet input.rollstats-toggle:checked ~ div.rollbasestatsbuttoncontainer {
-  display: block;
-}
-
-.charsheet input.weaponskill1:checked ~ div.weaponskillrow1,
-.charsheet input.weaponskill2:checked ~ div.weaponskillrow2,
-.charsheet input.weaponskill3:checked ~ div.weaponskillrow3,
-.charsheet input.shield-toggle:checked ~ div.shieldhidden {
-  display: block;
 }
 
 .charsheet input.track:not([value="0"]) ~ div.track,
@@ -3204,36 +3266,42 @@ input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([valu
   display: block;
 }
 
-/* When "Core" is selected, show ONLY the core powers div within the elementalistskills div */
-.charsheet input.elementalist_raw_power_type[value="Core"] ~ .elementalist_core_powers { 
-    display: block;
+.charsheet input.rollhp-toggle:checked ~ div.rollbasehpbuttoncontainer,
+.charsheet input.rollstats-toggle:checked ~ div.rollbasestatsbuttoncontainer {
+  display: block;
 }
 
-/* When "PG" is selected, show ONLY the alternate powers div within the elementalistskills div */
-.charsheet input.elementalist_raw_power_type[value="PG"] ~ .elementalist_alternate_powers {
-    display: block;
+.charsheet input.weaponskill1:checked ~ div.weaponskillrow1,
+.charsheet input.weaponskill2:checked ~ div.weaponskillrow2,
+.charsheet input.weaponskill3:checked ~ div.weaponskillrow3 {
+  display: block;
 }
 
-/* When "Both" is selected, show BOTH divs within the elementalistskills div */
+.charsheet input.shield[value="1"] ~ div.shieldhidden {
+  display: block;
+}
+
+.charsheet input.elementalist_raw_power_type[value="Core"] ~ .elementalist_core_powers, 
+.charsheet input.elementalist_raw_power_type[value="PG"] ~ .elementalist_alternate_powers,
 .charsheet input.elementalist_raw_power_type[value="Both"] ~ .elementalist_alternate_powers,
 .charsheet input.elementalist_raw_power_type[value="Both"] ~ .elementalist_core_powers {
-    display: block;
+  display: block;
 }
 
-/* Hide both divs by default */
-.charsheet div.elementalist_alternate_powers,
-.charsheet div.attr_elementalist_core_powers { /* Use .attr_elementalist_core_powers here as well */
-    display: none;
+.charsheet input.ranged_magic_toggle[value="Enabled"] ~ div.rangedmagicallowed {
+  display: block;
 }
+
+.charsheet input.steper_toggle[value="1"] ~ .steper_d20,
+.charsheet input.steper_toggle[value="0"] ~ .steper_2d10 {
+  display: block;
+}
+
 
 .charsheet input.supremacy_able[value="disabled"] ~ div.supremacy,
 .charsheet input.paths_toggle[value="disabled"] ~ div.pathscontainer,
 .charsheet input.secondaryskills_toggle[value="disabled"] ~ div.secondaryskillscontainer,
-.charsheet input.playerspells_toggle[value="disabled"] ~ div.playerspell {
-    display: none;
-}
-
-/* Hide all sections by default */
+.charsheet input.playerspells_toggle[value="disabled"] ~ div.playerspell,
 .charsheet div.knightskills,
 .charsheet div.barbarianskills,
 .charsheet div.assassinskills,
@@ -3278,6 +3346,7 @@ input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([valu
 .charsheet div.mystic_spell_list,
 .charsheet div.warlock_spell_list,
 .charsheet div.elementalist_spell_list,
+.charsheet div.demonologist_spell_list,
 .charsheet div.air_spell_list,
 .charsheet div.earth_spell_list,
 .charsheet div.water_spell_list,
@@ -3377,9 +3446,12 @@ input.profession-toggle:not([value="Knight"]):not([value="Barbarian"]):not([valu
 .charsheet div.bloodrage_button_front,
 .charsheet div.main_gauche_button_front,
 .charsheet div.elementalist_alternate_powers,
-.charsheet div.elementalist_core_powers {
+.charsheet div.elementalist_core_powers,
+.charsheet div.steper_d20,
+.charsheet div.steper_2d10,
+.charsheet div.rangedmagicallowed {
         display: none;
-    }
+}
 
 /* Base styles for all custom templates */
 .sheet-rolltemplate-custom,

--- a/Dragon Warriors/Dragon Warriors Revised.html
+++ b/Dragon Warriors/Dragon Warriors Revised.html
@@ -2,8 +2,8 @@
     
     <div class="buttonbar">
         <img class="headerimage" src="https://i.imgur.com/KnxTKFu.png" alt="Dragon Warriors" />
-        <button type="action" name="act_character" >Character</button>
-        <button type="action" name="act_basescores" >Base Scores</button>
+        <button type="action" name="act_character" >Combat Summary</button>
+        <button type="action" name="act_basescores" >Character Modification</button>
         <button type="action" name="act_magic" >Magic</button>
         <button type="action" name="act_inventory" >Inventory</button>
         <button type="action" name="act_skills" >Paths and Skills</button>
@@ -11,39 +11,28 @@
         <button type="action" name="act_biographical" >Biography</button>
         <button type="action" name="act_documentation" >Settings & Documentation</button>
     </div>
-    
     <input type='hidden' class='tabstoggle' name='attr_sheetTab' value='character' />
-    
     <div class="character">
-        
         <div class="frontpage common">
-          
           <div class="label-input-pair name">
             <label>Name</label>
             <input id="character-name" name="attr_character_name" type="text" class="fourteenlongtextinput" />
           </div>
-          
           <div class="label-input-pair profession">
             <label>Profession</label>
             <input type="text" list="profession" name="attr_profession" class="fourteenlongtextinput">
           </div>
-          
           <div class="label-input-pair rank">
             <label>Rank</label>
             <input id="rank" class="sixshorttextinput" name="attr_rank" type="number" min="1" value="1" />
           </div>
-          
           <div class="label-input-pair experience">
             <label>Experience</label>
             <input id="xp" class="sixshorttextinput" name="attr_xp" type="number" value="0" />
           </div>
-        
         </div>
-
         <div class="frontpage primaryattributes">
-
             <h2>Characteristics</h2>
-            
             <div>Strength</div>
             <div>
                 <input class="fourshorttextinput" type="number" name="attr_finalstrength" value="0" readonly/>
@@ -51,7 +40,6 @@
             <div>
                 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} tests Strength}} {{subtitle=Roll under Strength Value}} {{roll= [[?{Number of dice|1}d20cs1cf20]]}} {{Vs= [[@{finalstrength}+?{Modifier?|0}]] }}" name="roll_strengthcheck"></button>
             </div>
-            
             <div>Reflexes</div>
             <div>
                 <input class="fourshorttextinput" type="number" name="attr_finalreflexes" value="0" readonly/>
@@ -59,7 +47,6 @@
             <div>
                 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} tests Reflexes}} {{subtitle=Roll under Reflexes Value}} {{roll= [[?{Number of dice|1}d20cs1cf20]]}} {{Vs= [[@{finalreflexes}+?{Modifier?|0}]] }}" name="roll_reflexescheck"></button>
             </div>
-            
             <div>Intelligence</div>
             <div>
                 <input class="fourshorttextinput" type="number" name="attr_finalintelligence" value="0" readonly/>
@@ -67,7 +54,6 @@
             <div>
                 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} tests Intelligence}} {{subtitle=Roll under Intelligence Value}} {{roll= [[?{Number of dice|1}d20cs1cf20]]}} {{Vs= [[@{finalintelligence}+?{Modifier?|0}]] }}" name="intelligencecheck"></button>
             </div>
-            
             <div>Psychic Talent</div>
             <div>
                 <input class="fourshorttextinput" type="number" name="attr_finalpsychictalent" value="0" readonly/>
@@ -75,7 +61,6 @@
             <div>
                 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} tests Psychic Talent}} {{subtitle=Roll under Psychic Talent Value}} {{roll= [[?{Number of dice|1}d20cs1cf20]]}} {{Vs= [[@{finalpsychictalent}+?{Modifier?|0}]] }}" name="roll_psychictalentcheck"></button>
             </div>
-            
             <div>Looks</div>
             <div>
                 <input class="fourshorttextinput" type="number" name="attr_finallooks" value="0" readonly/>
@@ -84,10 +69,8 @@
                 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} tests Looks}} {{subtitle=Roll under Looks Value}} {{roll= [[?{Number of dice|1}d20cs1cf20]]}} {{Vs= [[@{finallooks}+?{Modifier?|0}]] }}" name="roll_lookscheck"></button>
             </div>
         </div>
-
         <div class="frontpage finalattackdefenceattributes">
           <h2>Combat Factors</h2>
-          
           <div class="finalmeleelabel1">Melee Attack</div>
           <div class="finalmeleebox1">
             <input class="fourshorttextinput" type="number" name="attr_finalmeleeattack" value="0" readonly />
@@ -104,11 +87,8 @@
           <div class="finalrangedbox2">
             <input class="fourshorttextinput" type="number" name="attr_finalrangeddefence" value="0" readonly />
           </div>
-
         </div>
-        
         <div class="frontpage evasionattribute">
-
             <h2>Dodging</h2>
             <div class="finaldodge">
                 Evasion
@@ -117,7 +97,6 @@
                 <input class="fourshorttextinput" type="number" name="attr_finalevasion" value="0" readonly />
             </div>
         </div>
-        
         <div class="frontpage mamdattributes">
             <h2>Magical Combat Factors</h2>
             <div class="magicalattacklabel">
@@ -133,78 +112,77 @@
                 <input class="fourshorttextinput" type="number" name="attr_finalmagicaldefence" value="0" readonly />
             </div>
         </div>
-
         <div class="frontpage stealthperceptionattributes">
             <h2>Stealth and Perception</h2>
-        
-            <!-- Stealth section -->
             <div>Stealth</div>
             <div>
                 <input class="fourshorttextinput" type="number" name="attr_finalstealth" value="0" readonly />
             </div>
             <div>
-                <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Stealth}} {{subtitle=Stealth vs Perception}} {{roll=[[2d10]]}} {{Vs= [[@{finalstealth}-(?{Target's Perception|0})]] }}" name="roll_stealth2d10">
-                </button>
-                <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} uses Stealth}} {{subtitle=Stealth vs Perception}}  {{roll=[[1d20cs1cf20]]}} {{Vs= [[@{finalstealth}-(?{Target's Perception|0})]] }}" name="roll_stealth1d20">
-                </button>
+                <input type="hidden" name="attr_steper_toggle" class="steper_toggle" value="0" />
+                <div class="steper_2d10">
+                    <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Stealth}} {{subtitle=Stealth vs Perception}} {{roll=[[2d10]]}} {{Vs= [[@{finalstealth}-(?{Target's Perception|0})]] }}" name="roll_stealth2d10">
+                    </button>
+                </div>
+                <input type="hidden" name="attr_steper_toggle" class="steper_toggle" value="0" />
+                <div class="steper_d20">
+                    <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} uses Stealth}} {{subtitle=Stealth vs Perception}}  {{roll=[[1d20cs1cf20]]}} {{Vs= [[@{finalstealth}-(?{Target's Perception|0})]] }}" name="roll_stealth1d20">
+                    </button>
+                </div>
             </div>
-        
-            <!-- Perception section -->
             <div>Perception</div>
             <div>
                 <input class="fourshorttextinput" type="number" name="attr_finalperception" value="0" readonly />
             </div>
             <div>
-                <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Perception}} {{subtitle=Roll Perception or less}} {{roll= [[2d10]]}} {{Vs= [[@{finalperception}-(?{Other Modifiers|0})]] }}" name="roll_perception2d10">
-                </button>
-                <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} uses Perception}} {{subtitle=Roll Perception or less}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}-(?{Other Modifiers|0})]] }}" name="roll_perception1d20">
-                </button>
+                <input type="hidden" name="attr_steper_toggle" class="steper_toggle" value="0" />
+                <div class="steper_2d10">
+                    <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Perception}} {{subtitle=Roll Perception or less}} {{roll= [[2d10]]}} {{Vs= [[@{finalperception}-(?{Other Modifiers|0})]] }}" name="roll_perception2d10">
+                    </button>
+                </div>
+                <input type="hidden" name="attr_steper_toggle" class="steper_toggle" value="0" />
+                <div class="steper_d20">
+                    <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} uses Perception}} {{subtitle=Roll Perception or less}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}-(?{Other Modifiers|0})]] }}" name="roll_perception1d20">
+                    </button>
+                </div>
             </div>
         </div>
-
-        <div class="frontpage gapfillimg">
+<!--    <div class="gapfillimg">
             <img class="headerimage" src="https://i.imgur.com/bJM6vzJ.png" alt="Dice Warriors" />
         </div>
-        
-        <div class="frontpage afattributes">
+-->
+        <div class="afattributes">
             <h2>Armour</h2>
-            
             <div class="imgshieldcol">
                 <img class="icon shield" src="https://i.imgur.com/pjGm1On.png" alt="Shield" />
             </div>
-            
             <div class="aftype">
-                Type
+                <span>Type</span>
             </div>
-            
             <div class="aftypeinput">
-                <input type="text" class="flexitextinput" name="attr_armourtype" value="None" readonly />
+                <div class="sheet-auto-expand">
+                    <span name="attr_armourtype"></span>
+                    <textarea name="attr_armourtype" value="None" readonly />
+                </div>
             </div>
-            
-            <div class="afname">
-                Armour Factor
-            </div>
-            
             <div class="afinput">
+                <span>Armour Factor</span>
                 <input title="Includes Magic and Miscellaneous Bonuses" type="number" class="fourshorttextinput" name="attr_totalaf" value="0" readonly />
             </div>
-            
             <div class="shieldtogglebox">
-                <span>Shield Equipped?</span> <input type="checkbox" class="shield-toggle" name="attr_shield" />
-                <div class="shieldhidden">
-                    <div class="shielddie">
-                        Roll <input title="Modified by Guard/Abilities" type="number" class="fourshorttextinput" name="attr_shieldsuccessvalue" value="1" readonly /> on <input class="fourshorttextinput" type="text" name="attr_shielddievalue" value="1d6" readonly />
-                    </div>
-                    <div class="shieldbutton">
-                        <button class="d6" type="roll" value="&{template:custom} {{title=@{character_name} attempts to block with a Shield}} {{subtitle=Roll target number or less}} {{roll= [[@{shielddievalue}]]}} {{Vs= [[@{shieldsuccessvalue}]] }}" name="roll_shieldcheck"></button>
-                    </div>
-                </div>    
+                <span>Shield</span>
+                <select class="shield" name="attr_shield">
+                    <option value="0">Not Equipped</option>
+                    <option value="1">Equipped</option>
+                </select>
             </div>
+            <input type="hidden" class="shield" name="attr_shield" value="0" />            
+            <div class="shieldhidden">
+                <span>Roll</span><input title="Modified by Guard/Abilities" type="number" class="fourshorttextinput" name="attr_shieldsuccessvalue" value="1" readonly /> <span>on</span> <input class="fourshorttextinput" type="text" name="attr_shielddievalue" value="1d6" readonly /> <button class="d6" type="roll" value="&{template:custom} {{title=@{character_name} attempts to block with a Shield}} {{subtitle=Roll target number or less}} {{roll= [[@{shielddievalue}]]}} {{Vs= [[@{shieldsuccessvalue}]] }}" name="roll_shieldcheck"> </button>
+            </div>    
         </div>
-
         <div class="frontpage hpattributes">
             <h2>Health Points</h2>
-
             <span>Maximum Health Points:</span><span name="attr_maxhp" ></span>
             <br>
             <span>Wounds Taken:</span><input name="attr_input_wounds" type="number" min="0" step="1" />
@@ -380,10 +358,8 @@
             <br>
             <span>Poison Save</span><button class="button1 d6" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} tries to resist the effects of poison}} {{subtitle=Roll Poison Strength under Strength to resist}} {{roll= [[?{Number of Dice|3}d6]]}} {{Vs= [[@{finalstrength}+?{Strength Modifier?|0}]] }}" name="roll_poisoncheck"></button>
         </div>
-
-        <div class="frontpage finalcombatattributes">
-            <h2>Combat Summary</h2>
-            
+        <div class="finalmeleecombatattributes">
+            <h2>Melee Combat Summary</h2>
             <div class="meleeattack1">
                 <span>Melee Attack</span>
                 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} attacks with @{equippedmeleeweaponname}}} {{subtitle=@{equippedmeleeweapontype} +@{equippedmeleeweaponmagicbonus}}} {{attackroll=[[1d20cs1cf20]]}} {{attackvsdefence=[[@{finalmeleeattack}-(?{Enemy Defence|0})]]}} {{abr=[[@{equippedmeleeweaponabr}+@{finalmeleeabrbonus}]]}} {{Damage=[[@{equippedmeleeweapondamage}+@{finalmeleedmgbonus}]]}} {{desc=@{equippedmeleeweaponother}}}" name="roll_meleeattack"></button>                
@@ -394,8 +370,6 @@
                 <span>Magic Bonus:</span><input type="number" name="attr_equippedmeleeweaponmagicbonus" readonly="readonly" /><br>
                 <input class="hidden" name="attr_warlockweapongroupmelee" value="0" />
                 <input class="hidden" name="attr_ismaingauchedefenceweapon" value="0" />
-                <input class="hidden" name="attr_meleeothereffects" value="0" />
-
             </div>
             <div class="abrbox">
                 <span>Armour Bypass Roll: </span><input type="text" name="attr_equippedmeleeweaponabr" readonly="readonly" /><br>
@@ -403,10 +377,19 @@
             <div class="damagebox"> 
                 <span>Damage: </span><input type="text" name="attr_equippedmeleeweapondamage" readonly="readonly" /><br>
             </div>
+            <div class="meleeothereffects">
+                <span>Other effects: </span>
+                <div class="sheet-auto-expand">
+                    <span name="attr_meleeothereffects"></span>
+                    <textarea name="attr_meleeothereffects" value="" readonly> </textarea>
+                </div>
+            </div>
             <div class="swordimage">
                 <img class="icon sword" src="https://i.imgur.com/uTrcbgb.png" alt="Sword" />
             </div>
-
+        </div>
+        <div class="finalrangedcombatattributes">
+            <h2>Ranged Combat Summary</h2>
             <div class="rangedattack1">
                 <span>Ranged Attack</span>
                 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} attacks with @{equippedrangedweaponname}}} {{subtitle=@{equippedrangedweapontype} +@{equippedrangedweaponmagicbonus} using @{equippedammotype}}} {{attackroll= [[1d20cs1cf20]]}} {{attackvsranged=[[ @{finalrangedattack} - ?{Range Modifier|Short @{equippedrangedweaponshortrange}m, 0|Medium @{equippedrangedweaponmediumrange}m, 3|Long @{equippedrangedweaponlongrange}m, 7} - ?{Small or Crouching target?|No, 0|Yes, 2} - ?{Is the Target moving?|No, 0|Slowly, 2|Quickly, 4} -(?{Light Conditions|Normal, 0|Poor, 3|Other, ?{Other&amp;#125;}) + (?{Miscellaneous Modifiers, can be a positive (improves chance to hit) or a negative (decreases chance to hit)|0}) ]] }} {{abr=[[ @{equippedrangedweaponabr} + @{finalrangedabrbonus} ]]}} {{Damage=[[ @{equippedrangedweapondamage} + @{finalrangeddmgbonus} ]]}} {{desc=@{equippedammospecialeffect}}}" name="roll_rangedattack">
@@ -438,19 +421,15 @@
             <div class="rangedweaponranges">
                     <span>Ranges:</span>
                     <br>
-                    <span>Short</span><input class="fourshorttextinput" type='text' name="attr_equippedrangedweaponshortrange" value="" readonly /> 
+                    <span>Short</span><br><input class="fourshorttextinput" type='text' name="attr_equippedrangedweaponshortrange" value="" readonly /> 
                     <br>
-                    <span>Medium</span><input class="fourshorttextinput" type='text' name="attr_equippedrangedweaponmediumrange" value="" readonly /> 
+                    <span>Medium</span><br><input class="fourshorttextinput" type='text' name="attr_equippedrangedweaponmediumrange" value="" readonly /> 
                     <br>
-                    <span>Long</span><input class="fourshorttextinput" type='text' name="attr_equippedrangedweaponlongrange" value="" readonly /> 
+                    <span>Long</span><br><input class="fourshorttextinput" type='text' name="attr_equippedrangedweaponlongrange" value="" readonly /> 
             </div>
         </div>
-
         <div class="classcombatabilities">
-            <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
-            
             <h2>Profession Abilities</h2>
-            
             <div class="skills_known">
                  <details>  
                     <summary>Skills Known</summary>
@@ -460,668 +439,684 @@
                     </div>
                 </details>
             </div>
-                
-            <div class="melee barbarianmelee">
-                <input type="hidden" name="attr_bloodrageactive" value="0" />
-                <input type="hidden" name="attr_bloodragedmgmod" value="0" />
-
-                <h2>Barbarian Profession Abilities</h2>
-                <div class="skillrow">
+            <div class="melee">
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="barbarianmelee">
+                    <input type="hidden" name="attr_bloodrageactive" value="0" />
+                    <input type="hidden" name="attr_bloodragedmgmod" value="0" />
                     <details>
-                        <summary>Track</summary>
-                        <input type="hidden" class="barbariancheckbox track" name="attr_track" value="0" />
-                        <div class="barbarianroll track_front">
-                            <span>Roll Track</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} searches for Tracks}} {{subtitle=Roll under Tracking Skill}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}+@{trackmodifier}-?{Other Modifiers|0}]] }}" name="roll_track"></button>
-                        </div>
-                    </details>
-                </div>       
-                <div class="skillrow">
-                    <details>
-                        <summary>Berserk</summary>
-                        <input type="hidden" class="barbariancheckbox berserk_front" name="attr_berserk" value="0" />
-                        <div class="barbarianroll berserk_button_front">
-                            <span>Defence Penalty</span> <input class="fourshorttextinput" title="By default this bonus applies to Melee attacks only. See below." type="number" name="attr_berserkneg" max="0" step="3" value="0"/>
-                            <br>
-                            <span>Attack Bonus</span> <input class="fourshorttextinput" type="number" name="attr_berserkpos" min="0" value="0" readonly />
-                            <br>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Bloodrage </summary>
-                        <input type="hidden" class="barbariancheckbox bloodrage_front" name="attr_bloodrage" value="0" />
-                        <div class="barbarianroll bloodrage_button_front">
-                            <select title="Deactivates Berserk" name="attr_bloodrageselect" >
-                                <option value="0">Inactive</option>
-                                <option value="1">Active</option>
-                            </select>
-                        </div>
-                    </details>
-                </div>
-                <input type="hidden" class="supremacy_able" name="attr_supremacy_able" value="0" />
-                <div class="supremacy">
+                    <summary><h2>Barbarian Profession Abilities</h2></summary>
                     <div class="skillrow">
                         <details>
-                            <summary>Iron Will</summary>
-                            <input type="hidden" class="barbariancheckbox iron_will_front" name="attr_iron_will" value="0" />
-                            <div class="barbarianskill iron_will_button_front">
-                                <span>Activate against the following spells: Command, Curse, Transfix, Enslave, Enthrall, Benight, Turncoat, Pacify, Dark Thoughts, Winds of Change, and Witch Steed.</span>
-                                <select name="attr_activateiron_will">
-                                    <option>Inactive</option>
-                                    <option>Active</option>
+                            <summary>Track</summary>
+                            <input type="hidden" class="barbariancheckbox track" name="attr_track" value="0" />
+                            <div class="barbarianroll track_front">
+                                <span>Roll Track</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} searches for Tracks}} {{subtitle=Roll under Tracking Skill}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}+@{trackmodifier}-?{Other Modifiers|0}]] }}" name="roll_track"></button>
+                            </div>
+                        </details>
+                    </div>       
+                    <div class="skillrow">
+                        <details>
+                            <summary>Berserk</summary>
+                            <input type="hidden" class="barbariancheckbox berserk_front" name="attr_berserk" value="0" />
+                            <div class="barbarianroll berserk_button_front">
+                                <span>Defence Penalty</span> <input class="fourshorttextinput" title="By default this bonus applies to Melee attacks only. See below." type="number" name="attr_berserkneg" max="0" step="3" value="0"/>
+                                <br>
+                                <span>Attack Bonus</span> <input class="fourshorttextinput" type="number" name="attr_berserkpos" min="0" value="0" readonly />
+                                <br>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Bloodrage </summary>
+                            <input type="hidden" class="barbariancheckbox bloodrage_front" name="attr_bloodrage" value="0" />
+                            <div class="barbarianroll bloodrage_button_front">
+                                <select title="Deactivates Berserk" name="attr_bloodrageselect" >
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Active</option>
+                                </select>
+                            </div>
+                        </details>
+                    </div>
+                    <input type="hidden" class="supremacy_able" name="attr_supremacy_able" value="0" />
+                    <div class="supremacy">
+                        <div class="skillrow">
+                            <details>
+                                <summary>Iron Will</summary>
+                                <input type="hidden" class="barbariancheckbox iron_will_front" name="attr_iron_will" value="0" />
+                                <div class="barbarianskill iron_will_button_front">
+                                    <span>Activate against the following spells: Command, Curse, Transfix, Enslave, Enthrall, Benight, Turncoat, Pacify, Dark Thoughts, Winds of Change, and Witch Steed.</span>
+                                    <select name="attr_activateiron_will">
+                                        <option>Inactive</option>
+                                        <option>Active</option>
+                                    </select>
+                                </div>
+                            </details>    
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Intimidating</summary>
+                                <input type="hidden" class="barbariancheckbox intimidating_front" name="attr_intimidating" value="0" />
+                                <div class="barbarianroll intimidating_button_front">
+                                    <span>Roll Intimidate</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} glares intimidatingly}} {{subtitle=Roll Intimidation check under your Looks}} {{roll=[[1d20cs1cf20]]}} {{Vs=[[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_intimidate"></button>
+                                </div>
+                            </details>
+                        </div>
+                    </div>
+                    </details>
+                </div>
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="knightmelee">
+                    <details>
+                    <summary><h2>Knight Profession Abilities</h2></summary>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Track</summary>
+                            <input type="hidden" class="knightcheckbox track_front" name="attr_track" value="0" />
+                            <div class="knightroll track_button_front">
+                                <span>Roll Track</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} searches for Tracks}} {{subtitle=Roll under Tracking Skill}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}+@{trackmodifier}-?{Other Modifiers|0}]] }}" name="roll_track"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Weaponskill</summary>
+                            
+                            <input type="hidden" class="knightcheckbox weaponskill1_front" name="attr_weaponskill1" value="0" />
+                            <div class="knightskill weaponskillrow1_button_front">
+                                <span>Weaponskill</span> <input type="text" name="attr_weapon1" readonly />
+                            </div>
+                            
+                            <input type="hidden" class="knightcheckbox weaponskill2_front" name="attr_weaponskill2" value="0" />
+                            <div class="knightskill weaponskillrow2_button_front">
+                                <span>Weaponskill</span> <input type="text" name="attr_weapon2" readonly />
+                            </div>
+                            
+                            <input type="hidden" class="knightcheckbox weaponskill3_front" name="attr_weaponskill3" value="0" />
+                            <div class="knightskill weaponskillrow3_button_front">
+                                <span>Weaponskill</span> <input type="text" name="attr_weapon3" readonly />
+                            </div>
+                            
+                        </details>
+                    </div>
+                    <div>
+                        <details>
+                            <summary>Main Gauche</summary>
+                            <input type="hidden" class="knightcheckbox main_gauche_front" name="attr_main_gauche" value="0" />
+                            <div class="knightskill main_gauche_button_front">
+                                <select name="attr_main_gauche_active">
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Defensive (+2 Defence, +Weapon Magic Bonus)</option>
+                                    <option value="2">Offensive (Attack twice vs full Defence</option>
+                                </select>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Disarm Technique</summary>
+                            <input type="hidden" class="knightcheckbox disarm_front" name="attr_disarm_technique" value="0" />
+                            <div class="knightroll disarm_button_front">
+                                <span>Roll Disarm</span> <button class="button d6" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts a disarm maneuver}} {{subtitle=Roll Disarm check under Opponent's Rank}} {{roll=[[3d6]]}} {{Vs=?{Input enemy rank or rank equivalent}}}" name="roll_disarm"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <input type="hidden" class="supremacy_able" name="attr_supremacy_able" value="0" />
+                    <div class="supremacy">
+                        <div class="skillrow">
+                            <details>
+                                <summary>Iron Will</summary>
+                                <input type="hidden" class="knightcheckbox iron_will_front" name="attr_iron_will" value="0" />
+                                <div class="knightskill iron_will_button_front">
+                                    <span>Activate against the following spells: Command, Curse, Transfix, Enslave, Enthrall, Benight, Turncoat, Pacify, Dark Thoughts, Winds of Change, and Witch Steed.</span>
+                                    <select name="attr_activateiron_will">
+                                        <option>Inactive</option>
+                                        <option>Active</option>
+                                    </select>
+                                </div>
+                            </details>    
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Intimidating</summary>
+                                <input type="hidden" class="knightcheckbox intimidating_front" name="attr_intimidating" value="0" />
+                                <div class="knightroll intimidating_button_front">
+                                    <span>Roll Intimidate</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} glares intimidatingly}} {{subtitle=Roll Intimidation check under your Looks}} {{roll=[[1d20cs1cf20]]}} {{Vs=[[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_intimidate"></button>
+                                </div>
+                            </details>
+                        </div>
+                    </div>
+                    </details>
+                </div>
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="warlockmelee">
+                    <details>
+                    <summary><h2>Warlock Profession Abilities</h2></summary>
+                    <br>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Selected Weapon Groups</summary>
+                            <div class="weapon-group-container">
+                                <span>Weapon Group 1:</span> 
+                                <div class="sheet-auto-expand">
+                                    <span name="attr_weapon_group_1_description"></span>
+                                    <textarea name="attr_weapon_group_1_description" class="warlock-weapongroup" readonly ></textarea>
+                                </div>    
+                                <br>
+                                <span>Weapon Group 2:</span> 
+                                <div class="sheet-auto-expand">
+                                    <span name="attr_weapon_group_2_description"></span>
+                                    <textarea name="attr_weapon_group_2_description" class="warlock-weapongroup" readonly ></textarea>
+                                </div>    
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                      <details>
+                        <summary>Appraise Enemy</summary>
+                        <input type="hidden" class="warlockcheckbox appraiseenemy_front" name="attr_appraise_enemy" value="0" />
+                        <div class="warlockroll appraiseenemy_button_front">
+                            <span>Activate</span> <button class="button1 d20 " type="roll" value="/w gm&{template:custom} {{title=@{character_name} attempts to appraise their enemy}} {{subtitle=Roll 1d20 under Psychic Talent}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalpsychictalent}}} {{On fail, percieved rank= [[3d6 –7]]}}" name="roll_appraiseenemy"></button>
+                        </div>
+                        </details>
+                    </div>
+                    </details>
+                </div>
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="assassinmelee">
+                    <details>
+                        <summary><h2>Assassin Profession Abilities</h2></summary>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Shock Attack</summary>
+                                <input type="hidden" class="assassincheckbox shock_attack_front" name="attr_shock_attack" value="0" />
+                                <div class="assassinroll shock_attack_button_front">
+                                    <span>Roll Shock Attack result:</span> <button class="roll d6" type="roll" value="&{template:custom} {{title=@{character_name} delivers a Shock Attack!}} {{subtitle=Roll a D6}} {{roll= [[1d6]]}} {{Result= 1 Stunned Opponent’s attack, defence and evasion are all at 0.
+                                    2 Aghast Opponent’s attack and evasion are at 0; defence is half normal. 
+                                    3-4 Astonished Opponent’s attack is at 0; evasion and defence at half normal. 
+                                    5-6 Surprised Opponent’s attack is at 0; evasion and defence are unimpaired}}" ></button>
+                                </div>
+                        </details>
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Inner Sense</summary>
+                                <input type="hidden" class="assassincheckbox inner_sense_front" name="attr_inner_sense" value="0" />
+                                <div class="assassinroll inner_sense_button_front">
+                                    <span>GM rolls</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} extends their Inner Senses}} {{subtitle=Roll under Psychic Talent on 1d20}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalpsychictalent} }}" name="roll_inner_sense"></button>
+                                </div>
+                            </details>
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Memorize</summary>
+                                <input type="hidden" class="assassincheckbox memorize_front" name="attr_memorize" value="0" />
+                                <div class="assassinroll memorize_button_front">
+                                    <span>GM rolls</span> <button class="roll twod10" type="roll" value="&{template:custom} {{title=@{character_name} tries to recall information}} {{subtitle=Roll under target number on 1d100}} {{roll=[[1d100cs1cf100]]}} {{Vs=[[100 - (?{Months Passed (max 9)|1} * 10)]]}}" name="roll_inner_sense"></button>
+                                </div>
+                            </details>
+                        </div>
+                        <div class="skillrow">
+                           <details>
+                                <summary>Disguise</summary>
+                                <input type="hidden" class="assassincheckbox disguise_front" name="attr_disguise" value="0" />
+                                <div class="assassinroll disguise_button_front">
+                                    <span>Roll Disguise</span> <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to deceive by disguise.}} {{subtitle=Stealth vs. Perception}} {{roll= [[2d10]]}} {{Vs= [[@{finalstealth}-?{Target's Perception|0}]] }}" name="roll_disguise"></button>
+                                </div>
+                            </details>
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Pilfer</summary>
+                                <input type="hidden" name="attr_pilfermodifier_front" value="0" />
+                                <input type="hidden" class="assassincheckbox pilfer_front" name="attr_pilfer" value="0" />
+                                <div class="assassinroll pilfer_button_front">
+                                    <span>Roll Pilfer</span> <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to pilfer.}} {{subtitle=Stealth vs. Perception}} {{roll= [[2d10]]}} {{Vs= [[@{finalstealth}-(@{pilfermodifier})-?{Target's Perception|0}]] }}" name="roll_pilfer"></button>
+                                </div>
+                            </details>
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Pick Lock</summary>
+                                <input type="hidden" name="attr_pick_lockscore" value="0" />
+                                <input type="hidden" class="assassincheckbox pick_lock_front" name="attr_pick_lock" value="0" />
+                                <div class="assassinroll pick_lock_button_front">
+                                    <span>GM rolls for possibility of success</span> <button class="roll twod10" type="roll" value="/w gm&{template:custom} {{title=@{character_name} examines the lock.}} {{subtitle=Roll 1d100 under the Lock Difficulty}} {{roll=[[1d100cs1cf100]]}} {{Vs= [[@{pick_lockscore} - ?{Lock Difficulty|0} ]]}}" name="roll_pick_lockcheck"></button>
+                                    Roll Pick Lock <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts to pick a lock.}} {{subtitle=Roll 1d100 under Rank}} {{roll= [[1d100cs1cf100]]}} {{Vs= @{rank}}}" name="roll_pick_lockchance"></button>
+                                </div>
+                            </details>
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Track</summary>
+                                <input type="hidden" class="assassincheckbox track_front" name="attr_track" value="0" />
+                                <div class="assassinroll track_button_front">
+                                    <span>Roll Track</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} searches for Tracks}} {{subtitle=Roll under Tracking Skill}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}+@{trackmodifier}-?{Other Modifiers|0}]] }}" name="roll_track"></button>
+                                </div>
+                            </details>
+                        </div>
+                        <div class="skillrow">
+                            <details>    
+                                <summary>Deathvow</summary>
+                                <input type="hidden" class="assassincheckbox deathvow_front" name="attr_deathvow" value="0" />
+                                <div class="assassinroll deathvow_button_front">
+                                    <span>Activate</span>
+                                    <select name="attr_deathvowselect" >
+                                        <option value="0">Inactive</option>
+                                        <option value="1">Active</option>
+                                    </select>
+                                </div>
+                            </details>
+                        </div>
+                    </details>
+                </div>
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="mysticmelee">
+                    <details>
+                    <summary><h2>Mystic Profession Abilities</h2></summary>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Spell Mastery</summary>
+                            <span>Current Mastered Spell</span><input type="text" name="attr_mastered_spell" />
+                        </details>
+                    </div>              
+                    <div class="skillrow">
+                        <details>
+                            <summary>ESP</summary>
+                            <input type="hidden" class="mysticcheckbox esp_front" name="attr_esp" value="0" />
+                            <div class="mysticroll esp_button_front">
+                                <span>ESP Chance</span> <input class="fourshorttextinput" type="number" name="attr_espchance" value="0" /> %
+                                <span>Roll ESP</span> <button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} uses ESP}} {{subtitle=Roll 1d100 under ESP chance}} {{roll= [[1d100cs1cf100]]}} {{Vs= [[@{espchance}]]%}}" name="roll_espcheck" ></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                        <summary>Premonition</summary> 
+                            <input type="hidden" class="mysticcheckbox premonition_front" name="attr_premonition" value="0" />
+                            <div class="mysticroll premonition_button_front">
+                                <span>Premonition Chance</span> <input class="fourshorttextinput" type="number" name="attr_premonitionchance" value="0" /> %
+                                <span>Roll Premonition</span> <button class="button twod10" type="roll" value="/w gm &{template:custom} {{title=@{character_name} uses Premonition}} {{subtitle=Roll 1d100 under Premonition Chance}} {{roll=[[1d100cs1cf100]]}} {{Vs=[[@{premonitionchance}]]%}}" name="roll_premonitioncheck"></button>
+                            </div>
+                        </details>
+                    </div>
+                    </details>
+                </div>
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="huntermelee">
+                    <details>
+                    <summary><h2>Hunter Profession Abilities</h2></summary>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Favoured Weapon</summary> 
+                            <input type="hidden" class="huntercheckbox favoured_weapon_front" name="attr_favoured_weapon" value="0"/>
+                            <div class="hunterroll favoured_weapon_button_front">
+                                <span>Weapon type</span> <input type="text" name="attr_favoured_weapon_selected" readonly />                                    
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Favoured Terrain</summary>
+                            <input type="hidden" class="huntercheckbox favoured_terrain_front" name="attr_favoured_terrain" value="0" />
+                            <div class="hunterroll favoured_terrain_button_front">
+                                <span>Terrain Type</span> <input type="text" name="attr_favoured_terrain_selected" readonly />
+                            </div>
+                        </details>
+                    </div>
+                    <!-- Precise Shot Section -->
+                    <div class="skillrow">
+                        <details>
+                            <summary>Precise Shot</summary>
+                            <input type="hidden" class="huntercheckbox precise_shot_front" name="attr_precise_shot" value="0" />
+                            <div class="hunterroll precise_shot_button_front">
+                                <span>Defence Penalty</span> <input class="fourshorttextinput" type="number" name="attr_preciseneg" step="3" max="0" value="0" />
+                                <br>
+                                <span>Attack Bonus</span> <input class="fourshorttextinput" type="text" name="attr_precisepos" value="0" readonly />
+                            </div>
+                        </details>
+                    </div>
+                    <!-- Stillness Section -->
+                    <div class="skillrow">
+                        <details>
+                            <summary>Stillness</summary>
+                            <input type="hidden" class="huntercheckbox stillness_front" name="attr_stillness" value="0" />
+                            <div class="hunterroll stillness_button_front">
+                                <span>Defence Penalty</span> <input class="fourshorttextinput" type="number" name="attr_stillnessneg" step="1" max="0" value="0" /> 
+                                <br>
+                                <span>Stealth Bonus</span> <input class="fourshorttextinput" type="text" name="attr_stillnesspos" value="0" readonly />
+                                <br>
+                                <span>Apply favoured terrain bonus</span> 
+                                <select name="attr_favoured_terrain">
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Active</option>
+                                </select>
+                            </div>
+                        </details>
+                    </div>
+                    <!-- Penetrating Shot Section -->
+                    <div class="skillrow">
+                        <details>
+                            <summary>Penetrating Shot</summary>
+                            <input type="hidden" class="huntercheckbox penetrating_shot_front" name="attr_penetrating_shot" value="0" />
+                            <div class="hunterroll penetrating_shot_button_front">
+                                <span>Activate when firing at short range</span>
+                                <select name="attr_penetratingshotselect" >
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Active</option>
                                 </select>
                             </div>
                         </details>    
                     </div>
+                        <!-- New Hunter's Mind Section -->
                     <div class="skillrow">
                         <details>
-                            <summary>Intimidating</summary>
-                            <input type="hidden" class="barbariancheckbox intimidating_front" name="attr_intimidating" value="0" />
-                            <div class="barbarianroll intimidating_button_front">
-                                <span>Roll Intimidate</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} glares intimidatingly}} {{subtitle=Roll Intimidation check under your Looks}} {{roll=[[1d20cs1cf20]]}} {{Vs=[[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_intimidate"></button>
-                            </div>
-                        </details>
-                    </div>
-                </div>
-            </div>
-
-            <div class="melee knightmelee">
-                Knight Profession Abilities
-                <div class="skillrow">
-                    <details>
-                        <summary>Track</summary>
-                        <input type="hidden" class="knightcheckbox track_front" name="attr_track" value="0" />
-                        <div class="knightroll track_button_front">
-                            <span>Roll Track</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} searches for Tracks}} {{subtitle=Roll under Tracking Skill}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}+@{trackmodifier}-?{Other Modifiers|0}]] }}" name="roll_track"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Weaponskill</summary>
-                        
-                        <input type="hidden" class="knightcheckbox weaponskill1_front" name="attr_weaponskill1" value="0" />
-                        <div class="knightskill weaponskillrow1_button_front">
-                            <span>Weaponskill</span> <input type="text" name="attr_weapon1" readonly />
-                        </div>
-                        
-                        <input type="hidden" class="knightcheckbox weaponskill2_front" name="attr_weaponskill2" value="0" />
-                        <div class="knightskill weaponskillrow2_button_front">
-                            <span>Weaponskill</span> <input type="text" name="attr_weapon2" readonly />
-                        </div>
-                        
-                        <input type="hidden" class="knightcheckbox weaponskill3_front" name="attr_weaponskill3" value="0" />
-                        <div class="knightskill weaponskillrow3_button_front">
-                            <span>Weaponskill</span> <input type="text" name="attr_weapon3" readonly />
-                        </div>
-                        
-                    </details>
-                </div>
-                <div>
-                    <details>
-                        <summary>Main Gauche</summary>
-                        <input type="hidden" class="knightcheckbox main_gauche_front" name="attr_main_gauche" value="0" />
-                        <div class="knightskill main_gauche_button_front">
-                            <select name="attr_main_gauche_active">
-                                <option value="0">Inactive</option>
-                                <option value="1">Defensive (+2 Defence, +Weapon Magic Bonus)</option>
-                                <option value="2">Offensive (Attack twice vs full Defence</option>
-                            </select>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Disarm Technique</summary>
-                        <input type="hidden" class="knightcheckbox disarm_front" name="attr_disarm_technique" value="0" />
-                        <div class="knightroll disarm_button_front">
-                            <span>Roll Disarm</span> <button class="button d6" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts a disarm maneuver}} {{subtitle=Roll Disarm check under Opponent's Rank}} {{roll=[[3d6]]}} {{Vs=?{Input enemy rank or rank equivalent}}}" name="roll_disarm"></button>
-                        </div>
-                    </details>
-                </div>
-                <input type="hidden" class="supremacy_able" name="attr_supremacy_able" value="0" />
-                <div class="supremacy">
-                    <div class="skillrow">
-                        <details>
-                            <summary>Iron Will</summary>
-                            <input type="hidden" class="knightcheckbox iron_will_front" name="attr_iron_will" value="0" />
-                            <div class="knightskill iron_will_button_front">
-                                <span>Activate against the following spells: Command, Curse, Transfix, Enslave, Enthrall, Benight, Turncoat, Pacify, Dark Thoughts, Winds of Change, and Witch Steed.</span>
-                                <select name="attr_activateiron_will">
-                                    <option>Inactive</option>
-                                    <option>Active</option>
+                            <summary>Hunter's Mind</summary>
+                            <input type="hidden" class="huntercheckbox hunters_mind_front" name="attr_hunters_mind" value="0" />
+                            <div class="hunterroll hunters_mind_button_front">
+                                <span>Activate when in the wilderness and wearing at most padded armour</span>
+                                <select name="attr_huntersmindactivate">
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Active</option>
                                 </select>
                             </div>
-                        </details>    
-                    </div>
+                       </details>
+                        </div>
                     <div class="skillrow">
                         <details>
-                            <summary>Intimidating</summary>
-                            <input type="hidden" class="knightcheckbox intimidating_front" name="attr_intimidating" value="0" />
-                            <div class="knightroll intimidating_button_front">
-                                <span>Roll Intimidate</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} glares intimidatingly}} {{subtitle=Roll Intimidation check under your Looks}} {{roll=[[1d20cs1cf20]]}} {{Vs=[[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_intimidate"></button>
+                            <summary>Fast Shot</summary>
+                            <input type="hidden" class="huntercheckbox fast_shot_front" name="attr_fast_shot" value="0" />
+                            <div class="hunterroll fast_shot_button_front">
+                                <span>Check if second shot is possible</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} concentrates on snapping off two quick shots.}} {{subtitle=Roll 1d20 under Reflexes}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalreflexes} }}" name="roll_fast_shot"></button>
+                                <br>
+                                <span>Roll second attack at end of round</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} rapidly fires a second time with @{equippedrangedweaponname}}} {{subtitle=@{equippedrangedweapontype} +@{equippedrangedweaponmagicbonus} with @{equippedammotype}}} {{attackroll= [[1d20cs1cf20]]}} {{attackvsranged=[[ @{finalrangedattack} - ?{Different target from first?|No, 0|Yes, 2} - ?{Range Modifier|Short @{equippedrangedweaponshortrange}m, 0|Medium @{equippedrangedweaponmediumrange}m, 3|Long @{equippedrangedweaponlongrange}m, 7} - ?{Small or Crouching target?|No, 0|Yes, 2} - ?{Is the Target moving?|No, 0|Slowly, 2|Quickly, 4} - (?{Light Conditions|Normal, 0|Poor, 3|Other, ?{Other}}) + (?{Miscellaneous Modifiers, can be a positive (improves chance to hit) or a negative (decreases chance to hit)|0})]] }} {{abr=[[ @{equippedrangedweaponabr} + @{finalrangedabrbonus} ]]}} {{Damage=[[ @{equippedrangedweapondamage} + @{finalrangeddmgbonus} ]]}} {{desc=@{equippedammospecialeffect}}}" name="roll_fast_shot"></button>
                             </div>
                         </details>
                     </div>
-                </div>
-            </div>
-            
-            <div class="melee warlockmelee">
-                <h1>Warlock Profession Abilities</h1>
-                <br>
-                <div class="skillrow">
-                    <details>
-                        <summary>Selected Weapon Groups</summary>
-                        <div class="weapon-group-container">
-                            <span>Weapon Group 1:</span> 
-                            <div class="sheet-auto-expand">
-                                <span name="attr_weapon_group_1_description"></span>
-                                <textarea name="attr_weapon_group_1_description" class="warlock-weapongroup" readonly ></textarea>
-                            </div>    
-                            <br>
-                            <span>Weapon Group 2:</span> 
-                            <div class="sheet-auto-expand">
-                                <span name="attr_weapon_group_2_description"></span>
-                                <textarea name="attr_weapon_group_2_description" class="warlock-weapongroup" readonly ></textarea>
-                            </div>    
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                  <details>
-                    <summary>Appraise Enemy</summary>
-                    <input type="hidden" class="warlockcheckbox appraiseenemy_front" name="attr_appraise_enemy" value="0" />
-                    <div class="warlockroll appraiseenemy_button_front">
-                        <span>Activate</span> <button class="button1 d20 " type="roll" value="/w gm&{template:custom} {{title=@{character_name} attempts to appraise their enemy}} {{subtitle=Roll 1d20 under Psychic Talent}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalpsychictalent}}} {{On fail, percieved rank= [[3d6 –7]]}}" name="roll_appraiseenemy"></button>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Forage</summary>
+                            <input type="hidden" class="huntercheckbox forage_front" name="attr_forage" value="0" />
+                            <div class="hunterroll forage_button_front">
+                                <span>Roll Forage</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} forages in the wilderness.}} {{subtitle=Roll 2d20 under Forage Skill}} {{roll=[[1d20cs1cf20]]}} {{Vs= ?{Terrain Type?|Fecund, &#91;&#91; &#64;&#123;finalperception&#125; - 10 &#93;&#93; 
+                                it takes 
+                                &#91;&#91;1d3&#93;&#93; 
+                                hours |Fertile, &#91;&#91; &#64;&#123;finalperception&#125; - 14 &#93;&#93; 
+                                it takes 
+                                &#91;&#91;1d3+3&#93;&#93; 
+                                hours |Desolate, &#91;&#91; &#64;&#123;finalperception&#125; - 18 &#93;&#93; 
+                                it takes 
+                                &#91;&#91;1d3+6&#93;&#93; 
+                                hours} }}" name="roll_forage"></button>
+                            </div>
+                        </details>
                     </div>
                     </details>
                 </div>
-            </div>
-            
-            <div class="melee assassinmelee">
-                <h1>Assassin Profession Abilities</h1>
-                <div class="skillrow">
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="knavemelee">
                     <details>
-                        <summary>Shock Attack</summary>
-                        <input type="hidden" class="assassincheckbox shock_attack_front" name="attr_shock_attack" value="0" />
-                        <div class="assassinroll shock_attack_button_front">
-                            <span>Roll Shock Attack result:</span> <button class="roll d6" type="roll" value="&{template:custom} {{title=@{character_name} delivers a Shock Attack!}} {{subtitle=Roll a D6}} {{roll= [[1d6]]}} {{Result= 1 Stunned Opponent’s attack, defence and evasion are all at 0.
-                            2 Aghast Opponent’s attack and evasion are at 0; defence is half normal. 
-                            3-4 Astonished Opponent’s attack is at 0; evasion and defence at half normal. 
-                            5-6 Surprised Opponent’s attack is at 0; evasion and defence are unimpaired}}" ></button>
-                        </div>
-                </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Inner Sense</summary>
-                        <input type="hidden" class="assassincheckbox inner_sense_front" name="attr_inner_sense" value="0" />
-                        <div class="assassinroll inner_sense_button_front">
-                            <span>GM rolls</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} extends their Inner Senses}} {{subtitle=Roll under Psychic Talent on 1d20}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalpsychictalent} }}" name="roll_inner_sense"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Memorize</summary>
-                        <input type="hidden" class="assassincheckbox memorize_front" name="attr_memorize" value="0" />
-                        <div class="assassinroll memorize_button_front">
-                            <span>GM rolls</span> <button class="roll twod10" type="roll" value="&{template:custom} {{title=@{character_name} tries to recall information}} {{subtitle=Roll under target number on 1d100}} {{roll=[[1d100cs1cf100]]}} {{Vs=[[100 - (?{Months Passed (max 9)|1} * 10)]]}}" name="roll_inner_sense"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                   <details>
+                    <summary><h2>Knave Profession Abilities</h2></summary>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Favoured Language</summary>
+                            <input type="text" name="attr_favoured_modernlanguage" readonly />
+                            <br>
+                            <span>Add +1 to Perception and +1 to Looks when communicating with humans in that language.</span>
+                            <select name="attr_favoured_language">
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Active</option>
+                                </select>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Human Intuition</summary>
+                            <input type="hidden" class="knavecheckbox human_intuition_front" name="attr_human_intuition" value="0" />
+                            <div class="knaveroll human_intuition_button_front">
+                                <select name="attr_humanintuitionselect">
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Apply to Perception</option> 
+                                    <option value="2">Apply to Attack</option>
+                                    <option value="3">Apply to both Perception and Attack</option>
+                                </select>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                      <details>
                         <summary>Disguise</summary>
-                        <input type="hidden" class="assassincheckbox disguise_front" name="attr_disguise" value="0" />
-                        <div class="assassinroll disguise_button_front">
+                        <input type="hidden" class="knavecheckbox disguise_front" name="attr_disguise" value="0" />
+                        <div class="knaveroll disguise_button_front">
                             <span>Roll Disguise</span> <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to deceive by disguise.}} {{subtitle=Stealth vs. Perception}} {{roll= [[2d10]]}} {{Vs= [[@{finalstealth}-?{Target's Perception|0}]] }}" name="roll_disguise"></button>
                         </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
+                      </details>
+                    </div>
+                    <div class="skillrow">
+                      <details>
                         <summary>Pilfer</summary>
-                        <input type="hidden" name="attr_pilfermodifier_front" value="0" />
-                        <input type="hidden" class="assassincheckbox pilfer_front" name="attr_pilfer" value="0" />
-                        <div class="assassinroll pilfer_button_front">
+                        <input type="hidden" class="knavecheckbox pilfer_front" name="attr_pilfer" value="0" />
+                        <div class="knaveroll pilfer_button_front">
                             <span>Roll Pilfer</span> <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to pilfer.}} {{subtitle=Stealth vs. Perception}} {{roll= [[2d10]]}} {{Vs= [[@{finalstealth}-(@{pilfermodifier})-?{Target's Perception|0}]] }}" name="roll_pilfer"></button>
                         </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Pick Lock</summary>
-                        <input type="hidden" name="attr_pick_lockscore" value="0" />
-                        <input type="hidden" class="assassincheckbox pick_lock_front" name="attr_pick_lock" value="0" />
-                        <div class="assassinroll pick_lock_button_front">
-                            <span>GM rolls for possibility of success</span> <button class="roll twod10" type="roll" value="/w gm&{template:custom} {{title=@{character_name} examines the lock.}} {{subtitle=Roll 1d100 under the Lock Difficulty}} {{roll=[[1d100cs1cf100]]}} {{Vs= [[@{pick_lockscore} - ?{Lock Difficulty|0} ]]}}" name="roll_pick_lockcheck"></button>
-                            Roll Pick Lock <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts to pick a lock.}} {{subtitle=Roll 1d100 under Rank}} {{roll= [[1d100cs1cf100]]}} {{Vs= @{rank}}}" name="roll_pick_lockchance"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Track</summary>
-                        <input type="hidden" class="assassincheckbox track_front" name="attr_track" value="0" />
-                        <div class="assassinroll track_button_front">
-                            <span>Roll Track</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} searches for Tracks}} {{subtitle=Roll under Tracking Skill}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finalperception}+@{trackmodifier}-?{Other Modifiers|0}]] }}" name="roll_track"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>    
-                        <summary>Deathvow</summary>
-                        <input type="hidden" class="assassincheckbox deathvow_front" name="attr_deathvow" value="0" />
-                        <div class="assassinroll deathvow_button_front">
-                            <span>Activate</span>
-                            <select name="attr_deathvowselect" >
-                                <option value="0">Inactive</option>
-                                <option value="1">Active</option>
-                            </select>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            
-            <div class="melee mysticmelee">
-                <h1>Mystic Profession Abilities</h1>
-                <div class="skillrow">
-                    <details>
-                        <summary>Spell Mastery</summary>
-                        <span>Current Mastered Spell</span><input type="text" name="attr_mastered_spell" />
-                    </details>
-                </div>              
-                <div class="skillrow">
-                    <details>
-                        <summary>ESP</summary>
-                        <input type="hidden" class="mysticcheckbox esp_front" name="attr_esp" value="0" />
-                        <div class="mysticroll esp_button_front">
-                            <span>ESP Chance</span> <input class="fourshorttextinput" type="number" name="attr_espchance" value="0" /> %
-                            <span>Roll ESP</span> <button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} uses ESP}} {{subtitle=Roll 1d100 under ESP chance}} {{roll= [[1d100cs1cf100]]}} {{Vs= [[@{espchance}]]%}}" name="roll_espcheck" ></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                    <summary>Premonition</summary> 
-                        <input type="hidden" class="mysticcheckbox premonition_front" name="attr_premonition" value="0" />
-                        <div class="mysticroll premonition_button_front">
-                            <span>Premonition Chance</span> <input class="fourshorttextinput" type="number" name="attr_premonitionchance" value="0" /> %
-                            <span>Roll Premonition</span> <button class="button d20" type="roll" value="/w gm &{template:custom} {{title=@{character_name} uses Premonition}} {{subtitle=Roll 1d100 under Premonition Chance}} {{roll= [[1d100cs1cf100]]}} {{Vs= [[@{premonitionchance}]]%}}" name="roll_premonitioncheck"></button>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            
-            <div class="melee huntermelee">
-                <h2>Hunter Profession Abilities</h2>
-                <div class="skillrow">
-                    <details>
-                        <summary>Favoured Weapon</summary> 
-                        <input type="hidden" class="huntercheckbox favoured_weapon_front" name="attr_favoured_weapon" value="0"/>
-                        <div class="hunterroll favoured_weapon_button_front">
-                            <span>Weapon type</span> <input type="text" name="attr_favoured_weapon_selected" readonly />                                    
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Favoured Terrain</summary>
-                        <input type="hidden" class="huntercheckbox favoured_terrain_front" name="attr_favoured_terrain" value="0" />
-                        <div class="hunterroll favoured_terrain_button_front">
-                            <span>Terrain Type</span> <input type="text" name="attr_favoured_terrain_selected" readonly />
-                        </div>
-                    </details>
-                </div>
-                
-                <!-- Precise Shot Section -->
-                <div class="skillrow">
-                    <details>
-                        <summary>Precise Shot</summary>
-                        <input type="hidden" class="huntercheckbox precise_shot_front" name="attr_precise_shot" value="0" />
-                        <div class="hunterroll precise_shot_button_front">
-                            <span>Defence Penalty</span> <input class="fourshorttextinput" type="number" name="attr_preciseneg" step="3" max="0" value="0" />
-                            <br>
-                            <span>Attack Bonus</span> <input class="fourshorttextinput" type="text" name="attr_precisepos" value="0" readonly />
-                        </div>
-                    </details>
-                </div>
-                <!-- Stillness Section -->
-                <div class="skillrow">
-                    <details>
-                        <summary>Stillness</summary>
-                        <input type="hidden" class="huntercheckbox stillness_front" name="attr_stillness" value="0" />
-                        <div class="hunterroll stillness_button_front">
-                            <span>Defence Penalty</span> <input class="fourshorttextinput" type="number" name="attr_stillnessneg" step="1" max="0" value="0" /> 
-                            <br>
-                            <span>Stealth Bonus</span> <input class="fourshorttextinput" type="text" name="attr_stillnesspos" value="0" readonly />
-                            <br>
-                            <span>Apply favoured terrain bonus</span> 
-                            <select name="attr_favoured_terrain">
-                                <option value="0">Inactive</option>
-                                <option value="1">Active</option>
-                            </select>
-                        </div>
-                    </details>
-                </div>
-                <!-- Penetrating Shot Section -->
-                <div class="skillrow">
-                    <details>
-                        <summary>Penetrating Shot</summary>
-                        <input type="hidden" class="huntercheckbox penetrating_shot_front" name="attr_penetrating_shot" value="0" />
-                        <div class="hunterroll penetrating_shot_button_front">
-                            <span>Activate when firing at short range</span>
-                            <select name="attr_penetratingshotselect" >
-                                <option value="0">Inactive</option>
-                                <option value="1">Active</option>
-                            </select>
-                        </div>
-                    </details>    
-                </div>
-                    <!-- New Hunter's Mind Section -->
-                <div class="skillrow">
-                    <details>
-                        <summary>Hunter's Mind</summary>
-                        <input type="hidden" class="huntercheckbox hunters_mind_front" name="attr_hunters_mind" value="0" />
-                        <div class="hunterroll hunters_mind_button_front">
-                            <span>Activate when in the wilderness and wearing at most padded armour</span>
-                            <select name="attr_huntersmindactivate">
-                                <option value="0">Inactive</option>
-                                <option value="1">Active</option>
-                            </select>
-                        </div>
-                   </details>
+                      </details>
                     </div>
-                
-                <div class="skillrow">
-                    <details>
-                        <summary>Fast Shot</summary>
-                        <input type="hidden" class="huntercheckbox fast_shot_front" name="attr_fast_shot" value="0" />
-                        <div class="hunterroll fast_shot_button_front">
-                            <span>Check if second shot is possible</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} concentrates on snapping off two quick shots.}} {{subtitle=Roll 1d20 under Reflexes}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalreflexes} }}" name="roll_fast_shot"></button>
-                            <br>
-                            <span>Roll second attack at end of round</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} rapidly fires a second time with @{equippedrangedweaponname}}} {{subtitle=@{equippedrangedweapontype} +@{equippedrangedweaponmagicbonus} with @{equippedammotype}}} {{attackroll= [[1d20cs1cf20]]}} {{attackvsranged=[[ @{finalrangedattack} - ?{Different target from first?|No, 0|Yes, 2} - ?{Range Modifier|Short @{equippedrangedweaponshortrange}m, 0|Medium @{equippedrangedweaponmediumrange}m, 3|Long @{equippedrangedweaponlongrange}m, 7} - ?{Small or Crouching target?|No, 0|Yes, 2} - ?{Is the Target moving?|No, 0|Slowly, 2|Quickly, 4} - (?{Light Conditions|Normal, 0|Poor, 3|Other, ?{Other}}) + (?{Miscellaneous Modifiers, can be a positive (improves chance to hit) or a negative (decreases chance to hit)|0})]] }} {{abr=[[ @{equippedrangedweaponabr} + @{finalrangedabrbonus} ]]}} {{Damage=[[ @{equippedrangedweapondamage} + @{finalrangeddmgbonus} ]]}} {{desc=@{equippedammospecialeffect}}}" name="roll_fast_shot"></button>
-                        </div>
-                    </details>
-                </div>
-                
-                <div class="skillrow">
-                    <details>
-                        <summary>Forage</summary>
-                        <input type="hidden" class="huntercheckbox forage_front" name="attr_forage" value="0" />
-                        <div class="hunterroll forage_button_front">
-                            <span>Roll Forage</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} forages in the wilderness.}} {{subtitle=Roll 2d20 under Forage Skill}} {{roll=[[1d20cs1cf20]]}} {{Vs= ?{Terrain Type?|Fecund, &#91;&#91; &#64;&#123;finalperception&#125; - 10 &#93;&#93; 
-                            it takes 
-                            &#91;&#91;1d3&#93;&#93; 
-                            hours |Fertile, &#91;&#91; &#64;&#123;finalperception&#125; - 14 &#93;&#93; 
-                            it takes 
-                            &#91;&#91;1d3+3&#93;&#93; 
-                            hours |Desolate, &#91;&#91; &#64;&#123;finalperception&#125; - 18 &#93;&#93; 
-                            it takes 
-                            &#91;&#91;1d3+6&#93;&#93; 
-                            hours} }}" name="roll_forage"></button>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            
-            <div class="melee knavemelee">
-                <h1>Knave Profession Abilities</h1>
-                <div class="skillrow">
-                    <details>
-                        <summary>Favoured Language</summary>
-                        <input type="text" name="attr_favoured_modernlanguage" readonly />
-                        <br>
-                        <span>Add +1 to Perception and +1 to Looks when communicating with humans in that language.</span>
-                        <select name="attr_favoured_language">
-                                <option value="0">Inactive</option>
-                                <option value="1">Active</option>
-                            </select>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Human Intuition</summary>
-                        <input type="hidden" class="knavecheckbox human_intuition_front" name="attr_human_intuition" value="0" />
-                        <div class="knaveroll human_intuition_button_front">
-                            <select name="attr_humanintuitionselect">
-                                <option value="0">Inactive</option>
-                                <option value="1">Apply to Perception</option> 
-                                <option value="2">Apply to Attack</option>
-                                <option value="3">Apply to both Perception and Attack</option>
-                            </select>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                  <details>
-                    <summary>Disguise</summary>
-                    <input type="hidden" class="knavecheckbox disguise_front" name="attr_disguise" value="0" />
-                    <div class="knaveroll disguise_button_front">
-                        <span>Roll Disguise</span> <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to deceive by disguise.}} {{subtitle=Stealth vs. Perception}} {{roll= [[2d10]]}} {{Vs= [[@{finalstealth}-?{Target's Perception|0}]] }}" name="roll_disguise"></button>
-                    </div>
-                  </details>
-                </div>
-                <div class="skillrow">
-                  <details>
-                    <summary>Pilfer</summary>
-                    <input type="hidden" class="knavecheckbox pilfer_front" name="attr_pilfer" value="0" />
-                    <div class="knaveroll pilfer_button_front">
-                        <span>Roll Pilfer</span> <button class="roll twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to pilfer.}} {{subtitle=Stealth vs. Perception}} {{roll= [[2d10]]}} {{Vs= [[@{finalstealth}-(@{pilfermodifier})-?{Target's Perception|0}]] }}" name="roll_pilfer"></button>
-                    </div>
-                  </details>
-                </div>
-                <div class="skillrow">
-                  <details>
-                    <summary>Distract</summary>
-                    <input type="hidden" class="knavecheckbox distract_front" name="attr_distract" value="0" />
-                    <div class="knaveroll distract_button_front">
-                        <span>Roll Distract</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} attempts to distract their target.}} {{subtitle=Roll 1d20 under Reflexes}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalreflexes} }}" name="roll_distract"></button>
-                    </div>
-                  </details>
-                </div>
-                <div class="skillrow">
-                  <details>
-                    <summary>Bodyguard</summary>
-                    <input type="hidden" class="knavecheckbox bodyguard_front" name="attr_bodyguard" value="0" />
-                    <div class="knaveroll bodyguard_button_front">
-                        <span>Use the Bodyguard to Intimidate</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} has their bodyguard glare intimidatingly}} {{subtitle=Roll 1d20 under Looks}} {{roll=[[1d20cs1cf20]]}} {{Vs=[[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_intimidate"></button>
-                    </div>
-                  </details>
-                </div>
-                <div class="skillrow">
+                    <div class="skillrow">
                       <details>
-                        <summary>Gossip</summary>
-                        <input type="hidden" class="knavecheckbox gossip_front" name="attr_gossip" value="0" />
-                        <div class="knaveroll gossip_button_front">
-                            <span>Roll Gossip</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} gossips around town. }} {{subtitle=Roll 2d20 - Rank}} {{It takes= [[2d20-@{rank}]] hours in a small settlement; Days in a large settlement; Weeks in a Capital City}} {{and it costs = [[1d6]] Silver Florins per day}} }" name="roll_gossip"></button>
+                        <summary>Distract</summary>
+                        <input type="hidden" class="knavecheckbox distract_front" name="attr_distract" value="0" />
+                        <div class="knaveroll distract_button_front">
+                            <span>Roll Distract</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} attempts to distract their target.}} {{subtitle=Roll 1d20 under Reflexes}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalreflexes} }}" name="roll_distract"></button>
                         </div>
                       </details>
                     </div>
-                <div class="skillrow">
+                    <div class="skillrow">
                       <details>
-                        <summary>Presence</summary>
-                        <input type="hidden" class="knavecheckbox presence_front" name="attr_presence" value="0" />
-                        <div class="knaveroll presence_button_front">
-                            <span>Roll Presence</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} projects their presence.}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_presence"></button>
+                        <summary>Bodyguard</summary>
+                        <input type="hidden" class="knavecheckbox bodyguard_front" name="attr_bodyguard" value="0" />
+                        <div class="knaveroll bodyguard_button_front">
+                            <span>Use the Bodyguard to Intimidate</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} has their bodyguard glare intimidatingly}} {{subtitle=Roll 1d20 under Looks}} {{roll=[[1d20cs1cf20]]}} {{Vs=[[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_intimidate"></button>
                         </div>
                       </details>
                     </div>
-                <div class="skillrow">
-                      <details>
-                        <summary>Sense Falsehood</summary>
-                        <input type="hidden" class="knavecheckbox sense_falsehood_front" name="attr_sense_falsehood" value="0" />
-                        <div class="knaveroll sense_falsehood_button_front">
-                            <span>Roll Sense Falsehood</span> <button class="button twod10 " type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title= @{character_name} tries to discern a lie.}} {{subtitle=Roll 1d100 under Target Number}} {{roll= [[1d100cs1cf100]]}} {{Vs= [[50+@{finalintelligence}+@{finalpsychictalent}+@{rank}-?{Target's rank/equivalent|1}]] }}" name="roll_sense_falsehood"></button>
-                        </div>
-                      </details>
-                    </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Hypnotic Suggestion</summary>
-                        <input type="hidden" class="knavecheckbox hypnotic_suggestion_front" name="attr_hypnotic_suggestion" value="0" />
-                        <div class="knaveroll hypnotic_suggestion_button_front">
-                            <span>Roll Hypnotic Suggestion</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} projects a Hypnotic Suggestion.}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finallooks}}}" name="roll_hypnotic_suggestion"></button>
-                        </div>
-                      </details>
-                    </div>
-                <div class="skillrow">
-                      <details>
-                        <summary>Network</summary>
-                        <input type="hidden" class="knavecheckbox network_front" name="attr_network" value="0" />
-                        <div class="knaveroll network_button_front">
-                            <span>Roll Network</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} recalls the favours owed to them.}} {{subtitle=Roll 1d20 under Rank}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{rank}}} {{Number of loyal friends= ?{Size of settlement|village, [[1d4]]|Town, [[1d10]]| City, [[1d20]]}}}" name="roll_network"></button>
-                        </div>
-                      </details>
-                    </div>
-                <div class="skillrow">
-                      <details>
-                        <summary>Words are Power</summary>
-                        <input type="hidden" class="knavecheckbox words_are_power_front" name="attr_words_are_power" value="0" />
-                        <div class="knaveroll words_are_power_button_front">
-                            <span>Roll Words are Power</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} gives an impassioned speech.}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs = @{finallooks}}} {{Number of people affected = [[2d20]]}}" name="roll_words_are_power"></button>
-                        </div>
-                      </details>
-                    </div>
-            </div>    
-            
-            <div class="melee elementalistmelee">
-                Elementalist Profession Abilities
-                <div class="skillrow">
-                    <details>
-                        <summary>Raw Power</summary>
-                        <input type="hidden" class="elementalistcheckbox raw_power_front" name="attr_raw_power" value="0" />
-                        <input type="hidden" class="elementalistcheckbox raw_poweralternate_front" name="attr_raw_poweralternate" value="0" />
-                        <div class="elementalistroll raw_power_button_front">
-                            <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
-                            <div class="elementalist_core_powers">
-                                <span>Attack with Raw Power:</span> <button class="button d20 skillroll" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Raw Power}} {{spellattackroll= [[10 + ?{Magic Points expended}]]}} {{speedvsevasion= ?{Target Evasion}}} {{range= [[10 * ?{Magic Points expended}]] metres}} {{damage= [[2d6 * ?{Magic Points expended}]]}}" name="roll_raw_power"></button>
+                    <div class="skillrow">
+                          <details>
+                            <summary>Gossip</summary>
+                            <input type="hidden" class="knavecheckbox gossip_front" name="attr_gossip" value="0" />
+                            <div class="knaveroll gossip_button_front">
+                                <span>Roll Gossip</span> <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} gossips around town. }} {{subtitle=Roll 2d20 - Rank}} {{It takes= [[2d20-@{rank}]] hours in a small settlement; Days in a large settlement; Weeks in a Capital City}} {{and it costs = [[1d6]] Silver Florins per day}} }" name="roll_gossip"></button>
                             </div>
-                            <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
-                            <div class="elementalist_alternate_powers">
-                              <span>Attack with Raw Power (alternate):</span> <button class="button1 twod10 skillroll" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Raw Power to attack}} {{spellattackroll= [[2d10]]}} {{VS = [[@{finalmagicalattack} - ?{Target's Magical Defence}]]}} {{damage=Dealing 2 Damage per Magic Point Spent: [[?{Magic Points spent} * 2]]}}" name="roll_raw_poweralternate"></button>
+                          </details>
+                        </div>
+                    <div class="skillrow">
+                          <details>
+                            <summary>Presence</summary>
+                            <input type="hidden" class="knavecheckbox presence_front" name="attr_presence" value="0" />
+                            <div class="knaveroll presence_button_front">
+                                <span>Roll Presence</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} projects their presence.}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs= [[@{finallooks}+?{+1 to Looks for each other character of equal or greater Rank that stands with them|0}]] }}" name="roll_presence"></button>
                             </div>
+                          </details>
                         </div>
-                    </details>
-                </div>    
-                <div class="skillrow">
-                    <details>
-                        <summary>Elemental Resistance</summary>
-                        <input type="hidden" class="elementalistcheckbox elemental_resistance_front" name="attr_elemental_resistance" value="0" />
-                        <div class="elementalistroll elemental_resistance_button_front">
-                            <select name="attr_elemental_resistance_select" >
-                                <option value="0">Inactive</option>
-                                <option value="1">Activate Primary Element Resistance</option>
-                                <option value="2">Activate Secondary Element Resistance</option>
-                            </select>
+                    <div class="skillrow">
+                          <details>
+                            <summary>Sense Falsehood</summary>
+                            <input type="hidden" class="knavecheckbox sense_falsehood_front" name="attr_sense_falsehood" value="0" />
+                            <div class="knaveroll sense_falsehood_button_front">
+                                <span>Roll Sense Falsehood</span> <button class="button twod10 " type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title= @{character_name} tries to discern a lie.}} {{subtitle=Roll 1d100 under Target Number}} {{roll= [[1d100cs1cf100]]}} {{Vs= [[50+@{finalintelligence}+@{finalpsychictalent}+@{rank}-?{Target's rank/equivalent|1}]] }}" name="roll_sense_falsehood"></button>
+                            </div>
+                          </details>
                         </div>
-                    </details>
-                </div>
-            </div>
-            
-            <div class="melee priestmelee">
-                Priest Profession Abilities
                     <div class="skillrow">
                         <details>
-                        <summary>Linguist</summary>
-                        <input type="hidden" class="priestcheckbox linguist_front" name="attr_linguist" value="0" />
-                        <div class="priestroll linguist_button_front">
-                            <span>Roll Linguist</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts to decipher some text.}} {{subtitle=Roll 1d20 under Intelligence}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalintelligence} }}" name="roll_linguist"></button>
+                            <summary>Hypnotic Suggestion</summary>
+                            <input type="hidden" class="knavecheckbox hypnotic_suggestion_front" name="attr_hypnotic_suggestion" value="0" />
+                            <div class="knaveroll hypnotic_suggestion_button_front">
+                                <span>Roll Hypnotic Suggestion</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} projects a Hypnotic Suggestion.}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finallooks}}}" name="roll_hypnotic_suggestion"></button>
+                            </div>
+                          </details>
                         </div>
+                    <div class="skillrow">
+                          <details>
+                            <summary>Network</summary>
+                            <input type="hidden" class="knavecheckbox network_front" name="attr_network" value="0" />
+                            <div class="knaveroll network_button_front">
+                                <span>Roll Network</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} recalls the favours owed to them.}} {{subtitle=Roll 1d20 under Rank}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{rank}}} {{Number of loyal friends= ?{Size of settlement|village, [[1d4]]|Town, [[1d10]]| City, [[1d20]]}}}" name="roll_network"></button>
+                            </div>
+                          </details>
+                        </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Words are Power</summary>
+                            <input type="hidden" class="knavecheckbox words_are_power_front" name="attr_words_are_power" value="0" />
+                            <div class="knaveroll words_are_power_button_front">
+                                <span>Roll Words are Power</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} gives an impassioned speech.}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs = @{finallooks}}} {{Number of people affected = [[2d20]]}}" name="roll_words_are_power"></button>
+                            </div>
+                        </details>
+                    </div>
+                    </details>
+                </div>    
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="elementalistmelee">
+                    <details>
+                    <summary><h2>Elementalist Profession Abilities</h2></summary>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Raw Power</summary>
+                            <input type="hidden" class="elementalistcheckbox raw_power_front" name="attr_raw_power" value="0" />
+                            <input type="hidden" class="elementalistcheckbox raw_poweralternate_front" name="attr_raw_poweralternate" value="0" />
+                            <div class="elementalistroll raw_power_button_front">
+                                <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
+                                <div class="elementalist_core_powers">
+                                    <span>Attack with Raw Power:</span> <button class="button d20 skillroll" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Raw Power}} {{spellattackroll= [[10 + ?{Magic Points expended}]]}} {{speedvsevasion= ?{Target Evasion}}} {{range= [[10 * ?{Magic Points expended}]] metres}} {{damage= [[2d6 * ?{Magic Points expended}]]}}" name="roll_raw_power"></button>
+                                </div>
+                                <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
+                                <div class="elementalist_alternate_powers">
+                                  <span>Attack with Raw Power (alternate):</span> <button class="button1 twod10 skillroll" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Raw Power to attack}} {{spellattackroll= [[2d10]]}} {{VS = [[@{finalmagicalattack} - ?{Target's Magical Defence}]]}} {{damage=Dealing 2 Damage per Magic Point Spent: [[?{Magic Points spent} * 2]]}}" name="roll_raw_poweralternate"></button>
+                                </div>
+                            </div>
+                        </details>
+                    </div>    
+                    <div class="skillrow">
+                        <details>
+                            <summary>Elemental Resistance</summary>
+                            <input type="hidden" class="elementalistcheckbox elemental_resistance_front" name="attr_elemental_resistance" value="0" />
+                            <div class="elementalistroll elemental_resistance_button_front">
+                                <select name="attr_elemental_resistance_select" >
+                                    <option value="0">Inactive</option>
+                                    <option value="1">Activate Primary Element Resistance</option>
+                                    <option value="2">Activate Secondary Element Resistance</option>
+                                </select>
+                            </div>
+                        </details>
+                    </div>
                     </details>
                 </div>
-                <div class="skillrow">
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="priestmelee">
                     <details>
-                        <summary>Exorcism</summary>
-                        <input type="hidden" class="priestcheckbox exorcism_front" name="attr_exorcism" value="0" />
-                        <div class="priestroll exorcism_button_front">
-                            <span>Roll Exorcism</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} pits his will against a demon!}} {{subtitle=Roll 1d20 + Rank under 1d20 + Demon's Rank/Equivalent}} {{roll= [[1d20cs1cf20+@{rank}]]}} {{Vs= [[?{The Demon's Rank/Equivalent|1}+1d20cs1cf20]] }}" name="roll_exorcism"></button>
-                        </div>
+                    <summary><h2>Priest Profession Abilities</h2></summary>
+                        <div class="skillrow">
+                            <details>
+                            <summary>Linguist</summary>
+                            <input type="hidden" class="priestcheckbox linguist_front" name="attr_linguist" value="0" />
+                            <div class="priestroll linguist_button_front">
+                                <span>Roll Linguist</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts to decipher some text.}} {{subtitle=Roll 1d20 under Intelligence}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalintelligence} }}" name="roll_linguist"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Exorcism</summary>
+                            <input type="hidden" class="priestcheckbox exorcism_front" name="attr_exorcism" value="0" />
+                            <div class="priestroll exorcism_button_front">
+                                <span>Roll Exorcism</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} pits his will against a demon!}} {{subtitle=Roll 1d20 + Rank under 1d20 + Demon's Rank/Equivalent}} {{roll= [[1d20cs1cf20+@{rank}]]}} {{Vs= [[?{The Demon's Rank/Equivalent|1}+1d20cs1cf20]] }}" name="roll_exorcism"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Sermon</summary>
+                            <input type="hidden" class="priestcheckbox sermon_front" name="attr_sermon" value="0" />
+                            <div class="priestroll sermon_button_front">
+                                <span>Roll Sermon</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} gives a stirring sermon}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finallooks} }}" name="roll_sermon"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Remove Curse</summary>
+                            <input type="hidden" class="priestcheckbox remove_curse_front" name="attr_remove_curse" value="0" />
+                            <div class="priestroll remove_curse_button_front">
+                                <span>Roll Remove Curse</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts to remove a foul curse}} {{Roll 1d20 under Target Number}} {{roll= [[1d20cs1cf20]]}} {{Vs = [[@{rank}+@{finalmagicaldefence}]] }}" name="roll_remove_curse"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Remove Madness</summary>
+                            <input type="hidden" class="priestcheckbox remove_madness_front" name="attr_remove_madness" value="0" />
+                            <div class="priestroll remove_madness_button_front">
+                                <span>Roll Remove Madness</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} soothe a troubled mind}} {{subtitle=Roll 1d20 under Target Number}} {{roll= [[1d20cs1cf20]]}} {{Vs = [[@{rank}+?{Relic Quality|Holy, 1|Saintly, 2|Perfect, 4|Godly, 8}]] }}" name="roll_remove_madness"></button>
+                            </div>
+                        </details>
+                    </div>
                     </details>
                 </div>
-                <div class="skillrow">
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="demonologistmelee">
                     <details>
-                        <summary>Sermon</summary>
-                        <input type="hidden" class="priestcheckbox sermon_front" name="attr_sermon" value="0" />
-                        <div class="priestroll sermon_button_front">
-                            <span>Roll Sermon</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} gives a stirring sermon}} {{subtitle=Roll 1d20 under Looks}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finallooks} }}" name="roll_sermon"></button>
-                        </div>
+                    <summary><h2>Demonologist Profession Abilities</h2></summary>
+                    <div class="skilrow">
+                        <details>
+                            <summary>Demonology</summary>
+                            <input type="hidden" class="demonologistcheckbox demonology_front" name="attr_demonology" value="0" />
+                            <input type="hidden" name="attr_demonology_modifier" value='0' />
+                            <div class="demonologistroll demonology_button_front">
+                                <span>Roll Demonology</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} seeks hidden, forbidden knowledge}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}} {{Time spent in research and meditation= [[2d10]]}}" name="roll_demonology"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>The Ritual of Summoning</summary>
+                            <input type="hidden" class="demonologistcheckbox ritual_front" name="attr_ritual_of_summoning" value="0" />
+                            <div class="demonologistroll ritual_button_front">
+                                <span>Perform The Ritual of Summoning</span> <button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} crafts a ritual to summon a Demon}} {{subtitle=Magical Attack vs Magical Defence}} {{roll= [[2d10]]}} {{Vs= [[@{finalmagicalattack}-?{The Demon's Magical Defence|0}]] }} {{Money spent on the summoning= [[2d4*10]] Silver Florins}} {{If successful, the Demon will remain for= [[1d4]] hours}} {{The caster is drained= [[1d3]] Strength 
+                                (manually input into Strength Misc Modifiers)}} {{The Demon's response to being summoned is= [[1d10]] 
+                                1 Aggressive and hostile; will attack immediately. 
+                                2-4 Antipathetic; will need a lot of convincing to do anything other than attack. 
+                                5-9 Surly; may serve, if offered a good deal. 
+                                10 Friendly.}}" name="roll_ritual"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>Banishing a Demon</summary>
+                            <input type="hidden" class="demonologistcheckbox banish_front" name="attr_banishing_a_demon" value="0" />
+                            <div class="demonologistroll banish_button_front">
+                                <span>Roll to Banish a Demon</span> <button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} tries to Banish a demon}} {{subtitle=Magical Attack vs Magical Defence}} {{roll= [[2d10]]}} {{Vs= [[@{finalmagicalattack}-?{Demon's Magical Defence|0}-?{Whose Demon?|My own, 0|Another's, 2}]] }}" name="roll_banish"></button>
+                            </div>
+                        </details>
+                    </div>
+                    <div class="skillrow">
+                        <details>
+                            <summary>The Pact of the Dark Companion</summary>
+                            <input type="hidden" class="demonologistcheckbox pact_front" name="attr_pact_of_the_dark_companion" value="0" />
+                            <div class="demonologistroll pact_button_front">
+                                <span>Roll to summon the Dark Companion</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} calls for their Dark Companion}} {{subtitle=Roll 1d100 under Target Number}} {{roll= [[1d100cs1cf100]]}} {{Vs= 20% }}" name="roll_pact"></button>
+                            </div>
+                        </details>
+                    </div>
                     </details>
                 </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Remove Curse</summary>
-                        <input type="hidden" class="priestcheckbox remove_curse_front" name="attr_remove_curse" value="0" />
-                        <div class="priestroll remove_curse_button_front">
-                            <span>Roll Remove Curse</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} attempts to remove a foul curse}} {{Roll 1d20 under Target Number}} {{roll= [[1d20cs1cf20]]}} {{Vs = [[@{rank}+@{finalmagicaldefence}]] }}" name="roll_remove_curse"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Remove Madness</summary>
-                        <input type="hidden" class="priestcheckbox remove_madness_front" name="attr_remove_madness" value="0" />
-                        <div class="priestroll remove_madness_button_front">
-                            <span>Roll Remove Madness</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} soothe a troubled mind}} {{subtitle=Roll 1d20 under Target Number}} {{roll= [[1d20cs1cf20]]}} {{Vs = [[@{rank}+?{Relic Quality|Holy, 1|Saintly, 2|Perfect, 4|Godly, 8}]] }}" name="roll_remove_madness"></button>
-                        </div>
-                    </details>
+                <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />  
+                <div class="nomelee">
+                    <img class="icon rider" src="https://i.imgur.com/TvsSUOU.png" alt="No Magic Attributes" />
                 </div>
             </div>
-            
-            <div class="melee demonologistmelee">
-                Demonologist Profession Abilities
-                <div class="skilrow">
-                    <details>
-                        <summary>Demonology</summary>
-                        <input type="hidden" class="demonologistcheckbox demonology_front" name="attr_demonology" value="0" />
-                        <input type="hidden" name="attr_demonology_modifier" value='0' />
-                        <div class="demonologistroll demonology_button_front">
-                            <span>Roll Demonology</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} seeks hidden, forbidden knowledge}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}} {{Time spent in research and meditation= [[2d10]]}}" name="roll_demonology"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>The Ritual of Summoning</summary>
-                        <input type="hidden" class="demonologistcheckbox ritual_front" name="attr_ritual_of_summoning" value="0" />
-                        <div class="demonologistroll ritual_button_front">
-                            <span>Perform The Ritual of Summoning</span> <button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} crafts a ritual to summon a Demon}} {{subtitle=Magical Attack vs Magical Defence}} {{roll= [[2d10]]}} {{Vs= [[@{finalmagicalattack}-?{The Demon's Magical Defence|0}]] }} {{Money spent on the summoning= [[2d4*10]] Silver Florins}} {{If successful, the Demon will remain for= [[1d4]] hours}} {{The caster is drained= [[1d3]] Strength 
-                            (manually input into Strength Misc Modifiers)}} {{The Demon's response to being summoned is= [[1d10]] 
-                            1 Aggressive and hostile; will attack immediately. 
-                            2-4 Antipathetic; will need a lot of convincing to do anything other than attack. 
-                            5-9 Surly; may serve, if offered a good deal. 
-                            10 Friendly.}}" name="roll_ritual"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>Banishing a Demon</summary>
-                        <input type="hidden" class="demonologistcheckbox banish_front" name="attr_banishing_a_demon" value="0" />
-                        <div class="demonologistroll banish_button_front">
-                            <span>Roll to Banish a Demon</span> <button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} tries to Banish a demon}} {{subtitle=Magical Attack vs Magical Defence}} {{roll= [[2d10]]}} {{Vs= [[@{finalmagicalattack}-?{Demon's Magical Defence|0}-?{Whose Demon?|My own, 0|Another's, 2}]] }}" name="roll_banish"></button>
-                        </div>
-                    </details>
-                </div>
-                <div class="skillrow">
-                    <details>
-                        <summary>The Pact of the Dark Companion</summary>
-                        <input type="hidden" class="demonologistcheckbox pact_front" name="attr_pact_of_the_dark_companion" value="0" />
-                        <div class="demonologistroll pact_button_front">
-                            <span>Roll to summon the Dark Companion</span> <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} calls for their Dark Companion}} {{subtitle=Roll 1d100 under Target Number}} {{roll= [[1d100cs1cf100]]}} {{Vs= 20% }}" name="roll_pact"></button>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            
-            <div class="melee nomelee">
-                <img class="icon rider" src="https://i.imgur.com/TvsSUOU.png" alt="No Magic Attributes" />
-            </div>
-
         </div>
-        
         <div class="frontpage mpattributes">
             
             <h2>Profession Magic and Guards</h2>
@@ -2116,11 +2111,11 @@
         <div class="spellbox">
             <input type="hidden" class="profession-toggle" name="attr_profession" value="0" /> 
             
-            <div class="spells noncaster">
+            <div class="noncaster">
                 <img class="headerimage" src=https://i.imgur.com/71b5OWK.png alt="Scroll" /> 
             </div>
 
-            <div class="spells mystic_spell_list">
+            <div class="mystic_spell_list">
                 <details class="spellbook">
                     <summary class="spellbook-header">Mystic Spells of Rank One</summary> 
                     <div class="spell-entry"> 
@@ -2727,8 +2722,7 @@
                 </details>
             </div>
 
-            <div class="spells sorcerer_spell_list">
-
+            <div class="sorcerer_spell_list">
                 <details class="spellbook">
                     <summary>Sorcerer Spells of Rank One</summary>
                     <div class="spell-entry">
@@ -3120,7 +3114,7 @@
                         </fieldset>
                     </div>
                 </details>
-                    
+
                 <details class="spellbook">
                     <summary>Sorcerer Spells of Level Five</summary>
                     
@@ -3790,7 +3784,7 @@
                 </details>
             </div>
 
-            <div class="spells warlock_spell_list">
+            <div class="warlock_spell_list">
                 <details>
                     <summary>Warlock Spells of Level One</summary>
                     <div class="spell-entry">
@@ -4589,7 +4583,7 @@
                 </details>
             </div>
 
-            <div class="spells elementalist_spell_list">
+            <div class="elementalist_spell_list">
                 <input type="hidden" class="element-toggle1" name="attr_primaryelement" value="" />
                 <input type="hidden" class="element-toggle2" name="attr_secondaryelement" value="" />
                 <input type="hidden" class="element-toggle3" name="attr_tertiaryelement" value="" />
@@ -5753,7 +5747,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 2</summary>
                             <div class="spell-entry">
@@ -5767,7 +5760,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 3</summary>
                             <div class="spell-entry">
@@ -5802,7 +5794,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 4</summary>
                             <div class="spell-entry">
@@ -5816,7 +5807,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 5</summary>
                             <div class="spell-entry">
@@ -5833,7 +5823,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 6</summary>
                             <div class="spell-entry">
@@ -5849,7 +5838,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 7</summary>
                             <div class="spell-entry">
@@ -5878,6 +5866,7 @@
                                     <p>Geas: Every time the Darkness Elementalist casts this spell, he must resist becoming a creature of the shadows, an insubstantial Wraith (see p. 253). Roll a magical attack of 2d8 +1 against the character’s magical defence.</p>
                                 </div>
                             </div>
+                            
                         <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
                             <div class="spell-entry playerspell">
                                 <div class="spell_name">Dark Rebirth</div>
@@ -5892,7 +5881,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 8</summary>
                             <div class="spell-entry">
@@ -5905,7 +5893,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 9</summary>
                             <div class="spell-entry">
@@ -5918,7 +5905,6 @@
                                 </div>
                             </div>
                         </details>
-
                         <details>
                             <summary>Level 10</summary>
                             <div class="spell-entry">
@@ -5930,7 +5916,7 @@
                                     <p>Geas: Summoning Balor results in death to the caster and everyone within a 20m radius.</p>
                                 </div>
                             </div>
-                        <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
+                            <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
                             <div class="spell-entry playerspell">
                                 <div class="spell_name">Karach</div>
                                 <div class="spell_range">Range: Touch</div>
@@ -5945,8 +5931,219 @@
                                 </div>
                             </div>
                         </details>
-                        <div class="spell-entry">
-                            <fieldset class="repeating_spells_darkness">
+                        <details>
+                            <summary>Custom Spells of Darkness</summary>
+                            <div class="spell-entry">
+                                <fieldset class="repeating_spells_darkness">
+                                <span>Name</span>
+                                <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                                <span>Range </span>
+                                <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                                <span>Duration</span> 
+                                <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                                <span>Description</span>
+                                <div class="sheet-auto-expand">
+                                    <span name="attr_CustomSpellDescription"></span>
+                                    <textarea name="attr_CustomSpellDescription"></textarea>
+                                </div>   
+                                </fieldset>
+                            </div>
+                        </details>
+                    </details>
+                </div>   
+            </div>
+            
+            <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
+            <div class="demonologist_spell_list playerspell">
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank One</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Demonic Vitality</div>
+                        <div class="spell_range">Range: Self</div>
+                        <div class="spell_duration">Duration: Instant</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell leeches the vigour from a small animal or bird to cure the caster. The caster sacrifices the animal with a dark incantation and regains 1d4 Health Points. The spell also removes minor blemishes and scars from the caster’s skin, and subtly changes their appearance over time to appear better-looking but slightly crueller. Demonologists who have used this spell for years tend to look beautiful, but their inner cruelty is clearly painted on their faces. Due to this, there is no increase in Looks score.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Demonic Vitality HP Roll:</span> <button type="roll" name="attr_demonicvitality" class="roll d4" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} leeches vitality from a small creature}} {{subtitle=Demonic Vitality}} {{Health Point Regain=[[1d4]]}} {{desc=The spell also removes minor blemishes and scars from the caster’s skin, and subtly changes their appearance over time to appear better-looking but slightly crueller.}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Vice</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Instant</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>All of mankind’s sins are laid bare in the deepest pits of hell. This spell summons forth an infernal servant that whispers the target’s greatest vice in the Demonologist’s ear. The infernal servant lies about the vice 5% of the time. It is a wise man who does not wholly trust his servants.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Vice Spell - chance the demon is lying</span><button type="roll" class="roll twod10" name="attr_vice_chance" value="/w gm &{template:custom2d10} {{title=This spell summons forth an infernal servant that whispers the target’s greatest vice in the @{character_name}'s' ear}} {{subtitle=Vice Spell Chance that the Demon is lying}} {{roll=[[1d100]]}} {{vs=[[5%]]}} {{desc=It is a wise man who does not wholly trust his servants.}}"></button>
+                        </div>  
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Gleam of Malevolence</div>
+                        <div class="spell_range">Range: Self</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The caster welcomes dark powers into his own body, giving him a taste of powers to come. Others can sense this fell power, and while this spell is in effect normal animals will not approach the caster or attack him. Humans instinctively flinch from the caster and take a -1 to penalty to attack him.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Festering Blow</div>
+                        <div class="spell_range">Range: Touch</div>
+                        <div class="spell_duration">Duration: One Attack</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell infuses a single attack made by the caster with hellish power. The caster attacks as normal—including making an armour bypass roll—and inflicts normal damage +2 on a successful strike (for example, a sword would inflict 6 Health Points). If the blow misses then the spell is lost. The wound thus inflicted will not heal naturally, festering and rotting until some magical means of healing is applied. Demonologists have been known to use this spell to disfigure those who cross them.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist1">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>     
+                        </fieldset>
+                    </div>
+                </details>    
+                <details class="spellbook">
+                    <summary class="spellbook-header">Sorcerer Spells of Rank One</summary>
+                    <div class="spell-entry">
+                        <div class="spell_name">Dragonbreath</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>Range: 20m This spell creates a narrow jet of flame which can be directed at a single target. If the target fails to dodgethe flame (match the spell’s speed of 12 against the target’s evasion) he takes 1d6 +6 Health Points damage. This damage roll is reduced by the target’s Armour Factor, however, so a character in plate armour would lose only 1d6 +1 HP.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Dragonbreath Spell Attack Roll:</span><button type="roll" name="attr_dragonbreath" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} directs searing flames at their foe}} {{subtitle=Dragonbreath}} {{spellattackroll=[[2d10]]}} {{speedvsevasion= [[12-?{Target's Evasion}]]}} {{damage= [[1d6+6-?{Target's Armour Factor}]]}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Image</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_duration">Duration: see below</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The caster can create a visual image of no greater than man-size; this is nearly perfect, and has only a 10% chance of being recognized to be an illusion. The Image is a kind of hologram, and cannot be made to move around. It will last until touched or Dispelled.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Lesser Healing</div>
+                        <div class="spell_range">Range: touch</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell restores 2 Health Points to a wounded character. It will not increase his Health Point score above its normal (unwounded) level, of course. Lesser Healing cannot bring a character back from the dead—such a feat is possible in the Dragon Warriors world, but more potent sorcery than this is needed!.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Moonglow</div>
+                        <div class="spell_duration">Duration: lasts for ten minutes</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>A circle of light 5m in radius surrounds the caster, who can dim the intensity to zero or brighten it to about the level of the full moon’s light, at will. Unlike torchlight, the illumination provided by this spell is sufficiently diffuse that it may not alert monsters lurking nearby. A party of characters using no other light source but Moonglow have a chance (the usual 1 in 6) of surprising any monster they meet.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Portal</div>
+                        <div class="spell_range">Range: touch</div>
+                        <div class="spell_duration">Duration: see below</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell may be used in either of two ways. Open Portal will thrust open any door which could normally be forced by a character of Strength 16. The second mode of the spell, Close Portal, shuts andlocks a door magically. This form of the spell is durational, and will stay in effect until Dispelled or broken by physical force.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Weaken</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>Match the caster’s magical attack vs target’s magical defence. The character on whom this spell takes effects will be weakened. He temporarily loses 2 attack points and inflicts 1 less point of damage than usual when striking in combat.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Weaken Spell Attack Roll:</span><button type="roll" name="attr_weaken" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to sap their opponent's strength}} {{subtitle=Weaken}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}}"></button>
+                        </div>
+                    </div>
+                    <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
+                    <div class="spell-entry playerspell">
+                        <div class="spell_name">Witchbane</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Instant</div>
+                        <div class="spell_origin">Origin: Algandy</div>
+                        <div class="spell_rarity">Rarity: Common in Algandy, uncommon elsewhere</div>
+                        <div class="spell_replaces">Replaces: Dragonbreath for Algandish Sorcerers</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>A stream of emerald flame bursts from the Sorcerer’s fingertips to engulf a single target. This spell works on all manner of supernatural entities but has no effect on a normal human – even one trained in the black arts. If a normal human is targeted the flame washes about him leaving him unharmed, though likely terrified. If the spell hits a supernatural being (Speed 12 versus the targets Evasion), the target suffers 1d6+6 damage reduced by its Armour Factor. This spell prevents a Sorcerer from being a threat to a knightly warrior while making them an excellent tool for rooting out “evil beings”.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Witchbane Spell Attack Roll:</span><button type="roll" name="attr_witchbane" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} blasts emerald flames from their fingertips}} {{subtitle=Witchbane}} {{spellattackroll=[[2d10]]}} {{speedvsevasion=[[12-?{Target's Evasion}]]}} {{damage=[[1d6+6-?{Target's Armour Factor}]]}}"></button>
+                        </div>
+                    </div>
+                    <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
+                    <div class="spell-entry playerspell">
+                        <div class="spell_name">Bedevil</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Permanent</div>
+                        <div class="spell_origin">Origin: Algandy</div>
+                        <div class="spell_rarity">Rarity: Common throughout Legend</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The Sorcerer casts this spell on a single tool, weapon, or implement. The target can be no larger than a small cart or plough. The spell causes the item to attempt to thwart any action a user tries to undertake with it. For example, a compass will give false readings, a hammer might strike a thumb, and a saddle might become undone. The spell rarely causes serious injuries but, for example, using a bedevilled rope to climb a mountain can be suicidal. The spell remains until the Sorcerer removes the spell or a Dispel Magic spell is cast on the item. Any Sorcerer who knows this spell can cast a “counter curse” on a bedevilled item.</p>
+                        </div>
+                    </div>
+                </details>    
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Two</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Torment of the Pit</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell inflicts a taste of eternal torment on the target. The target takes a 3 point penalty to all rolls as they writhe in agony. This spell is used as both a means of punishment and as a method of crippling powerful opponents in battle.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Torment of the Pit Attack Roll:</span> <button type="roll" name="attr_tormentofthepit" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} inflicts the target with a taste of eternal torment}} {{subtitle=Torment of the Pit}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-(?{Target's Magical Defence|0})]]}} {{desc=The target takes a 3 point penalty to all rolls as they writhe in agony.}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Vanity</div>
+                        <div class="spell_range">Range: Self</div>
+                        <div class="spell_duration">Duration: 2 hours</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>Folk forget that the masters of the pit were once Gods and angelic beings. This spell boosts the caster’s Looks to 16, or if it were already 16 or higher, it becomes 19—truly angelic. Once the spell duration lapses, the caster’s Looks score drops to 3 for the next 8 hours as the darker aspects of the pit take over. The demonologist can cast the spell again and again while under the penalty, but if he does so the remaining penalty time is “banked” and must be paid off after the last spell ends, with an extra 8 hours for each successive Vanity spell cast. Vain demonologists who cast this spell often frequently find themselves facing a long time of looking like a monster.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Activate Vanity Spell</span>
+                            <select name="attr_vanity_toggle">
+                                <option value="0">Inactive</option>
+                                <option value="1">Active Positive Effect</option>
+                                <option value="2">Active Negative Effect</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Eye for an Eye</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Instant</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell can be cast on any target that hurt the caster in the last 5 rounds. The spell causes the caster to suffer 1d6 Health Points damage and heals the caster of an equal amount of damage. The spell only works on living beings, and has no effect on undead, golems, or their ilk.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Eye for an Eye Attack Roll:</span> <button type="roll" name="attr_eyeforaneye" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} suffers and heals damage}} {{subtitle=Eye for an Eye}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-(?{Target's Magical Defence|0})]]}} {{damage=[[1d6]]}} {{desc=The spell heals the caster of an equal amount of damage, please manually adjust.}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Dark Divination</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_duration">Duration: Instant</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The caster makes a minor sacrifice to the dark powers and specifies a target. Demonic spies whisper the target’s darkest secret to the caster. There is a 10% chance that the demons lie to the caster out of spite. This chance increases to 50% if the caster has cast the spell already today... the forces of hell do not like to be called upon lightly. This spell can be used to gain incredible leverage over a person, but more than one Demonologist has had his throat cut for daring to blackmail the wrong nobleman.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Dark Divination Spell - chance the demon is lying</span><button type="roll" class="roll twod10" name="attr_vice_chance" value="/w gm &{template:custom2d10} {{title=Demonic spies whisper the target’s darkest secret to @{character_name}.}} {{subtitle=Dark Divination Spell Chance that the Demon is lying}} {{roll=[[1d100]]}} {{vs=?{Is this the first casting of this spell today?|Yes, [[10%]]|No, [[50%]]} }} {{desc=It is a wise person who does not wholly trust their servants.}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist2">
                             <span>Name</span>
                             <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
                             <span>Range </span>
@@ -5958,13 +6155,658 @@
                                 <span name="attr_CustomSpellDescription"></span>
                                 <textarea name="attr_CustomSpellDescription"></textarea>
                             </div>   
-                            </fieldset>
+                        </fieldset>
+                    </div>
+                </details>   
+                <details>
+                    <summary class="spellbook-header" >Sorcerer Spells of Level Two</summary>
+                    <div class="spell-entry">
+                        <div class="spell_name">Detect Aura</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell enables the caster (or another on whom he casts the spell) to see the supernatural aura which surrounds enchanted beings and objects.</p>
                         </div>
-                    </details>
-                </div>   
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Hold Off the Dead</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell creates a zone around the caster, 2m in radius, which affects Undead whose rank-equivalent does not exceed the caster’s rank. If such Undead enter the zone, they are immediately subject to a magical attack (match the caster’s magical attack against the Undead’s magical defence). If successful, the spell prevents them from approaching the caster as long as the enchantment lasts.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Hold Off the Dead Spell Effect Roll: (roll when an Undead attempts to enter the area of effect)</span><button type="roll" name="attr_hold_off_the_dead" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title= An undead foe attempts to enter @{character_name}'s zone of protection}} {{subtitle=Hold Off The Dead}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=If successful, the spell prevents them from approaching the caster as long as the enchantment lasts.}} "></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Inflict Wound</div>
+                        <div class="spell_range">Range: 3m</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>Match the caster’s magical attack against the target’s magical defence. If successful, this inflicts a wound of 5 Health Points on the victim. Armour provides no protection against this damage.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Inflict Wound Spell Attack Roll:</span><button type="roll" name="attr_inflict_wound" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title= @{character_name} assaults their target with magic}} {{subtitle=Inflict Wound}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{damage=5}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Peer</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies, and see below</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>When this spell is cast, the Sorcerer specifies any point within the spell’s range (e.g. “14m due north of me”, “5m straight down”, etc.). He is then able to see anything that is happening within 3m of the specified point as though he were standing there. The spell is not hampered by intervening walls or floors unless these are made of metal; more than 2cm thickness of metal will block a Peer spell. The spell will expire immediately if the caster moves around while it is operating.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Tangleroots</div>
+                        <div class="spell_range">Range: 15m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell affects one target, causing a tangle of magical creepers to sprout out of the ground and ensnare his legs. If the target fails to leap clear (match spell’s speed of 14 vs target’s evasion) then he is caught and immobilized. With an edged weapon it is possible to cut oneself free within 2–8 Combat Rounds (roll 2d4); beings of great strength (Strength 16 or more) will be able to pull free of the roots in only 1–3 rounds, and animals such as Wolves will take 2–12 rounds to claw and chew through the roots. This spell is commonly used either to hold any enemy while trying to escape from him or to prevent him evading a more devastating follow-up spell.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Tangleroots Spell Attack Roll</span><button type="roll" name="attr_spell_name" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} summons roots and vines to tangle their enemies}} {{subtitle=Tangleroots}} {{spellattackroll=[[2d10]]}} {{speedvsevasion=[[14-?{Target's Evasion}]]}} {{desc=Target can free themself in: ?{Method of escape|Cut free, [[2d4]] rounds|Pull free (Str 16 or higher), [[1d3]] rounds|Claw and chew, [[2d6]] rounds}}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Warding</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>Warding enhances the Sorcerer’s luck in combat. Any character attempting a Hit Roll against him, whether in mêlée or with a missile weapon, must add 2 to the d20 score.</p>
+                        </div>
+                    </div>
+                    <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
+                    <div class="spell-entry playerspell">
+                        <div class="spell_name">Echoes of Spyte</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_origin">Origin: Krarth</div>
+                        <div class="spell_rarity">Rarity: Uncommon in Krarth and rare outside of that foul land</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>When cast, the Sorcerer must pick a point anywhere within 20m of where he stands. Until the spell expires or is cancelled, the Sorcerer hears everything as if he were standing at that point. This spell was used by the Krarth Magi of old to spy upon their rivals and enemies. Following the Blasting of Spyte, the remaining apprentices carried this spell out of the ruins, teaching it to their followers and spies as needed.</p>
+                        </div>
+                    </div>
+                </details>
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Three</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Wrath</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The Demonologist casts this spell on a friendly target to infuse them with the essence of wrath. The target feels hellish fury, gaining +3 to Attack, +1 to armour bypass rolls, and +1 to damage until the spell ends. The target also suffers a -5 penalty to Defence during this time.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Glutton’s Curse</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The target of this spell suffers from a terrible hunger that lasts until the spell expires. The target eats and drinks as fast as they can; if no food is present the target tries to eat any living being, and failing that even tears into their own flesh for sustenance.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Glutton’s Curse Attack Roll:</span> <button type="roll" name="attr_gluttonscurse" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} inflicts the target with a ravenous hunger}} {{subtitle=Glutton’s Curse}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-(?{Target's Magical Defence|0})]]}} {{desc=The target eats and drinks as fast as they can; if no food is present the target tries to eat any living being, and failing that even tears into their own flesh for sustenance.}} "></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Lord of Lies</div>
+                        <div class="spell_range">Range: Self</div>
+                        <div class="spell_duration">Duration: Spell Expiry Applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The next lie the caster tells before the spell’s expiry will be believed by everyone hearing it. Once the spell expires, those affected will no-longer believe the caster and may turn on him. The Demonologist can only state “facts” and not force others reactions/attitudes; for example the caster can state “I am the world’s greatest lover” or “I am the king” not “You find me incredibly attractive”. Use of this spell can be quite addictive and dangerous.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Scent of the Fallen</div>
+                        <div class="spell_range">Range: Self</div>
+                        <div class="spell_duration">Duration: Spell Expiry Applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>Through use of this spell the demonologist can smell corruption and lies. A lie will be plain as a breath of sweet air from the liar’s mouth. Corrupt people will have a sweet smell commensurate with their level of corruption; an innocent child will stink, while a brutal killer will smell like a summer meadow. This is a fine example of a spell intended to rework how the Demonologist sees the world.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist3">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>    
+                <details>
+                    <summary class="spellbook-header">Sorcerer Spells of Level Three</summary>
+                    <div class="spell-entry">
+                        <div class="spell_name">Banquet</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>Enough food and drink is created to provide one meal for five people. The food is nourishing but—despite the spell’s appetising name—rather bland. Few would care to eat it if they had a choice; but when adventurers are starving they will fall upon Banquet fare enthusiastically enough!</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Beacon</div>
+                        <div class="spell_range">Range: 15m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>If any invisible object or being is within range when Beacon is cast, the spell causes a glowing ball of green light to appear just above it. This light will move as the invisible object/being moves, thus marking out its location.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Command</div>
+                        <div class="spell_range">Range: 5m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>A successful casting of this spell (match caster’s magical attack vs target’s magical defence) brings the victim (who must be of 1st–3rd rank) under the Sorcerer’s control. He will then do whatever the caster tells him to do. Commanded beings do not become mindless slaves; they retain their normal intelligence and ability to reason, and are thus capable of following quite complex orders. Language barriers may be a problem—if the victim cannot understand what his ‘master’ is saying to him then he will simply act in what he believes to be his master’s best interests.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Command Spell Attack Roll:</span><button type="roll" name="attr_command" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title= @{character_name} speaks in a magically Commanding voice}} {{subtitle=Command}} {{spellattackroll= [[2d10]]}} {{magicalattackvsmagicaldefence= [[@{finalmagicalattack}-?{Target's Magical Defence}]]}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Greater Healing</div>
+                        <div class="spell_range">Range: 5m</div>
+                        <div class="spell_desc">
+                            <span>Description:</span><p>A more powerful version of Lesser Healing. It restores 7 Health Points to the recipient, with the same provisos as for the level-one spell (p. 80).</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Illusion</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell creates an illusion no greater than two cubic metres in volume. This differs from an Image in two ways; the Illusion will move as the caster wishes, and it fools not just sight but the other natural senses as well. There is thus very little chance of distinguishing an Illusion from the real thing; even a rigorous examination gives only a 5% chance of this. If he wishes, the Sorcerer can cast Illusion over a character (himself included) in order to provide a near-perfect disguise. When overlapped in this way, the Illusion must be equal in at least one linear dimension to the thing it is covering. A man could thus be covered by the Illusion of a 2m-long snake, but not by the Illusion of a gnat. It is important to remember that Illusions exist only in the minds of those who behold them. An Illusion could not cast a spell, inflict a wound, carry treasure, open doors, or in any other way affect the real world.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Wolfcall</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell is usable only out-of-doors—in moorland, woods, and dense forest, the wild places where Wolves hunt. It summons one Wolf (see p. 253) to the caster’s side to fight for him. The Wolf will arrive 2–12 Combat Rounds after the spell is cast and will then remain until the spell wears off. The Sorcerer does not start making Spell Expiry Rolls until the Wolf turns up. (A note for the literal-minded: there does not actually have to be a Wolf nearby for Wolfcall to work. The Wolf may in fact be brought across miles of countryside in barely a minute, by the working of the Sorcerer’s magic.)</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Wolfcall Time to Arrival:</span><button type="roll" name="attr_wolfcall" class="roll d6" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title= @{character_name} calls for a Lupine ally}} {{subtitle=Wolfcall}} {{roll= The Wolf arrives in [[2d6]] rounds}}"></button>
+                            <details>
+                                <summary>Wolf Stats</summary>
+                                <ul>
+                                    <li>Attack: 15 <button class="roll d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} orders their Wolf to attack}} {{subtitle=Wolf Attack}} {{attackroll=[[1d20cs1cf20]]}} {{attackvsdefence=[[15-(?{Enemy Defence|0})]]}} {{abr=[[1d4]]}} {{Damage=[[5]]}} {{desc=}}" name="attr_wolfcall_attack"></button></li>    
+                                    <li>Weapon: Fangs (d4, 5 points)</li>
+                                    <li>Defence: 3</li>
+                                    <li>Armour Factor: 0</li>
+                                    <li>Evasion: 3</li>
+                                    <li>Magical Defence: 1</li>
+                                    <li>Health Points: 1d6+4</li>
+                                    <li>Movement: 12m (25m)</li> 
+                                    <li>Stealth: 16</li>
+                                    <li>Perception: 11</li>
+                                </ul>
+                            </details>
+                        </div>
+                    </div>
+                    <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
+                    <div class="spell-entry playerspell">
+                        <div class="spell_name">Summon Lesser Djinn</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll</div>
+                        <div class="spell_origin">Origin: Ta’ashim lands</div>
+                        <div class="spell_rarity">Rarity: Common in Ta’ashim lands, rare elsewhere</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The Sorcerer calls upon the power of the seven great Djinn sultans to summon one of their lesser servants; a whirling cloud of sand about half the size of a man. This lesser Djinn can do anything a normal human can, such as serving food, opening doors, carrying, and lifting. The Djinn cannot attack and, being a cloud of sand and air, is immune to non-magical damage. A few northerners have managed to learn the secrets of this spell and it can be found from time to time in the hands of well-travelled Sorcerers. Those who frequently abuse the sultan’s servants (for example by getting them to open obviously trapped doors all the time) may feel the wrath of the Djinn lords.</p>
+                        </div>
+                    </div>
+                </details>
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Four</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Witch Steed</div>
+                        <div class="spell_range">Range: Touch</div>
+                        <div class="spell_duration">Duration: One night</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell twists the mind of a pig, goat, or human so that it serves as a mount for the caster for a single night. The target cannot do anything except serve as a mount. Any attempt to attack or harm the target will dispel the spell instantly. The target is spurred on by the forces of hell itself and moves as fast as a normal horse. The spell ends at dawn the following morning, and the target takes 1d8 Health Points damage from cuts, bruises, and total exhaustion. It is not uncommon for a mere mortal to be struck dead by this effect. The spell can only be cast at night and requires a bridle (decorated with silver stolen from a church and worth 200F) be flung over the target. The target remembers the night as a vivid nightmare.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Witch Steed Attack Roll:</span> <button type="roll" name="attr_witchsteed" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} twists the mind of a creature to serve as their steed}} {{subtitle=Witch Steed}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-(?{Target's Magical Defence|0})]]}} {{damage=[[1d8]]}} {{desc=The target cannot do anything except serve as a mount. Any attempt to attack or harm the target will dispel the spell instantly. The target is spurred on by the forces of hell itself and moves as fast as a normal horse. The spell ends at dawn the following morning and the target takes damage from cuts, bruises, and total exhaustion.}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Phylactery</div>
+                        <div class="spell_range">Range: Touch</div>
+                        <div class="spell_duration">Duration: Special (see text)</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell infuses 2 of the caster’s Health Points into a bloodstone ring (costing 50F) worn on his finger. The lost Health Points reduces the caster’s maximum Health Points by 2, which are restored when the spell ends. As a standard action, the caster can call upon the power of the ring to heal 8 Health Points damage to himself, at which point the ring melts and the caster’s maximum Health Points return to normal. An enemy can attack the ring directly by taking a -8 to their Attack. This destroys the ring and ends the spell.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Activate Phylactery Spell Effect</span>
+                            <select name="attr_phylactery_toggle">
+                                <option value="0">Inactive</option>
+                                <option value="1">Active</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Hellsbreath</div>
+                        <div class="spell_range">Range: 10m</div>
+                        <div class="spell_duration">Duration: Instant</div>
+                        <div class="spell_attack">Attack: Speed Vs Target’s Evasion</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>The caster exhales a poisonous fume that affects 1d4 targets in front of themself. The spell has a Speed of 14 and causes 2d6 Health Points of damage to affected targets. This damage is not reduced by armour factor.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Hellsbreath Spell Number of Targets</span><button type="roll" class="roll d4" name="attr_hellsbreath_targets" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} exhales a poisonous fume in front of themself}} {{subtitle=Hellsbreath Number of Targets}} {{roll=[[1d4]]}}" ></button>
+                            <span>Hellsbreath Spell Attack Roll:</span> <button type="roll" name="attr_hellsbreath" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=The poisonous fume begins to eat away its target}} {{subtitle=Hellsbreath}} {{spellattackroll=[[2d10]]}} {{speedvsevasion=[[14-?{Target's Evasion}]]}} {{damage=[[2d6]]}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Indulgence</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Applies</div>
+                        <div class="spell_attack">Attack: Magical Attack Vs Target’s Magical Defence</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>This spell is cast on a single target, forcing them to indulge their greatest vice as soon as physically possible. No thought is given to propriety or stealth, the target simply indulges as soon as possible, ignoring all social conventions. Use of this spell can destroy reputations and start wars.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Indulgence Spell Attack Roll:</span>
+                            <button type="roll" name="attr_indulgence" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} casts Indulgence}} {{subtitle=Indulgence}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The target is forced to indulge their greatest vice as soon as physically possible. No thought is given to propriety or stealth, the target simply indulges as soon as possible, ignoring all social conventions.}} "></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist4">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>
+                <details class='spellbook'>
+                    <summary class="spellbook-header">Sorcerer Spells of Level Four</summary>
+                    <div class="spell-entry">
+                        <div class="spell_name">Antidote</div>
+                        <div class="spell_range">Range: 5m</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This reduces the potency of poisons or drugs in a character’s bloodstream. A poison which normally requires a 3d6 roll compared to the character’s Strength (see p. 122 in Chapter 11) is reduced to one which requires a 2d6 roll, etc. The spell must be applied within one Combat Round (six seconds) of the character being poisoned. It does not reverse any damage or other effects already caused by the poison.</p>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Curse</div>
+                        <div class="spell_range">Range: 15m</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>This spell affects up to four beings (roll 1d4), cursing them with bad luck if it is successful (match caster’s magical attack vs target’s magical defence). Cursed beings must adjust all their die rolls by 2 so as to make them less favourable—i.e., +2 to the die score when making a Hit Roll, –2 when making an Armour Bypass Roll, etc.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Curse Number of Targets:</span><button type="roll" name="attr_curse" class="roll d4" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title= @{character_name} spits curses at their foes}} {{subtitle=Roll 1d4 for number of targets affected}} {{roll=[[1d4]]}}"></button>
+                            <span>Curse Spell Attack Roll:</span><button type="roll" name="attr_curse_magical_attack" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name}'s curse attacks its target'}} {{subtitle=Curse}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Targets Magical Defence}]] }}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Disease</div>
+                        <div class="spell_range">Range: 15m</div>
+                        <div class="spell_duration">Duration: lasts until Dispelled</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>A single living being may be afflicted with a rotting disease (match caster’s magical attack vs target’s magical defence). The victim loses 2 Health Points every Combat Round until cured or dead.</p>
+                        </div>
+                        <span>Disease Spell Attack Roll:</span><button type="roll" name="attr_disease" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title= @{character_name} attempts to magically infect their foe}} {{subtitle=Disease}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{damage=2 Health Points per round until cured}}"></button>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Oracle</div>
+                        <div class="spell_duration">Duration: lasts for one minute</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The Sorcerer attunes himself to the spirit world and is able to ask up to three questions. The questions must be phrased in such a way that they can be answered by a yes or a no. The spirits have a 75% chance of knowing the answer to any question they are asked. (The GamesMaster rolls d100. On 01–75 they know the answer; on rolls of 76–00 they don’t.) If they do not know the answer to a question, or if the question is worded vaguely, the spirits will give a random answer (roll d6: 1–3 = yes, 4–6 = no), and they will then stick to that answer if asked the same question again. The spirits can speak only of events concerning the past and present. They cannot see into the future, nor answer questions which concern a character’s thoughts and motives.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Spirit Knowledge Effect Roll:</span><button type="roll" name="attr_oracle_chance" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} asks the oracles of the spirit world for answers}} {{subtitle=Oracle}} {{roll=[[1d100cs1cf100]] vs 75%}} {{desc=Spirit's false response: [[1d6]] (1–3 = yes, 4–6 = no)}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Shadowbolt</div>
+                        <div class="spell_range">Range: 20m</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>Causes an ebon bolt of energy to shoot from the caster’s hand to strike a single being. If the bolt hits (match spell’s speed of 14 vs target’s evasion), it does 2d6+10 HP damage. The damage roll is reduced by a number equal to the target’s Armour Factor, if any (see the Dragonbreath spell on p. 89).</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Shadowbolt Spell Attack Roll:</span><button type="roll" name="attr_shadowbolt" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} casts Shadowbolt}} {{spellattackroll=[[2d10]]}} {{speedvsevasion=[[14-?{Target's Evasion}]]}} {{damage=[[2d6+10-?{Target's Armour Factor}]]}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Wall of Magic</div>
+                        <div class="spell_range">Range: Touch</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies, and see below</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>The caster—or another on whom he casts the spell—is surrounded by a protective zone that will block enemy spells. The caster may expend as many points as he likes when casting the Wall of Magic (down to a minimum of 4 MP), and this is the number of Magic Points the Wall will absorb from spells cast into it. Once it has absorbed its Magic Point limit, the Wall collapses. Wall of Magic blocks only direct-attack spells, however—i.e. those that involve a magical attack vs magical defence roll. Indirect-attack spells such as Shadowbolt are unaffected. If the Wall collapses without having absorbed all the Magic Points from an incoming spell, the spell still has a chance of taking effect but the attacking Sorcerer or Mystic must adjust his attack die roll by the difference between the number of MPs left in the spell and the spell’s level.</p>
+                        </div>
+                    </div>
+                    <input type="hidden" class="playerspells_toggle" name="attr_playerspells_toggle" value="0"/>
+                    <div class="spell-entry playerspell">
+                        <div class="spell_name">Udjat</div>
+                        <div class="spell_range">Range: Self</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll</div>
+                        <div class="spell_origin">Origin: Kaikuhuru</div>
+                        <div class="spell_rarity">Rarity: Rare everywhere due to its obviously pagan effect.</div>
+                        <div class="spell_desc">
+                            <span>Description</span><p>Upon casting this spell, a golden, glowing, eye-shaped glyph appears on the Sorcerer’s forehead. The spell increases the Sorcerer’s Psychic Talent and Intelligence to 16 or raises a score of 16-17 to 18. The Sorcerer gains all the associated bonuses for having these characteristics.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Activate Udjat Spell:</span>
+                            <select name="attr_udjat">
+                                <option value="0">Inactive</option>
+                                <option value="1">Active</option>
+                            </select>
+                        </div>
+                    </div>
+                </details>                          
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Five</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Ritual of Binding</div>
+                        <div class="spell_desc">
+                            <p>Binding eliminates the necessity of bargaining with a demon but it has its drawbacks in that attempting to bind a demon without its consent will certainly enrage it.</p>
+                            <p>Match the caster’s magical attack with the target demon’s magical defence. If the character succeeds then the demon is bound in his service. Instead of vanishing after a few hours, it remains on this plane until killed or banished. A bound demon cannot directly harm the one who bound it, nor can it deliberately kill itself in order to escape from this plane. The binder can give it one command of up to thirteen words, and the demon will obey this command literally. Commands such as ‘Obey all my future commands’ or ‘Serve me loyally’ are not effective, and immediately free the demon if tried. That is, the command must specify particular services and actions rather than establishing conditions or attitudes for future behaviour.</p>
+                            <p>A character cannot have more than seven demons bound on this plane at one time; if he tries to bind an eighth, all are freed. Some demons have a special resistance to binding, which increases their magical defence solely against this spell.</p>
+                            <p>Binding can in some cases be to the demon’s advantage. It may want permanent residence on this plane. Demon lords invariably desire to return to their realms as soon as possible, but some of the lesser demons lead a difficult existence in their own world and would prefer being bound to this plane. The problem is one of trust—there is nothing to prevent a summoner from agreeing to bind a demon ‘as a favour’ and then giving it any order he likes. There is thus only about a 1% chance of a demon asking to be bound—if you then actually keep your word and bind it without giving it a command, you will have that demon’s eternal gratitude.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Ritual of Binding Spell Attack</span><button type="roll" class="roll twod10" name="attr_ritual_of_binding" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attempts to bind a demon to their service}} {{subtitle=Ritual of Binding Spell Attack}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=A bound demon cannot directly harm the one who bound it, nor can it deliberately kill itself in order to escape from this plane. The binder can give it one command of up to thirteen words, and the demon will obey this command literally. Commands such as ‘Obey all my future commands’ or ‘Serve me loyally’ are not effective, and immediately free the demon if tried.}} " ></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist4">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Six</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Eldyr</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>The possession spells are a group of enchantments for possessing people (usually the caster’s companions) with the spirit-essence of a demon lord. The demon is not summoned by the spell. Unlike most normal spells, Possession by Eldyr takes five Combat Rounds to cast. To cast the Possession by Eldyr spell one must also have the talisman appropriate to the demon lord invoked—this may be a mask, wand, bell, gong, censer or one of several other items. The caster must prepare talismans for any demon lords he wishes to invoke, at a construction cost of 3d6F each. Alternatively, he can buy or otherwise obtain talismans prepared by another demonologist. The character must make a Demonology roll to see whether he has properly prepared a particular demonic talisman—a Possession by Eldyr spell will always fail (still with an expenditure of Magic Points) if the talisman used is defective.</p>
+                            <p>Up to three people are affected by a single casting of Possession by Eldyr. To be affected they must be conscious but passive—the spell cannot be applied to a character in combat. Possession can be directed at subdued or magically charmed enemies of the caster, but he must match his magical attack against their magical defence for the spell to take effect. Also, Possession by Eldyr does not give the caster control over the spell’s recipients—the possessed characters retain their own normal aims and motives. However, they cannot under any circumstances harm the caster so long as he carries the proper talisman. Note that two different Possession by... spells cannot be combined. Possessed characters are also unaffected by the following spells: Enslave, Enthrall, and Pacify.</p>
+                            <p>The possessed characters have magically charming voices and demeanours. Any characters of 3rd Rank or below who listen to them speak for one Combat Round or more will be affected by the possessed characters as though they had cast a Command spell (see Dragon Warriors, p. 82). Looks scores are raised to 19.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Eldyr Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Eldyr Spell Attack Roll:</span><button type="roll" name="attr_possession_eldyr" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Eldyr}} {{subtitle=Possession by Eldyr}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters have magically charming voices and demeanours. Any characters of 3rd Rank or below who listen to them speak for one Combat Round or more will be affected by the possessed characters as though they had cast a Command spell (see Dragon Warriors, p. 82). Looks scores are raised to 19.}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Kesh</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters have an aura of terror about them. If anyone attempts to come within 5m of one of them, he pits his Magical Attack against the Magical Defence of the approacher. If he succeeds, the possessed character is so terrifying that the victim may not approach any closer, and may not attack the possessed character by any means.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Kesh Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Kesh Spell Attack Roll:</span><button type="roll" name="attr_possession_kesh" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Kesh}} {{subtitle=Possession by Kesh}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters have an aura of terror about them. If anyone attempts to come within 5m of one of them, he pits his Magical Attack against the Magical Defence of the approacher. If he succeeds, the possessed character is so terrifying that the victim may not approach any closer, and may not attack the possessed character by any means.}}"></button>
+                                </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist4">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Seven</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Tsienra</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters gain +2 to Attack and +1 to Defence, and have their Reflexes scores raised to 19.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Tsienra Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Tsienra Spell Attack Roll:</span><button type="roll" name="attr_possession_Tsienra" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Tsienra}} {{subtitle=Possession by Tsienra}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters gain +2 to Attack and +1 to Defence, and have their Reflexes scores raised to 19.}}"></button>
+                                </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Kojuro</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters gain +2 to Attack and +2 to Defence, and gain a +1 bonus to Damage and to all armour bypass rolls in mêlée combat.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Kojuro Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Kojuro Spell Attack Roll:</span><button type="roll" name="attr_possession_Kojuro" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Kojuro}} {{subtitle=Possession by Kojuro}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters gain +2 to Attack and +2 to Defence, and gain a +1 bonus to Damage and to all armour bypass rolls in mêlée combat.}}"></button>
+                                </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist4">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Eight</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Akresh</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters gain +2 to Defence, a +1 bonus to any armour worn (or natural armour 2 if no armour is worn) and an increase of +2d6 Health Points. Damage is removed from the bonus Health Points first.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Akresh Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Akresh Spell Attack Roll:</span><button type="roll" name="attr_possession_Akresh" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Akresh}} {{subtitle=Possession by Akresh}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters gain +2 to Defence, a +1 bonus to any armour worn (or natural armour 2 if no armour is worn) and an increase of +2d6 Health Points. Damage is removed from the bonus Health Points first.}}"></button>
+           
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Hragahl</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters gain +2 to Magical Attack and +2 to Magical Defence, and have their Psychic Talent scores raised to 19.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Hragahl Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Hragahl Spell Attack Roll:</span><button type="roll" name="attr_possession_Hragahl" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Hragahl}} {{subtitle=Possession by Hragahl}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters gain +2 to Magical Attack and +2 to Magical Defence, and have their Psychic Talent scores raised to 19.}}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist8">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Nine</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Engala</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters have their Strength scores raised to 19, and gain an increase of +3d6 Health Points. Damage is removed from the bonus Health Points first.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Engala Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Engala Spell Attack Roll:</span><button type="roll" name="attr_possession_Engala" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Engala}} {{subtitle=Possession by Engala}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=he possessed characters have their Strength scores raised to 19, and gain an increase of +3d6 Health Points. Damage is removed from the bonus Health Points first.}}"></button>
+                                </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Sarasathsa</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters gain +6 to Magical Defence, are immune to Fright Attacks, and have their Intelligence scores raised to 19. Sarasatha’s possession is double-edged, in that the recipient could become sunk into lethargy and pensive introspection (roll Psychic Talent or less on 2d10 when coming out of possession to avoid this). A lethargic character will be unwilling to take any action that involves effort. He may attempt another Psychic Talent roll after every hour of lethargy to throw off the effects.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Sarasathsa Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Sarasathsa Spell Attack Roll:</span><button type="roll" name="attr_possession_Sarasathsa" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Sarasathsa}} {{subtitle=Possession by Sarasathsa}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters gain +6 to Magical Defence, are immune to Fright Attacks, and have their Intelligence scores raised to 19. Sarasatha’s possession is double-edged, in that the recipient could become sunk into lethargy and pensive introspection (roll Psychic Talent or less on 2d10 when coming out of possession to avoid this). A lethargic character will be unwilling to take any action that involves effort. He may attempt another Psychic Talent roll after every hour of lethargy to throw off the effects.}}"></button>
+                                </div>
+                    </div>    
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist9">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>
+                <details class="spellbook">
+                    <summary class="spellbook-header">Demonologist Spells of Rank Ten</summary> 
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Kyrax</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: The possessed characters gain +4 to Stealth and Perception.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Kyrax Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Kyrax Spell Attack Roll:</span><button type="roll" name="attr_possession_Kyrax" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Kyrax}} {{subtitle=Possession by Kyrax}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=The possessed characters gain +4 to Stealth and Perception.}}"></button>
+                                </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">Possession by Umalu</div>
+                        <div class="spell_range">Range: 1m</div>
+                        <div class="spell_duration">Duration: Spell Expiry Roll applies</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>As per Possession by Eldyr, except the following applies instead of the final paragraph: Roll 1d20 for each possessed character:</p>
+                            <ul>
+                                <li>1. Grows 2 extra arms; may wield either two two-handed weapons, or two shields and two one-handed weapons, attacking or defending with all (this will allow a character to make 2 attacks, and potentially attempt 2 shield parries, per combat round).</li>
+                                <li>2. Thick, armoured plates all over. The character gains an Armour Factor of 6 (not cumulative with other armour). Furthermore, any attack that does penetrate his armour does 1 point less damage than usual.</li>
+                                <li>3. Catlike quickness. The character’s Reflexes increases to 19, his movement is increased by half as much again, his Evasion increases by +2, and his Attack and Defence increase by +2.</li>
+                                <li>4. Venomed claws, horns, or other natural weapons. The character may make an unarmed attack that is d10, 5, and inflicts a strong poison attack on the target.</li>
+                                <li>5. Huge pincers, or club-like arm, or similar. The character may make a d12, 7 unarmed attack.</li>
+                                <li>6. Terrifying appearance. The character gains a Gaze Attack (see Dragon Warriors, p. 123). He matches his Magical Attack against the targets’ Magical Defence. If he succeeds, they are paralysed with terror for 1d6 Combat Rounds, unable to move or perform any actions.</li>
+                                <li>7. Wings. The character’s movement doubles, and he may fly, with all that that entails.</li>
+                                <li>8. Chameleonic skin. The character’s stealth increases by +6, and defence by +4.</li>
+                                <li>9. Flaming flesh. Anyone who is in mêlée combat with the character suffers an automatic hit each combat round, with d6 armour penetration and doing 4 damage.</li>
+                                <li>10. Flaming breath. The character may breathe flame each round, with a range of 20m, doing 5d6 damage to anyone who cannot evade its speed of 15 (armour worn reduces the damage by 2, regardless of type).</li>
+                                <li>11. Acid blood. Anyone who successfully wounds the character in mêlée combat must dodge a speed 16 attack, or suffer 6d6 damage (armour does not offer any protection, and indeed has a 25% chance of being melted and rendered useless).</li>
+                                <li>12. Death touch. The character’s right hand becomes cold and lifeless, imbued with necromantic energy. If he manages to touch an opponent in combat (normal attack versus defence roll applies), the victim suffers 1d6 damage (armour does not protect) and must roll equal to or less than his Strength on 2d10 or die on the spot.</li>
+                                <li>13. Living shadow. The character becomes immune to damage from non-magical weapons, which simply pass through him without harm. His own attacks ignore non-magical armour.</li>
+                                <li>14. Giantism. The character’s Strength increases to 19, and he gains an increase of +5d6 Health Points. Damage is removed from the bonus Health Points first.</li>
+                                <li>15. Webbed feet, withered legs, or tentacles instead of legs; movement is halved, and the character has a –2 penalty to stealth.</li>
+                                <li>16. One arm (determined randomly) withers away, or is replaced by a non-functional claw or other appendage. The character may not use a shield or 2-handed weapon.</li>
+                                <li>17. The character’s sight is interfered with, perhaps with the eyes being replaced with insectoid eyes, or perhaps with a flap of skin hanging over them. –2 penalty to Perception, Defence, and Attack.</li>
+                                <li>18. The character’s whole face is hideously warped and disfigured. Looks score is reduced to 1.</li>
+                                <li>19. The character’s bones become brittle and thin; all damage he suffers in combat is increased by +1.</li>
+                                <li>20. The character’s brain becomes soft and mushy, or is exposed to the air by part of the skull drawing back to reveal it. His Intelligence and Psychic Talent scores are each reduced by –6 (to a minimum of 1).</li>
+                            </ul>
+                        </div>
+                        <div class="spell_button">
+                            <span>Possession by Umalu Demonology Roll</span><button class="button twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} attmepts to prepare a demonic talisman}} {{subtitle=Roll 2d10 under Demonology Skill}} {{roll=[[2d10]]}} {{Vs = [[@{rank}+@{demonology_modifier}]]}}" name="roll_demonology_possession"></button>
+
+                            <span>Possession by Umalu Spell Attack Roll:</span> 
+                            <button type="roll" name="attr_possession_Umalu" class="roll twod10" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} invokes the spirit-essence of Umalu}} {{subtitle=Possession by Umalu}} {{spellattackroll=[[2d10]]}} {{magicalattackvsmagicaldefence=[[@{finalmagicalattack}-?{Target's Magical Defence}]]}} {{desc=Roll 1d20 for each possessed character: [[1d20]] }}"></button>
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <div class="spell_name">The Curse of Asterion</div>
+                        <div class="spell_range">Range: Touch</div>
+                        <div class="spell_duration">Duration: Permanent</div>
+                        <div class="spell_desc">
+                            <span>Description</span>
+                            <p>Also called the Curse of Binding Energy, this is a technique for dispelling a particular demon for all time. It is usable only once in a character’s lifetime (for reasons which will become obvious), and in fact only two cases of its use are recorded—once when the noble Asterion employed it to save his daughter’s life, the other when the lunatic mage Athat turned it against a demon lord in a moment of arrogant pique.</p>
+                            <p>A fairly short phrase, the Curse is only effective if the character follows through the complex logical arguments associated with it as he speaks the words of the Curse; this is represented by the demonologist rolling under his Intelligence score on three six-sided dice.</p>
+                            <p>The procedure is as follows: the character must touch and grapple with the demon (represented by a successful attack against its defence) as he (or she) activates the Curse of Asterion. If successful, both the demon and the character disappear forever from this world. Are they both disintegrated by the power of the magic? Or transported to a dimension of their own where they battle on together throughout Eternity? The truth is unknowable.</p>
+                        </div>
+                        <div class="spell_button">
+                            <span>The Curse of Asterion Intelligence Roll:</span><button type="roll" name="attr_curse_of_asterion" class="roll d6" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} invokes the Curse of Asterion}} {{subtitle=The Curse of Asterion}} {{roll=[[3d6]]}} {{vs=[[@{finalintelligence}]]}}"></button><br>
+                            <span>The Curse of Asterion Grapple Attack Roll:</span><button class="roll d20" type="roll" name="attr_meleeattack_asterion" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:customd20} {{title=@{character_name} grabs at the demon, trying to graple it}} {{subtitle=The Curse of Asterion Grapple Attack}} {{attackroll=[[1d20cs1cf20]]}} {{attackvsdefence=[[(@{finalmeleeattack}-@{magicmeleeweaponbonus})-(?{Enemy Defence|0})]]}} {{desc=If successful, both the demon and the character disappear forever from this world.}}" ></button>                
+                        </div>
+                    </div>
+                    <div class="spell-entry">
+                        <fieldset class="repeating_spells_demonologist4">
+                            <span>Name</span>
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellName" value="" /><br>
+                            <span>Range </span>
+                            <input class="eightmidtextinput" type="text" name="attr_CustomSpellRange" value="" /><br>
+                            <span>Duration</span> 
+                            <input class="sixteenlongtextinput" type="text" name="attr_CustomSpellDuration" value="" /><br>
+                            <span>Description</span>
+                            <div class="sheet-auto-expand">
+                                <span name="attr_CustomSpellDescription"></span>
+                                <textarea name="attr_CustomSpellDescription"></textarea>
+                            </div>    
+                        </fieldset>
+                    </div>
+                </details>
             </div>
         </div>
-
     </div>
     
     <div class="inventory">
@@ -5998,9 +6840,12 @@
                 <fieldset class="repeating_rangedweapons">
                     <input type="hidden" name="attr_hide" value="0" class="equip-toggle">
                     <div class="hidden-row">
-                        <span>Weapon name</span> <input type="text" name="attr_rangedweapon_name" class="eightmidtextinput" />
-                        <span>Weapon type</span> <input class="eightmidtextinput" type="text" name="attr_rangedweapon" list="rangedweapon" />
-                        <span>Magic Bonus</span> <input class="fourshorttextinput" type="number" name="attr_magicrangedweaponbonus" min="0" max="3" value="0" />
+                        <span>Weapon name</span> <input type="text" name="attr_rangedweapon_name" class="eightmidtextinput" /><br>
+                        <span>Weapon type</span> <input class="eightmidtextinput" type="text" name="attr_rangedweapon" list="rangedweapon" /><br>
+                        <input type="hidden" name="attr_ranged_magic_toggle" class="rangedmagicallowed" value="0"/>
+                        <div class="rangedmagicallowed">
+                            <span>Magic Bonus</span> <input class="fourshorttextinput" type="number" name="attr_magicrangedweaponbonus" min="0" max="3" value="0" />
+                        </div>
                         <span>Armour Bypass Roll</span> <input class="fourshorttextinput" type="text" name="attr_rangedabr" value="0" />
                         <span>Damage</span> <input class="fourshorttextinput" type="text" name="attr_rangeddamage" value="0" size="4" />
                         <br>
@@ -6018,8 +6863,8 @@
                 <fieldset class="repeating_ammo">
                     <input type="hidden" name="attr_hide" value="0" class="equip-toggle">
                     <div class="hidden-row">
-                        <span>Ammunition Name</span> <input type="text" name="attr_ammotype_name" class="eightmidtextinput" />
-                        <span>Ammunition Type</span> <input class="sixteenlongtextinput" type="text" name="attr_ammotype" list="ammotype" />
+                        <span>Ammunition Name</span> <input type="text" name="attr_ammotype_name" class="eightmidtextinput" /><br>
+                        <span>Ammunition Type</span> <input class="sixteenlongtextinput" type="text" name="attr_ammotype" list="ammotype" /><br>
                         <span>Quantity</span> <input class="fourshorttextinput" type="number" name="attr_ammoqty" value="0" />
                         <span>Magic Bonus</span> <input class="fourshorttextinput" type="number" name="attr_magicammobonus" min="0" max="3" value="0" />
                         <br>
@@ -6054,29 +6899,29 @@
             
             <div class="armourproficiencypenalties">
                 <h3>Non-Proficiency Penalties</h3>
-                <span>Attack</span> <input type="number" name="attr_armourattackpenalty" min="0" value="0"  /><br>
-                <span>Defence</span> <input type="number" name="attr_armourdefencepenalty" min="0" value="0"  /><br>
-                <span>Stealth</span> <input type="number" name="attr_armourstealthpenalty" min="0" value="0"  />
+                <span>Attack</span> <input type="number" name="attr_armourattackpenalty" max="0" step="1" value="0"  /><br>
+                <span>Defence</span> <input type="number" name="attr_armourdefencepenalty" max="0" step="1" value="0"  /><br>
+                <span>Stealth</span> <input type="number" name="attr_armourstealthpenalty" max="0" step="1" value="0"  />
             </div>
             
             <div class="skullimage"> 
                 <img class="icon skull" src="https://i.imgur.com/CrBuh7g.png" alt="Helmed Skull" /> 
             </div>
-                
+            
             <div class="shieldtogglebox">
-                <span>Shield Equipped?</span> <input type="checkbox" class="shield-toggle" name="attr_shield" /><br>
-                <span>Magic Bonus</span> <input class="fourshorttextinput" type='number' name='attr_magicshield' value='0' />    
-                
-                <div class="shieldhidden">
-                    <div class="shielddie">
-                        Roll <input title="Modified by Guard/Abilities" type="number" class="fourshorttextinput" name="attr_shieldsuccessvalue" value="1"  /> on <input class="fourshorttextinput" type="text" name="attr_shielddievalue" value="1d6"  />
-                    </div>
-                    <div class="shieldbutton">
-                        <button class="d6" type="roll" value="&{template:custom} {{title=@{character_name} attempts to block with a Shield}} {{subtitle=Roll equal to, or under, Target Number}} {{roll= [[@{shielddievalue}]]}} {{Vs= [[@{shieldsuccessvalue}]] }}" name="roll_shieldcheck"></button>
-                    </div>
-                </div>    
+                <span>Shield</span> 
+                <select name="attr_shield">
+                    <option value="0">Not Equipped</option>
+                    <option value="1">Equipped</option>
+                </select>
             </div>
             
+            <input type="hidden" class="shield" name="attr_shield" value="0" />
+            <div class="shieldhidden">
+                Roll <input title="Modified by Guard/Abilities" type="number" class="fourshorttextinput" name="attr_shieldsuccessvalue" value="1"  /> on <input class="fourshorttextinput" type="text" name="attr_shielddievalue" value="1d6"  />
+                <button class="d6" type="roll" value="&{template:custom} {{title=@{character_name} attempts to block with a Shield}} {{subtitle=Roll equal to, or under, Target Number}} {{roll= [[@{shielddievalue}]]}} {{Vs= [[@{shieldsuccessvalue}]] }}" name="roll_shieldcheck"></button>
+                <span>Magic Bonus</span> <input class="fourshorttextinput" type='number' name='attr_magicshield' value='0' />    
+            </div>    
         </div>
                 
         <div class="money">
@@ -6137,7 +6982,8 @@
         <div class="professionskillscontainer">
             <input type="hidden" class="profession-toggle" name="attr_profession" value="0" />
             <div class="assassinskills">
-                <h2>Assassin Profession Skills</h2>
+                <details>
+                <summary><h2>Assassin Profession Skills</h2></summary>
                 <div class="counter-container">
                     <!-- Combat Technique Counter -->
                     <div class="counterbox">
@@ -6599,9 +7445,11 @@
                         </div>
                     </div>
                 </details>
+            </details>
             </div>
             <div class="knightskills">
-                <h2>Knight Profession Skills</h2>
+                <details>
+                <summary><h2>Knight Profession Skills</h2></summary>
                 <div class="counter-container">
                     <!-- Combat Technique Counter -->
                     <div class="counterbox">
@@ -6972,10 +7820,12 @@
                                 </details>
                             </div>
                     </details>
-                </div>    
+                </div>
+                </details>
             </div>    
             <div class="barbarianskills">
-                <h2>Barbarian Profession Skills</h2>
+                <details>
+                <summary><h2>Barbarian Profession Skills</h2></summary>
                     <div class="counter-container">
                         <!-- Combat Technique Counter -->
                         <input type="hidden" class="supremacy_able" name="attr_supremacy_able" value="0" />
@@ -7138,9 +7988,11 @@
                         </div>
                     </details>
                 </div>
+                </details>
             </div>
             <div class="sorcererskills">
-                <h2>Sorcerer Profession Skills</h2>
+                <details>
+                <summary><h2>Sorcerer Profession Skills</h2></summary>
                 <details>
                     <summary>Special Abilities of a Sorcerer</summary>
                     <div class="skillrow">
@@ -7235,9 +8087,11 @@
                         </details>
                     </div>
                 </details>
+            </details>
             </div>
             <div class="mysticskills">
-                <h2>Mystic Profession Skills</h2>
+                <details>
+                <summary><h2>Mystic Profession Skills</h2></summary>
                 <details> 
                     <summary>The Special Abilities of a Mystic</summary>
                     <div class="skillrow">
@@ -7255,7 +8109,7 @@
                             </select>
                             <input type="hidden" class="mysticcheckbox premonition" name="attr_premonition" value="0"/>
                             <div class="mysticroll premonition">
-                                <button class="button d20" type="roll" value="/w gm &{template:custom} {{title=@{character_name} uses Premonition}} {{subtitle=Roll 1d100 under Premonition Chance}} {{roll=[[1d100cs1cf100]]}} {{Vs=[[ @ {premonitionchance} ]]}}" name="roll_premonitioncheck"></button>
+                                <button class="button twod10" type="roll" value="/w gm &{template:custom} {{title=@{character_name} uses Premonition}} {{subtitle=Roll 1d100 under Premonition Chance}} {{roll=[[1d100cs1cf100]]}} {{Vs=[[@{premonitionchance}]]}}" name="roll_premonitioncheck"></button>
                             </div>
                             <div class="sheet-auto-expand">
                                 <span name="attr_premonition_text"></span>
@@ -7351,234 +8205,249 @@
                         </details>
                     </div>
                 </details>
+                </details>
                 <!-- End of Mysticskills Section -->
             </div>
             <div class="elementalistskills">
-                <h2>Elementalist Profession Skills</h2>
-                <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
-                <div class="elementalist_core_powers">
-                    <div class="skillrow">
-                        <details>
-                            <summary>Raw Power</summary>
-                            <select class="elementalistcheckbox raw_power" name="attr_raw_power">
-                                <option value="0">Unknown</option>
-                                <option value="1">Known</option>
-                            </select>
-                            <input type="hidden" class="elementalistcheckbox raw_power" name="attr_raw_power" value="0"/>
-                            <div class="elementalistroll raw_power">
-                                <button class="button d20" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom} {{title=@{character_name} uses Raw Power}} {{spellattackroll= [[10 + ?{Magic Points expended}]]}} {{speedvsevasion=?{Target Evasion}}} {{Range=[[10 * ?{Magic Points expended}]] metres}} {{Damage=[[2d6 * ?{Magic Points expended}]]}}" name="roll_raw_power"></button>
-                            </div>
-                            <div class="sheet-auto-expand">
-                                <span name="attr_raw_power_text"></span>
-                                <textarea name="attr_raw_power_text" readonly>Even when incapable of casting a spell, or less effective at casting a spell, for some reason (for example, due to wearing armour, being paralyzed, or otherwise being unable to make the requisite arcane hand gestures), an Elementalist can cause raw elemental power to surge out from his body and into a foe, so long as he has Magic Points remaining in at least one Element. This is an Indirect Attack with a Speed of 10 + Magic Points expended, a Range of 10 metres per Magic Point expended, and damage of 2d6 per Magic Point expended. For example, a Water Elementalist using 3 Magic Points to make this attack would cause a surge of freezing water to blast a foe up to 30 metres away at a speed of 13, dealing 6d6 damage.
-                                An Elementalist can potentially use this raw elemental power for other, more mundane purposes, as in the examples in the table above. Note that these mundane uses are not usually intended as attacks, though there is nothing to prevent them from being used during combat if that might be helpful.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Raw Power (alternate version)</summary>
-                            <select class="elementalistcheckbox raw_poweralternate" name="attr_raw_poweralternate">
-                                <option value="0">Unknown</option>
-                                <option value="1">Known</option>
-                            </select>
-                            <input type="hidden" class="elementalistcheckbox raw_poweralternate" name="attr_raw_poweralternate" value="0"/>
-                            <div class="elementalistroll raw_poweralternate">
-                                <button class="button1 twod10" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Raw Power to attack}} {{spellattackroll= [[2d10cs1cf20]]}} {{VS = [[@{finalmagicalattack} - ?{Target's Magical Defence}]]}} {{damage=Dealing 2 Damage per Magic Point Spent: [[?{Magic Points spent} * 2]]}}" name="roll_raw_poweralternate"></button>
-                            </div>
-                            <div class="sheet-auto-expand">
-                                <span name="attr_raw_poweralternate_text"></span>
-                                <textarea name="attr_raw_poweralternate_text" readonly>The Elementalist’s body seethes with untapped elemental power. Using this ability, the Elementalist chooses a target and infuses it with the aforementioned elemental energy to cause damage. Raw power can still be used for mundane effects (see Dragon Warriors, p. 37).
-                                Raw power is a direct attack with a range of 10m and pits the Elementalist’s Magical Attack against the target’s Magical Defence. If the attack is successful the target takes 2 Health Points of damage for each Magic Point spent in the attack.
-                                The Elementalist can spend up to 1MP per rank on the Raw Power effect. The MP for a given elemental strike must come from the appropriate magic point pool; if the Elementalist doesn’t have MPs of that type available he cannot use or boost that attack.
-                                Each Raw Power attack has a special effect as follows:
-                                Fire: Sets the target on fire, inflicting 1HP damage per round, until the target spends a round putting the fire out.
-                                Earth: Shards of stone erupt from the target’s skin before vanishing. The shards shred armour and reduce the target’s Armour Factor by 1 until basic repairs are made. Repairs take 5-10 minutes of work.
-                                Air: This agonising attack forces air into the target’s body tissues, causing terrible pain and exploding organs. The target has his movement reduced by half for 1d6 rounds due to the pain. This special effect doesn’t work on automatons or the undead, though they take damage normally.
-                                Water: This attack freezes the target from the inside causing massive damage. The target has his Evasion reduced by 1 for 1d6 rounds.
-                                Darkness: Hampers the target’s vision, inflicting a -1 to Attack and Defence for 1d6 rounds.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Elemental Essence</summary>
-                            <select class="elementalistcheckbox elemental_essence" name="attr_elemental_essence">
-                                <option value="0">Unknown</option>
-                                <option value="1">Known</option>
-                            </select>
-                            <input type="hidden" class="elementalistcheckbox elemental_essence" name="attr_elemental_essence" value="0"/>
-                            <div class="sheet-auto-expand">
-                                <span name="attr_elemental_essence_text"></span>
-                                <textarea name="attr_elemental_essence_text" readonly>An 8th Rank Elementalist can create an Elemental Essence (see Dragon Warriors, p. 140) of her own main Element (only). This takes seven days of full-time work, per Essence, and costs just 100C. The Elementalist, unlike a Sorcerer using Alchemy (see Dragon Warriors, p. 30), does not need a laboratory or any other special equipment. However, she must brew the Essence in a place suited to the element: atop a volcano or by a massive forest fire for Fire, deep beneath a mighty mountain for Earth, out at sea or even underwater for Water, or on a mountaintop at least two miles high for Air.
-                                A Darkness Elemental Essence resembles an uncut black diamond, at least in smoothness and hardness, but reflects no light whatsoever. If it is immersed in the fresh blood of any creature, in a dark place, it immediately becomes a Darkness Elemental (see below). A Darkness Elementalist of 8th Rank can create a Darkness Elemental Essence as above. It must be brewed in a dark place both literally and figuratively; a place that has recently seen great death, such as a battlefield or mass plague grave.
-                                Elementalists of any Rank are treated as one Rank higher when attempting to command an elemental summoned by Elemental Essence, so long as it is of their main element, but they always fail an attempt to command an Elemental that is not from their main or subsidiary elements. An Elementalist automatically succeeds at commanding an elemental summoned from an Elemental Essence she has created herself; there is no need to roll.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Elemental Resistance</summary>
-                            <select class="elementalistcheckbox elemental_resistance" name="attr_elemental_resistance">
-                                <option value="0">Unknown</option>
-                                <option value="1">Known</option>
-                            </select>
-                            <div class="sheet-auto-expand">
-                                <span name="attr_elemental_resistance_text"></span>
-                                <textarea name="attr_elemental_resistance_text" readonly>An Elementalist is resistant to being attacked by her own element, as wielded by another Elementalist or (at the GM’s discretion) in the form of another spellcaster’s spell, magical item attack, or even mundane attack (for example a hurricane, blizzard, burning building, or rocky avalanche). She gains a +4 to magical defence and evasion if attacked by her primary element, or a +2 if attacked by one of her secondary elements. She is so familiar with the elements in question that she can easily evade or resist their attacks.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                </div>
-            </div>    
-            <div class="warlockskills">
-                <h2>Warlock Profession Skills</h2>
-                <div class="counter-container">
-                    <!-- Combat Technique Counter -->
-                    <div class="counterbox">
-                        <span>Special Abilities of a Warlock:</span>
-                        <div class="counterfields">
-                            <span>Max:</span>
-                            <input type="number" class="fourshorttextinput" name="attr_warlockskills_max" />
-                            
-                            <span>Selected:</span>
-                            <input type="number" class="fourshorttextinput" name="attr_warlockskills_selected" readonly />
+                <details>
+                    <summary><h2>Elementalist Profession Skills</h2></summary>
+                    
+                        <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
+                        <div class="skillrow elementalist_core_powers">
+                            <details>
+                                <summary>Raw Power</summary>
+                                <select class="elementalistcheckbox raw_power" name="attr_raw_power">
+                                    <option value="0">Unknown</option>
+                                    <option value="1">Known</option>
+                                </select>
+                                <div class="elementalistroll raw_power">
+                                    <div class="elementalist_core_powers">
+                                        <span>Attack with Raw Power:</span> <button class="button d20 skillroll" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Raw Power}} {{spellattackroll= [[10 + ?{Magic Points expended}]]}} {{speedvsevasion= ?{Target Evasion}}} {{range= [[10 * ?{Magic Points expended}]] metres}} {{damage= [[2d6 * ?{Magic Points expended}]]}}" name="roll_raw_power"></button>
+                                    </div>
+                                </div>
+                                <div class="sheet-auto-expand">
+                                    <span name="attr_raw_power_text"></span>
+                                    <textarea name="attr_raw_power_text" readonly>Even when incapable of casting a spell, or less effective at casting a spell, for some reason (for example, due to wearing armour, being paralyzed, or otherwise being unable to make the requisite arcane hand gestures), an Elementalist can cause raw elemental power to surge out from his body and into a foe, so long as he has Magic Points remaining in at least one Element. This is an Indirect Attack with a Speed of 10 + Magic Points expended, a Range of 10 metres per Magic Point expended, and damage of 2d6 per Magic Point expended. For example, a Water Elementalist using 3 Magic Points to make this attack would cause a surge of freezing water to blast a foe up to 30 metres away at a speed of 13, dealing 6d6 damage.
+                                    An Elementalist can potentially use this raw elemental power for other, more mundane purposes, as in the examples in the table above. Note that these mundane uses are not usually intended as attacks, though there is nothing to prevent them from being used during combat if that might be helpful.</textarea>
+                                </div>
+                            </details>
                         </div>
-                    </div>
-                </div>
-
-                <!-- Weapon Groups Selection -->
-                <div class="weapon-group-selection">
-                    <details>
-                        <summary class="bigbolddetails">Select Weapon Groups</summary>
-                        <div class="weapon-group-container">
-                            <span>Weapon Group 1:</span>
-                            <select name="attr_weapon_group_1" class="warlock-weapongroup">
-                                <option value="1">Weapon Group I: Flail, Mace, Morningstar, Holy Water Sprinkler, Scourge, Warhammer</option>
-                                <option value="2">Weapon Group II: Dagger, Shortsword, Sword</option>
-                                <option value="3">Weapon Group III: Halberd, Staff, Spear, Footman's Flail, Pollaxe, War Lance</option>
-                                <option value="4">Weapon Group IV: Two-handed Sword, Longsword</option>
-                                <option value="5">Weapon Group V: Battleaxe, War Axe</option>
-                                <option value="6">Weapon Group VI: Bow, Longbow</option>
-                                <option value="7">Weapon Group VII: Crossbow, Javelin, Sling, Dagger, Rock, Throwing Spike, Arbalest</option>
-                                <option value="8">Weapon Group VIII: Cudgel, Unarmed combat</option>
-                            </select>
-            
-                            <span>Weapon Group 2:</span>
-                            <select name="attr_weapon_group_2" class="warlock-weapongroup">
-                                <option value="1">Weapon Group I: Flail, Mace, Morningstar, Holy Water Sprinkler, Scourge, Warhammer</option>
-                                <option value="2">Weapon Group II: Dagger, Shortsword, Sword</option>
-                                <option value="3">Weapon Group III: Halberd, Staff, Spear, Footman's Flail, Pollaxe, War Lance</option>
-                                <option value="4">Weapon Group IV: Two-handed Sword, Longsword</option>
-                                <option value="5">Weapon Group V: Battleaxe, War Axe</option>
-                                <option value="6">Weapon Group VI: Bow, Longbow</option>
-                                <option value="7">Weapon Group VII: Crossbow, Javelin, Sling, Dagger, Rock, Throwing Spike, Arbalest</option>
-                                <option value="8">Weapon Group VIII: Cudgel, Unarmed combat</option>
-                            </select>
+                        
+                        <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
+                        <div class="skillrow elementalist_alternate_powers">
+                            <details>
+                                <summary>Raw Power (alternate version)</summary>
+                                <select class="elementalistcheckbox raw_poweralternate" name="attr_raw_poweralternate">
+                                    <option value="0">Unknown</option>
+                                    <option value="1">Known</option>
+                                </select>
+                                <input type="hidden" class="elementalistcheckbox raw_poweralternate" name="attr_raw_poweralternate" value="0"/>
+                                <div class="elementalistroll raw_poweralternate">
+                                    <input type="hidden" class="elementalist_raw_power_type" name="attr_elementalist_raw_power_type" value="0"/>
+                                    <div class="elementalist_alternate_powers">
+                                      <span>Attack with Raw Power (alternate):</span> <button class="button1 twod10 skillroll" type="roll" value="?{Choose roll type|Public roll,|GM and player,/w gm}&{template:custom2d10} {{title=@{character_name} uses Raw Power to attack}} {{spellattackroll= [[2d10]]}} {{VS = [[@{finalmagicalattack} - ?{Target's Magical Defence}]]}} {{damage=Dealing 2 Damage per Magic Point Spent: [[?{Magic Points spent} * 2]]}}" name="roll_raw_poweralternate"></button>
+                                    </div>
+                                </div>
+                                <div class="sheet-auto-expand">
+                                    <span name="attr_raw_poweralternate_text"></span>
+                                    <textarea name="attr_raw_poweralternate_text" readonly>The Elementalist’s body seethes with untapped elemental power. Using this ability, the Elementalist chooses a target and infuses it with the aforementioned elemental energy to cause damage. Raw power can still be used for mundane effects (see Dragon Warriors, p. 37).
+                                    Raw power is a direct attack with a range of 10m and pits the Elementalist’s Magical Attack against the target’s Magical Defence. If the attack is successful the target takes 2 Health Points of damage for each Magic Point spent in the attack.
+                                    The Elementalist can spend up to 1MP per rank on the Raw Power effect. The MP for a given elemental strike must come from the appropriate magic point pool; if the Elementalist doesn’t have MPs of that type available he cannot use or boost that attack.
+                                    Each Raw Power attack has a special effect as follows:
+                                    Fire: Sets the target on fire, inflicting 1HP damage per round, until the target spends a round putting the fire out.
+                                    Earth: Shards of stone erupt from the target’s skin before vanishing. The shards shred armour and reduce the target’s Armour Factor by 1 until basic repairs are made. Repairs take 5-10 minutes of work.
+                                    Air: This agonising attack forces air into the target’s body tissues, causing terrible pain and exploding organs. The target has his movement reduced by half for 1d6 rounds due to the pain. This special effect doesn’t work on automatons or the undead, though they take damage normally.
+                                    Water: This attack freezes the target from the inside causing massive damage. The target has his Evasion reduced by 1 for 1d6 rounds.
+                                    Darkness: Hampers the target’s vision, inflicting a -1 to Attack and Defence for 1d6 rounds.</textarea>
+                                </div>
+                            </details>
                         </div>
-                    </details>
-                </div>
-
-                <div class="warlockabilities">
-                  <details>
-                    <summary class="bigbolddetails">Special Abilities of a Warlock</summary>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Appraise Enemy</summary>
-                            <input type="checkbox" class="warlockcheckbox appraiseenemy" name="attr_appraise_enemy" value="1" />
-                            <div class="warlockroll appraiseenemy">
-                                <button class="button1 d20" type="roll" value="/w gm&{template:custom} {{title=@{character_name} attempts to appraise their enemy}} {{subtitle=Roll 1d20 under Psychic Talent}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalpsychictalent}}} {{On fail, percieved rank= [[3d6 –7]]}}" name="roll_appraiseenemy"></button>
-                            </div>
-                            <div class="sheet-auto-expand">
-                                <span name="attr_appraise_enemy_text"></span>
-                                <textarea name="attr_appraise_enemy_text" readonly>This skill enables the Warlock to determine the Profession (if any) and rank of a character just by watching him for a few moments. The GM rolls a d20, and if the score is under the Warlock’s Psychic Talent he informs him accurately of the character’s Profession and rank. If the d20 roll fails, the GM derives a random result for the observed character’s rank by rolling 3d6 –7, taking results below 1 as 1st-rank, and gives his Profession as whatever seems most plausible. (Note that even without this skill it is usually easy to tell a Barbarian, say, from a Sorcerer! Also note that tables for determining random Professions and ranks will appear in the Dragon Warriors Bestiary. Use of the skill takes one Combat Round for each character observed. It can only be used once on any given character—i.e. the Warlock cannot double-check in case of a mistake the first time. Because this is a skill rather than a spell it is not affected by Deceit or Mind Cloak. However, for the same reason it is affected by an Assassin’s Disguise skill, and an Assassin who disguises himself successfully will be able to fool the Warlock into thinking him to be some other rank and Profession.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Arrow Cutting</summary>
-                            <input type="checkbox" name="attr_arrow_cutting" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_arrow_cutting_text"></span>
-                                <textarea name="attr_arrow_cutting_text" readonly>This talent allows the Warlock to knock or catch arrows out of the air before they hit him! This calls for total concentration, so he cannot do it while spell-casting, in mêlée, etc. He is able to pit his defence score against the bowman’s attack. The Hit Roll is thus made as for normal mêlée combat, except that the usual range and visibility modifiers (p. 68) still apply also. The Warlock will have to split his defence (p. 68) if more than one arrow is shot at him in the same Combat Round. The Arrow Cutting skill can only be used if the Warlock can see his attacker; this is because he needs to see the release of the arrow to time his parry—he does not actually follow it in flight with his eye. Despite the name, this skill applies to all missile weapons (throwing stars, arrows, javelins, etc.) except for crossbow bolts.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Fight Blind</summary>
-                            <input type="checkbox" name="attr_fight_blind" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_fight_blind_text"></span>
-                                <textarea name="attr_fight_blind_text" readonly>The Warlock acquires a kind of ‘radar’ sense. When fighting blind (in pitch darkness or thick smoke, or against an invisible foe, for instance) he incurs a penalty of only –2 attack and –4 defence. (This is only 50% of the usual penalty for fighting blind; see p. 61)</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Unarmed Combat</summary>
-                            <input type="checkbox" name="attr_unarmed_combat" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_unarmed_combat_text"></span>
-                                <textarea name="attr_unarmed_combat_text" readonly>In order to select this skill, the Warlock must have chosen Weapon Group VIII as one of his fields of specialization. If he later switches to another Weapon Group, he loses the use of this skill. When fighting unarmed, the skill means that he uses a d6 for Armour Bypass Rolls and inflicts 3 HP damage on a successful blow.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Minor Enchantment (Weapons)</summary>
-                            <input type="checkbox" name="attr_minor_enchantment_weapons" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_minor_enchantment_weapons_text"></span>
-                                <textarea name="attr_minor_enchantment_weapons_text" readonly>This gives the Warlock the ability to forge enchanted weapons. There are three sub-levels to the Minor Enchantment skill: basic, advanced, and master. The first time the Warlock chooses this skill it gives him the ability to produce +1 magic weapons. He must wait until he gains another rank and then take the same skill a second time in order to reach the advanced level required for +2 weapons. For master level (+3 weapons) he must take this skill three times. The time taken to create an enchanted weapon is given on p. 35. There is a 1% chance that the weapon will turn out to be flawed.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Minor Enchantment (Armour)</summary>
-                            <input type="checkbox" name="attr_minor_enchantment_armour" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_minor_enchantment_armour_text"></span>
-                                <textarea name="attr_minor_enchantment_armour_text" readonly>This gives the Warlock the ability to forge enchanted armour. There are three sub-levels to the Minor Enchantment skill: basic, advanced, and master. The first time the Warlock chooses this skill it gives him the ability to produce +1 magic armour. He must wait until he gains another rank and then take the same skill a second time in order to reach the advanced level required for +2 armour. For master level (+3 armour) he must take this skill three times. The time taken to create an enchanted armour is given on p. 35. There is a 1% chance that the armour will turn out to be flawed.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Major Enchantment (Weapons)</summary>
-                            <input type="checkbox" name="attr_major_enchantment_weapons" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_major_enchantment_weapons_text"></span>
-                                <textarea name="attr_major_enchantment_weapons_text" readonly>A Warlock is only able to take this skill when he has Minor Enchantment of Weapons at the master level. The skill enables him to produce three magic swords which are listed below. He can make only one of each type of sword in his lifetime, and each takes a year and a day to make. These items must be swords of some form—a normal sword, shortsword, scimitar, two-handed sword or whatever. It is not possible to forge other types of weapon using this skill. Volcanic Sword: The wielder of this sword can cause its blade to glow white-hot or even burst into flame. This adds +5 HP to the damage the weapon inflicts; e.g. a Volcanic Shortsword becomes a (d8, 8) weapon. This applies only against creatures that can be affected by heat and/or fire. Severblade: The edge of this sword is always razor-sharp. While fighting with it, a character uses d20 for Armour Bypass Rolls. The damage inflicted is as it would be for a normal sword. Vampire Sword: This sword leeches the life-energy of those it slays and channels it into its owner. If wounded, the wielder of the Vampire Sword gets back 3 HP for every living creature or character he kills with it. The powers listed above are the only magical powers these weapons possess. They cannot be imbued with magic bonuses (+1, etc.) in addition to these powers.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Major Enchantment (Armour)</summary>
-                            <input type="checkbox" name="attr_major_enchantment_armour" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_major_enchantment_armour_text"></span>
-                                <textarea name="attr_major_enchantment_armour_text" readonly>A Warlock must have mastered the Minor Enchantment of Armour before he can acquire this skill. When he takes the skill, he must select one armour type from the three given below. He must take the skill a second time if he also wants to be able to make one of the other armour types. All of these types of magic armour are plate. Like the special swords given above, they have no magic bonus; this means that they have an intrinsic Armour Factor. Fashioning a suit of these armour types takes three years. There is a 1% chance that the armour will turn out to be flawed. Nullplate: This must be made with an alloy of silver which becomes jet-black in the process of forging. The armour must be studded with emeralds and jade, and the total cost is likely to approach 5000 florins. Whoever wears the armour is protected at all times by a kind of low-power Spell Screen that reduces any direct-attack spells cast at him by 3 Magic Points. Herculean Armour: Made from an alloy of gold and decorated with rubies, topaz, or fire opals, this armour is likely to cost some 4000 florins. It has a reddish, coppery appearance when finished. The wearer has a Strength of 20 at all times, allowing him numerous advantages. Fortress Armour: An alloy of platinum produces a suit of armour that shimmers like quicksilver. Moreover, it must be adorned with diamonds, and the total expense may be more than 8000 florins. It protects its wearer from all forms of destructive energy by reducing the damage roll by 20 HP.</textarea>
-                            </div>
-                        </details>
-                    </div>
-                    <div class="skillrow">
-                        <details>
-                            <summary>Ride Warhorse</summary>
-                            <input type="checkbox" name="attr_ride_warhorse" value="1" />
-                            <div class="sheet-auto-expand">
-                                <span name="attr_ride_warhorse_text"></span>
-                                <textarea name="attr_ride_warhorse_text" readonly>A Warlock who has chosen this speciality can ride a warhorse, exactly as though she were a Knight or Barbarian.</textarea>
-                            </div>
-                        </details>
-                    </div>
+                        
+                        <div class="skillrow">
+                            <details>
+                                <summary>Elemental Essence</summary>
+                                <select class="elementalistcheckbox elemental_essence" name="attr_elemental_essence">
+                                    <option value="0">Unknown</option>
+                                    <option value="1">Known</option>
+                                </select>
+                                <input type="hidden" class="elementalistcheckbox elemental_essence" name="attr_elemental_essence" value="0"/>
+                                <div class="sheet-auto-expand">
+                                    <span name="attr_elemental_essence_text"></span>
+                                    <textarea name="attr_elemental_essence_text" readonly>An 8th Rank Elementalist can create an Elemental Essence (see Dragon Warriors, p. 140) of her own main Element (only). This takes seven days of full-time work, per Essence, and costs just 100C. The Elementalist, unlike a Sorcerer using Alchemy (see Dragon Warriors, p. 30), does not need a laboratory or any other special equipment. However, she must brew the Essence in a place suited to the element: atop a volcano or by a massive forest fire for Fire, deep beneath a mighty mountain for Earth, out at sea or even underwater for Water, or on a mountaintop at least two miles high for Air.
+                                    A Darkness Elemental Essence resembles an uncut black diamond, at least in smoothness and hardness, but reflects no light whatsoever. If it is immersed in the fresh blood of any creature, in a dark place, it immediately becomes a Darkness Elemental (see below). A Darkness Elementalist of 8th Rank can create a Darkness Elemental Essence as above. It must be brewed in a dark place both literally and figuratively; a place that has recently seen great death, such as a battlefield or mass plague grave.
+                                    Elementalists of any Rank are treated as one Rank higher when attempting to command an elemental summoned by Elemental Essence, so long as it is of their main element, but they always fail an attempt to command an Elemental that is not from their main or subsidiary elements. An Elementalist automatically succeeds at commanding an elemental summoned from an Elemental Essence she has created herself; there is no need to roll.</textarea>
+                                </div>
+                            </details>
+                        </div>
+                        <div class="skillrow">
+                            <details>
+                                <summary>Elemental Resistance</summary>
+                                <select class="elementalistcheckbox elemental_resistance" name="attr_elemental_resistance">
+                                    <option value="0">Unknown</option>
+                                    <option value="1">Known</option>
+                                </select>
+                                <div class="sheet-auto-expand">
+                                    <span name="attr_elemental_resistance_text"></span>
+                                    <textarea name="attr_elemental_resistance_text" readonly>An Elementalist is resistant to being attacked by her own element, as wielded by another Elementalist or (at the GM’s discretion) in the form of another spellcaster’s spell, magical item attack, or even mundane attack (for example a hurricane, blizzard, burning building, or rocky avalanche). She gains a +4 to magical defence and evasion if attacked by her primary element, or a +2 if attacked by one of her secondary elements. She is so familiar with the elements in question that she can easily evade or resist their attacks.</textarea>
+                                </div>
+                            </details>
+                        </div>
                 </details>
             </div>
+            
+            <div class="warlockskills">
+                <details>
+                    <summary><h2>Warlock Profession Skills</h2></summary>
+                    <div class="counter-container">
+                        <!-- Combat Technique Counter -->
+                        <div class="counterbox">
+                            <span>Special Abilities of a Warlock:</span>
+                            <div class="counterfields">
+                                <span>Max:</span>
+                                <input type="number" class="fourshorttextinput" name="attr_warlockskills_max" />
+                                
+                                <span>Selected:</span>
+                                <input type="number" class="fourshorttextinput" name="attr_warlockskills_selected" readonly />
+                            </div>
+                        </div>
+                    </div>
+    
+                    <!-- Weapon Groups Selection -->
+                    <div class="weapon-group-selection">
+                        <details>
+                            <summary class="bigbolddetails">Select Weapon Groups</summary>
+                            <div class="weapon-group-container">
+                                <span>Weapon Group 1:</span>
+                                <select name="attr_weapon_group_1" class="warlock-weapongroup">
+                                    <option value="1">Weapon Group I: Flail, Mace, Morningstar, Holy Water Sprinkler, Scourge, Warhammer</option>
+                                    <option value="2">Weapon Group II: Dagger, Shortsword, Sword</option>
+                                    <option value="3">Weapon Group III: Halberd, Staff, Spear, Footman's Flail, Pollaxe, War Lance</option>
+                                    <option value="4">Weapon Group IV: Two-handed Sword, Longsword</option>
+                                    <option value="5">Weapon Group V: Battleaxe, War Axe</option>
+                                    <option value="6">Weapon Group VI: Bow, Longbow</option>
+                                    <option value="7">Weapon Group VII: Crossbow, Javelin, Sling, Dagger, Rock, Throwing Spike, Arbalest</option>
+                                    <option value="8">Weapon Group VIII: Cudgel, Unarmed combat</option>
+                                </select>
+                
+                                <span>Weapon Group 2:</span>
+                                <select name="attr_weapon_group_2" class="warlock-weapongroup">
+                                    <option value="1">Weapon Group I: Flail, Mace, Morningstar, Holy Water Sprinkler, Scourge, Warhammer</option>
+                                    <option value="2">Weapon Group II: Dagger, Shortsword, Sword</option>
+                                    <option value="3">Weapon Group III: Halberd, Staff, Spear, Footman's Flail, Pollaxe, War Lance</option>
+                                    <option value="4">Weapon Group IV: Two-handed Sword, Longsword</option>
+                                    <option value="5">Weapon Group V: Battleaxe, War Axe</option>
+                                    <option value="6">Weapon Group VI: Bow, Longbow</option>
+                                    <option value="7">Weapon Group VII: Crossbow, Javelin, Sling, Dagger, Rock, Throwing Spike, Arbalest</option>
+                                    <option value="8">Weapon Group VIII: Cudgel, Unarmed combat</option>
+                                </select>
+                            </div>
+                        </details>
+                    </div>
+    
+                    <div class="warlockabilities">
+                        <details>
+                            <summary class="bigbolddetails">Special Abilities of a Warlock</summary>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Appraise Enemy</summary>
+                                    <input type="checkbox" class="warlockcheckbox appraiseenemy" name="attr_appraise_enemy" value="1" />
+                                    <div class="warlockroll appraiseenemy">
+                                        <button class="button1 d20" type="roll" value="/w gm&{template:custom} {{title=@{character_name} attempts to appraise their enemy}} {{subtitle=Roll 1d20 under Psychic Talent}} {{roll= [[1d20cs1cf20]]}} {{Vs= @{finalpsychictalent}}} {{On fail, percieved rank= [[3d6 –7]]}}" name="roll_appraiseenemy"></button>
+                                    </div>
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_appraise_enemy_text"></span>
+                                        <textarea name="attr_appraise_enemy_text" readonly>This skill enables the Warlock to determine the Profession (if any) and rank of a character just by watching him for a few moments. The GM rolls a d20, and if the score is under the Warlock’s Psychic Talent he informs him accurately of the character’s Profession and rank. If the d20 roll fails, the GM derives a random result for the observed character’s rank by rolling 3d6 –7, taking results below 1 as 1st-rank, and gives his Profession as whatever seems most plausible. (Note that even without this skill it is usually easy to tell a Barbarian, say, from a Sorcerer! Also note that tables for determining random Professions and ranks will appear in the Dragon Warriors Bestiary. Use of the skill takes one Combat Round for each character observed. It can only be used once on any given character—i.e. the Warlock cannot double-check in case of a mistake the first time. Because this is a skill rather than a spell it is not affected by Deceit or Mind Cloak. However, for the same reason it is affected by an Assassin’s Disguise skill, and an Assassin who disguises himself successfully will be able to fool the Warlock into thinking him to be some other rank and Profession.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Arrow Cutting</summary>
+                                    <input type="checkbox" name="attr_arrow_cutting" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_arrow_cutting_text"></span>
+                                        <textarea name="attr_arrow_cutting_text" readonly>This talent allows the Warlock to knock or catch arrows out of the air before they hit him! This calls for total concentration, so he cannot do it while spell-casting, in mêlée, etc. He is able to pit his defence score against the bowman’s attack. The Hit Roll is thus made as for normal mêlée combat, except that the usual range and visibility modifiers (p. 68) still apply also. The Warlock will have to split his defence (p. 68) if more than one arrow is shot at him in the same Combat Round. The Arrow Cutting skill can only be used if the Warlock can see his attacker; this is because he needs to see the release of the arrow to time his parry—he does not actually follow it in flight with his eye. Despite the name, this skill applies to all missile weapons (throwing stars, arrows, javelins, etc.) except for crossbow bolts.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Fight Blind</summary>
+                                    <input type="checkbox" name="attr_fight_blind" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_fight_blind_text"></span>
+                                        <textarea name="attr_fight_blind_text" readonly>The Warlock acquires a kind of ‘radar’ sense. When fighting blind (in pitch darkness or thick smoke, or against an invisible foe, for instance) he incurs a penalty of only –2 attack and –4 defence. (This is only 50% of the usual penalty for fighting blind; see p. 61)</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Unarmed Combat</summary>
+                                    <input type="checkbox" name="attr_unarmed_combat" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_unarmed_combat_text"></span>
+                                        <textarea name="attr_unarmed_combat_text" readonly>In order to select this skill, the Warlock must have chosen Weapon Group VIII as one of his fields of specialization. If he later switches to another Weapon Group, he loses the use of this skill. When fighting unarmed, the skill means that he uses a d6 for Armour Bypass Rolls and inflicts 3 HP damage on a successful blow.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Minor Enchantment (Weapons)</summary>
+                                    <input type="checkbox" name="attr_minor_enchantment_weapons" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_minor_enchantment_weapons_text"></span>
+                                        <textarea name="attr_minor_enchantment_weapons_text" readonly>This gives the Warlock the ability to forge enchanted weapons. There are three sub-levels to the Minor Enchantment skill: basic, advanced, and master. The first time the Warlock chooses this skill it gives him the ability to produce +1 magic weapons. He must wait until he gains another rank and then take the same skill a second time in order to reach the advanced level required for +2 weapons. For master level (+3 weapons) he must take this skill three times. The time taken to create an enchanted weapon is given on p. 35. There is a 1% chance that the weapon will turn out to be flawed.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Minor Enchantment (Armour)</summary>
+                                    <input type="checkbox" name="attr_minor_enchantment_armour" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_minor_enchantment_armour_text"></span>
+                                        <textarea name="attr_minor_enchantment_armour_text" readonly>This gives the Warlock the ability to forge enchanted armour. There are three sub-levels to the Minor Enchantment skill: basic, advanced, and master. The first time the Warlock chooses this skill it gives him the ability to produce +1 magic armour. He must wait until he gains another rank and then take the same skill a second time in order to reach the advanced level required for +2 armour. For master level (+3 armour) he must take this skill three times. The time taken to create an enchanted armour is given on p. 35. There is a 1% chance that the armour will turn out to be flawed.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Major Enchantment (Weapons)</summary>
+                                    <input type="checkbox" name="attr_major_enchantment_weapons" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_major_enchantment_weapons_text"></span>
+                                        <textarea name="attr_major_enchantment_weapons_text" readonly>A Warlock is only able to take this skill when he has Minor Enchantment of Weapons at the master level. The skill enables him to produce three magic swords which are listed below. He can make only one of each type of sword in his lifetime, and each takes a year and a day to make. These items must be swords of some form—a normal sword, shortsword, scimitar, two-handed sword or whatever. It is not possible to forge other types of weapon using this skill. Volcanic Sword: The wielder of this sword can cause its blade to glow white-hot or even burst into flame. This adds +5 HP to the damage the weapon inflicts; e.g. a Volcanic Shortsword becomes a (d8, 8) weapon. This applies only against creatures that can be affected by heat and/or fire. Severblade: The edge of this sword is always razor-sharp. While fighting with it, a character uses d20 for Armour Bypass Rolls. The damage inflicted is as it would be for a normal sword. Vampire Sword: This sword leeches the life-energy of those it slays and channels it into its owner. If wounded, the wielder of the Vampire Sword gets back 3 HP for every living creature or character he kills with it. The powers listed above are the only magical powers these weapons possess. They cannot be imbued with magic bonuses (+1, etc.) in addition to these powers.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Major Enchantment (Armour)</summary>
+                                    <input type="checkbox" name="attr_major_enchantment_armour" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_major_enchantment_armour_text"></span>
+                                        <textarea name="attr_major_enchantment_armour_text" readonly>A Warlock must have mastered the Minor Enchantment of Armour before he can acquire this skill. When he takes the skill, he must select one armour type from the three given below. He must take the skill a second time if he also wants to be able to make one of the other armour types. All of these types of magic armour are plate. Like the special swords given above, they have no magic bonus; this means that they have an intrinsic Armour Factor. Fashioning a suit of these armour types takes three years. There is a 1% chance that the armour will turn out to be flawed. Nullplate: This must be made with an alloy of silver which becomes jet-black in the process of forging. The armour must be studded with emeralds and jade, and the total cost is likely to approach 5000 florins. Whoever wears the armour is protected at all times by a kind of low-power Spell Screen that reduces any direct-attack spells cast at him by 3 Magic Points. Herculean Armour: Made from an alloy of gold and decorated with rubies, topaz, or fire opals, this armour is likely to cost some 4000 florins. It has a reddish, coppery appearance when finished. The wearer has a Strength of 20 at all times, allowing him numerous advantages. Fortress Armour: An alloy of platinum produces a suit of armour that shimmers like quicksilver. Moreover, it must be adorned with diamonds, and the total expense may be more than 8000 florins. It protects its wearer from all forms of destructive energy by reducing the damage roll by 20 HP.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                            <div class="skillrow">
+                                <details>
+                                    <summary>Ride Warhorse</summary>
+                                    <input type="checkbox" name="attr_ride_warhorse" value="1" />
+                                    <div class="sheet-auto-expand">
+                                        <span name="attr_ride_warhorse_text"></span>
+                                        <textarea name="attr_ride_warhorse_text" readonly>A Warlock who has chosen this speciality can ride a warhorse, exactly as though she were a Knight or Barbarian.</textarea>
+                                    </div>
+                                </details>
+                            </div>
+                        </details>
+                
+            </div>
+                </details>
+            </div>    
             <div class="knaveskills">
-                <h2>Knave Profession Skills</h2>
+                <details>
+                <summary><h2>Knave Profession Skills</h2></summary>
                 <div class="counter-container">
                     <!-- Combat Technique Counter -->
                     <div class="counterbox">
@@ -7849,9 +8718,11 @@
                         </details>
                     </div>
                 </details>
+                </details>
             </div>
             <div class="hunterskills">
-                <h2>Hunter Profession Skills</h2>
+                <details>
+                <summary><h2>Hunter Profession Skills</h2></summary>
                 <div class="counter-container">
                     <!-- Combat Technique Counter -->
                     <div class="counterbox">
@@ -8086,9 +8957,11 @@
                         </details>
                     </div>
                 </details>
+                </details>
             </div>
             <div class="priestskills">
-                <h2>Priest Profession Skills</h2>
+                <details>
+                <summary><h2>Priest Profession Skills</h2></summary>
                 <div class="counter-container">
                     <!-- Combat Technique Counter -->
                     <div class="counterbox">
@@ -8263,10 +9136,12 @@
                             </div>
                         </details>
                     </div>
-                </details>    
+                </details>  
+                </details>
             </div>
             <div class="demonologistskills">
-                <h2>Special Abilities of a Demonologist</h2>
+                <details>
+                <summary><h2>Demonologist Profession Skills</h2></summary>
                 <details>
                     <summary>Special Abilities of a Demonologist</summary>
                     <div class="skillrow">
@@ -8365,9 +9240,11 @@
                         </details>
                     </div>
                 </details>
+                </details>
             </div>
             <div class="customskills">
-                <h2>Custom Special Abilities</h2>
+                <details>
+                <summary><h2>Custom Special Abilities</h2></summary>
                 <details>
                     <summary>Customised Abilities of the <span name="attr_profession"></span></summary>
                     <fieldset class="repeating_customskills">
@@ -8381,9 +9258,10 @@
                         <span>Description</span>
                         <div class="specialabilitydescription sheet-auto-expand">
                             <span name="attr_special_ability_description"></span>
-                            <textarea name="attr_special_ability_description" placeholder="Description" readonly></textarea>
+                            <textarea name="attr_special_ability_description" placeholder="Description"></textarea>
                         </div>
                     </fieldset>
+                </details>
                 </details>
             </div>
         </div>
@@ -8398,7 +9276,7 @@
                 <span>Description </span>
                 <div class="sheet-auto-expand">
                     <span name="attr_pathdescription"></span>  
-                    <textarea name="attr_pathdescription" readonly></textarea>
+                    <textarea name="attr_pathdescription"></textarea>
                 </div>
                 </textarea>
             </div>
@@ -8420,13 +9298,12 @@
                     <br>
                     <div class="sheet-auto-expand">
                         <span name="attr_secondaryskilldescription"></span>  
-                        <textarea name="attr_secondaryskilldescription" readonly></textarea>
+                        <textarea name="attr_secondaryskilldescription"></textarea>
                     </div>
                 </fieldset>
             </div>
         </div>
-    </div>    
-    
+
     <div class="languages">
         <div class="modlang">
             <span>Modern Languages</span>
@@ -8553,35 +9430,39 @@
             <option value="0">Only applies to Melee (Core Rules Default)</option>
             <option value="1">Applies to Ranged and Melee</option>
         </select>
+        <span>Stealth and Perception Dice Type:</span><select title="Rule Option" name="attr_steper_toggle">
+            <option value="0" selected >Use 2d10 (default)</option>
+            <option value="1">Use d20</option>
+        </select>
+        <span>Allow Ranged Weapons to be Magical:</span><select title="Rule Option" name="attr_ranged_magic_toggle">
+            <option value="Enabled" selected >Ranged Weapons can be Magical (default)</option>
+            <option value="Disabled">Ranged Weapons can not be Magical</option>
+        </select>
         <span>Elementalist Raw Power</span><select title="Rule Option" name="attr_elementalist_raw_power_type">
-            <option value="Core">Core Rules (default)</option>
+            <option value="Core" selected >Core Rules (default)</option>
             <option value="PG">Player's Guide version</option>
             <option value="Both">Display both versions</option>
         </select>
         <span>Combat Guards</span><select title="Rule Option" name="attr_combat_guards_able">
-            <option value="enabled">Combat Guards are enabled (default)</option>
+            <option value="enabled" selected >Combat Guards are enabled (default)</option>
             <option value="disabled">Combat Guards are disabled</option>
         </select>
         <span>The Supremacy of the Sword</span><select title="Rule Option" name="attr_supremacy_able">
-            <option value="enabled">The Supremacy of the Sword skills are enabled (default)</option>
+            <option value="enabled" selected >The Supremacy of the Sword skills are enabled (default)</option>
             <option value="disabled">The Supremacy of the Sword skills are disabled</option>
         </select>
         <span>Paths</span><select title="Rule Option" name="attr_paths_toggle">
-            <option value="enabled">Paths are enabled (default)</option>
+            <option value="enabled" selected >Paths are enabled (default)</option>
             <option value="disabled">Paths skills are disabled</option>
         </select>
         <span>Secondary Skills</span><select title="Rule Option" name="attr_secondaryskills_toggle">
-            <option value="enabled">Secondary Skills are enabled (default)</option>
+            <option value="enabled" selected >Secondary Skills are enabled (default)</option>
             <option value="disabled">Secondary Skills are disabled</option>
         </select>
         <span>Players Guide Spells</span><select title="Rule Option" name="attr_playerspells_toggle">
-            <option value="enabled">Players Guide Spells are available (default)</option>
+            <option value="enabled" selected >Players Guide Spells are available (default)</option>
             <option value="disabled">Players Guide Spells are unavailable</option>
         </select>
-        <h1>Known Issues</h1>
-        <ul>
-            <li>Demonologist Spells not yet implemented</li>
-        </ul>
         <h1>Documentation</h1>
         <p>This character sheet includes material based on the Dragon Warriors setting, created by Dave Morris and Oliver Johnson, and used under the Serpent King Games Fan Policy. We are not permitted to charge for access to this content. This character sheet is not published, endorsed, or officially approved by Serpent King Games. For more information about Dragon Warriors products and Serpent King Games, please visit <a href="http://www.serpentking.com">www.serpentking.com</a>.</p>
         
@@ -8598,6 +9479,20 @@
         <p>And most certainly not least, the brave group of adventurers who have been my primary playtesters: Gille, Hariot, Cador, Randos, Ulfthak, Argane, Ivon, and Kallister.</p>
         
         <span >Release Notes</span>
+        <p>Ver 2.01</p>
+        <ul>
+            <li>Demonologist Spells have been implemented</li>
+            <li>Fixed errors in layout for Custom Classes - skills and abilities sections</li>
+            <li>Removed "readonly" from Secondary Skills and Paths textboxes to allow for custom edits</li>
+            <li>The Ammunition Repeating section event listner has been made more specific so that it does not overwrite custom data unless the Ammo type is changed</li>
+            <li>Multiple buttons beside Stealth and Perception were confusing some users. I have made a toggle option, switching which button is visible, on the settings page.</li>
+            <li>Armour penalties (from non-profession) were not being included in their relevent calculations, added the Javascript to support it properly</li>
+            <li>Many of the AF3 armour options were incorrectly classified as AF4, this has now been fixed.</li>
+            <li>Custom classes were not able to see spell lists, this has been corrected.</li>
+            <li>Rearranged the front character sheet so that the most commonly used items are at the top - please send feedback, I can always change it back if nobody likes it</li>
+            <li>Renamed the first two tabs to better reflect their purpose</li>
+            <li>The level advancement math was totally wrong! I have adjusted the math so that it should be working properly now - please report any math errors (this is NOT my strong point).</li>
+        </ul>
         <p>Ver 2.0</p>
         <ul>
             <li>Killed the 'Click to Update!' Button. The sheet now updates on change (Fair Warning: this may add lag to the sheet functions,this is the price of having a responsive sheet).</li>
@@ -9185,88 +10080,87 @@ on("change:profession change:rank", function() {
         let perceptionIncrease = 0;
 
         if (profession === "Assassin") {
-            attackIncrease = rank;
-            defenceIncrease = Math.floor((rank - 2) / 2);
-            magicalDefenceIncrease = rank;
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = rank;
-            perceptionIncrease = rank;
+            attackIncrease = Math.max(0, rank - 1);
+            defenceIncrease = Math.max(0, Math.floor((rank -1) / 2));
+            magicalDefenceIncrease = Math.max(0, rank - 1);
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, rank - 1);
+            perceptionIncrease = Math.max(0, rank - 1);
         } else if (profession === "Barbarian") {
-            attackIncrease = rank;
-            defenceIncrease = rank;
-            magicalDefenceIncrease = rank;
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = Math.floor((rank - 2) / 2);
-            perceptionIncrease = Math.floor((rank - 2) / 2);
+            attackIncrease = Math.max(0, rank - 1);
+            defenceIncrease = Math.max(0, rank - 1);
+            magicalDefenceIncrease = Math.max(0, rank - 1);
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, Math.floor((rank -1) / 2));
+            perceptionIncrease = Math.max(0, Math.floor((rank -1) / 2));
         } else if (profession === "Knight") {
-            attackIncrease = rank;
-            defenceIncrease = rank;
-            magicalDefenceIncrease = rank;
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            perceptionIncrease = Math.floor((rank - 2) / 2);
-            stealthIncrease = Math.floor((rank - 3) / 3);
+            attackIncrease = Math.max(0, rank - 1);
+            defenceIncrease = Math.max(0, rank - 1);
+            magicalDefenceIncrease = Math.max(0, rank - 1);
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            perceptionIncrease = Math.max(0, Math.floor((rank -1) / 2));
+            stealthIncrease = Math.max(0, Math.floor((rank - 1) / 3));
         } else if (profession === "Elementalist") {
-            attackIncrease = Math.floor((rank - 3) / 3);
-            defenceIncrease = Math.floor((rank - 3) / 3);
-            magicalAttackIncrease = rank + Math.floor((rank - 6) / 6);
-            magicalDefenceIncrease = rank + Math.floor((rank - 6) / 6);
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = Math.floor((rank - 3) / 3);
-            perceptionIncrease = Math.floor((rank - 3) / 3);
+            attackIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            defenceIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            magicalAttackIncrease = Math.max(0, rank - 1) + Math.min(1, Math.max(0, Math.floor(rank / 7))) + Math.min(1, Math.max(0, Math.floor(rank / 12)));
+            magicalDefenceIncrease = Math.max(0, rank - 1) + Math.min(1, Math.max(0, Math.floor(rank / 7))) + Math.min(1, Math.max(0, Math.floor(rank / 12)));
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            perceptionIncrease = Math.max(0, Math.floor((rank - 1) / 3));
         } else if (profession === "Mystic") {
-            attackIncrease = Math.floor((rank - 2) / 2);
-            defenceIncrease = Math.floor((rank - 2) / 2);
-            magicalAttackIncrease = rank + Math.floor((rank - 6) / 6);
-            magicalDefenceIncrease = rank + Math.floor((rank - 6) / 6) + Math.floor((rank - 12) / 12);
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = Math.floor((rank - 3) / 3);
-            perceptionIncrease = rank;
+            attackIncrease = Math.max(0, Math.floor((rank - 1) / 2));
+            defenceIncrease = Math.max(0, Math.floor((rank - 1) / 2));
+            magicalAttackIncrease = Math.max(0, rank - 1);
+            magicalDefenceIncrease = Math.max(0, rank - 1) + Math.min(1, Math.max(0, Math.floor(rank / 7))) + Math.min(1, Math.max(0, Math.floor(rank / 12)));            
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            perceptionIncrease = Math.max(0, rank - 1);
         } else if (profession === "Sorcerer") {
-            attackIncrease = Math.floor((rank - 3) / 3);
-            defenceIncrease = Math.floor((rank - 3) / 3);
-            magicalAttackIncrease = rank + Math.floor((rank - 6) / 6);
-            magicalDefenceIncrease = rank + Math.floor((rank - 6) / 6);
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = Math.floor((rank - 3) / 3);
-            perceptionIncrease = Math.floor((rank - 3) / 3);
+            attackIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            defenceIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            magicalAttackIncrease = Math.max(0, rank - 1) + Math.min(1, Math.max(0, Math.floor(rank / 7))) + Math.min(1, Math.max(0, Math.floor(rank / 12)));
+            magicalDefenceIncrease = Math.max(0, rank - 1) + Math.min(1, Math.max(0, Math.floor(rank / 7))) + Math.min(1, Math.max(0, Math.floor(rank / 12)));
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            perceptionIncrease = Math.max(0, Math.floor((rank - 1) / 3));
         } else if (profession === "Warlock") {
-            attackIncrease = rank;
-            defenceIncrease = rank;
-            magicalAttackIncrease = rank;
-            magicalDefenceIncrease = rank;
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = Math.floor((rank - 3) / 3);
-            perceptionIncrease = Math.floor((rank - 3) / 3);
+            attackIncrease = Math.max(0, rank - 1);
+            defenceIncrease = Math.max(0, rank - 1);
+            magicalAttackIncrease = Math.max(0, rank - 1);
+            magicalDefenceIncrease = Math.max(0, rank - 1);
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            perceptionIncrease = Math.max(0, Math.floor((rank - 1) / 3));
         } else if (profession === "Knave") {
-            attackIncrease = rank;
-            defenceIncrease = Math.floor((rank - 2) / 2);
-            magicalDefenceIncrease = rank;
-            evasionIncrease = rank;
-            stealthIncrease = rank;
-            perceptionIncrease = rank;
+            attackIncrease = Math.max(0, rank - 1);
+            defenceIncrease = Math.max(0, Math.floor((rank - 1) / 2));
+            magicalDefenceIncrease = Math.max(0, rank - 1);
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, rank - 1);
+            perceptionIncrease = Math.max(0, rank - 1);
         } else if (profession === "Hunter") {
-            attackIncrease = rank;
-            defenceIncrease = rank;
-            magicalDefenceIncrease = rank;
-            evasionIncrease = rank;
-            stealthIncrease = rank;
-            perceptionIncrease = rank;
+            attackIncrease = Math.max(0, rank - 1);
+            defenceIncrease = Math.max(0, Math.floor((rank - 1) / 2));
+            magicalDefenceIncrease = Math.max(0, rank - 1);
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, rank - 1);
+            perceptionIncrease = Math.max(0, rank - 1);
         } else if (profession === "Priest") {
-            attackIncrease = Math.floor((rank - 2) / 2);
-            defenceIncrease = Math.floor((rank - 2) / 2);
-            magicalAttackIncrease = Math.floor((rank - 4) / 4);
-            magicalDefenceIncrease = rank + Math.floor((rank - 6) / 6);
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = Math.floor((rank - 3) / 3);
-            perceptionIncrease = Math.floor((rank - 3) / 3);
+            attackIncrease = Math.max(0, Math.floor((rank - 1) / 2));
+            defenceIncrease = Math.max(0, Math.floor((rank - 1) / 2));
+            magicalDefenceIncrease = Math.max(0, rank - 1) + Math.min(1, Math.max(0, Math.floor(rank / 7))) + Math.min(1, Math.max(0, Math.floor(rank / 12)));
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            perceptionIncrease = Math.max(0, rank - 1);;
         } else if (profession === "Demonologist") {
-            attackIncrease = rank;
-            defenceIncrease = Math.floor((rank - 2) / 2);
-            magicalAttackIncrease = rank;
-            magicalDefenceIncrease = rank;
-            evasionIncrease = Math.floor((rank - 4) / 4);
-            stealthIncrease = Math.floor((rank - 3) / 3);
-            perceptionIncrease = Math.floor((rank - 3) / 3);
+            attackIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            defenceIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            magicalAttackIncrease = Math.max(0, rank - 1);
+            magicalDefenceIncrease = Math.max(0, rank - 1);
+            evasionIncrease = Math.max(0, Math.floor((rank - 1) / 4));
+            stealthIncrease = Math.max(0, Math.floor((rank - 1) / 3));
+            perceptionIncrease = Math.max(0, Math.floor((rank - 1) / 3));
         }
 
         // Calculate final values
@@ -9938,7 +10832,7 @@ on("clicked:repeating_ammo:equippedammo", function(eventInfo) {
   });
 });
 
-on('change:repeating_ammo change:profession', function(event) {
+on('change:repeating_ammo:ammotype change:profession', function(event) {
     if (event.sourceType === 'sheetworker') return;
 
     const id = (event.sourceAttribute.split('_')[2] || '').toLowerCase();
@@ -10709,11 +11603,12 @@ on('change:profession change:rank change:warlockweapongroups change:meleeweapon 
     });
 });
 
-on("change:stealth change:miscstealth change:perception change:miscperception change:reflexes change:psychic_talent change:humanintuitionselect change:stillnesspos change:rank change:huntersmindactivate change:baseaf change:favoured_language", function() {
+on("change:armourstealthpenalty change:stealth change:miscstealth change:perception change:miscperception change:reflexes change:psychic_talent change:humanintuitionselect change:stillnesspos change:rank change:huntersmindactivate change:baseaf change:favoured_language", function() {
     getAttrs([
         'stealth', 'miscstealth', 'perception', 'miscperception',
         'reflexes', 'psychic_talent', 'humanintuitionselect',
-        'stillnesspos', 'rank', 'huntersmindactivate', 'baseaf', 'favoured_language'
+        'stillnesspos', 'rank', 'huntersmindactivate', 'baseaf', 'favoured_language',
+        'armourstealthpenalty'
     ], function(values) {
         let stealth = parseInt(values.stealth) || 0;
         let miscStealth = parseInt(values.miscstealth) || 0;
@@ -10727,7 +11622,7 @@ on("change:stealth change:miscstealth change:perception change:miscperception ch
         let huntersMindActive = values.huntersmindactivate === "1";
         let baseAF = parseInt(values.baseaf) || 0;
         let favoured_language = values.favoured_language === "1";
-
+        let armourstealthpenalty = parseInt(values.armourstealthpenalty) || 0;
         // Initial final scores calculation
         let finalStealth = stealth + miscStealth + stillnessPos;
         let finalPerception = perception + miscPerception;
@@ -10763,6 +11658,10 @@ on("change:stealth change:miscstealth change:perception change:miscperception ch
             finalPerception += huntersMindBonus;
         }
 
+        if (armourstealthpenalty < 0) {
+            finalStealth += armourstealthpenalty; // Adding a negative value effectively subtracts
+        }
+
         // Update attributes with final scores
         setAttrs({
             'finalstealth': finalStealth,
@@ -10771,7 +11670,7 @@ on("change:stealth change:miscstealth change:perception change:miscperception ch
     });
 });
 
-on('change:finalstrength change:humanintuitionselect change:finalreflexes change:attack change:defence change:evasion change:miscattackmelee change:miscdefencemelee change:miscattackranged change:miscdefenceranged change:miscevasion change:berserkneg change:berserkpos change:berserktoranged change:bloodrageselect change:main_gauche_active change:maingauchedefencebonus change:shield change:magicshield change:equippedmeleeweaponmagicbonus change:magicrangedweaponbonus change:equippedammomagicbonus change:mattackmoda change:mdefencemoda change:rattackmoda change:rdefencemoda change:nonprofranged change:nonprofmelee change:deathvowselect change:preciseneg change:stillnessneg change:equippedammoattackmod change:intelligence change:elemental_resistance_select change:song_of_battle_toggle', function() {
+on('change:armourattackpenalty change:armourdefencepenalty change:finalstrength change:humanintuitionselect change:finalreflexes change:attack change:defence change:evasion change:miscattackmelee change:miscdefencemelee change:miscattackranged change:miscdefenceranged change:miscevasion change:berserkneg change:berserkpos change:berserktoranged change:bloodrageselect change:main_gauche_active change:maingauchedefencebonus change:shield change:magicshield change:equippedmeleeweaponmagicbonus change:magicrangedweaponbonus change:equippedammomagicbonus change:mattackmoda change:mdefencemoda change:rattackmoda change:rdefencemoda change:nonprofranged change:nonprofmelee change:deathvowselect change:preciseneg change:stillnessneg change:equippedammoattackmod change:intelligence change:elemental_resistance_select change:song_of_battle_toggle', function() {
 
     getAttrs([
         'finalstrength', 'finalreflexes', 'attack', 'defence', 'evasion',
@@ -10779,7 +11678,8 @@ on('change:finalstrength change:humanintuitionselect change:finalreflexes change
         'berserkpos', 'berserkneg', 'berserktoranged', 'bloodrageselect', 'main_gauche_active', 'maingauchedefencebonus',
         'shield', 'magicshield', 'equippedmeleeweaponmagicbonus', 'magicrangedweaponbonus', 'equippedammomagicbonus', 'song_of_battle_toggle',
         'mattackmoda', 'mdefencemoda', 'rattackmoda', 'rdefencemoda', 'nonprofranged', 'nonprofmelee', 'humanintuitionselect',
-        'deathvowselect', 'preciseneg', 'stillnessneg', 'equippedammoattackmod', 'intelligence', 'elemental_resistance_select'
+        'deathvowselect', 'preciseneg', 'stillnessneg', 'equippedammoattackmod', 'intelligence', 'elemental_resistance_select',
+        'armourattackpenalty', 'armourdefencepenalty'
     ], function(values) {
         
         // Retrieve base values
@@ -10799,6 +11699,10 @@ on('change:finalstrength change:humanintuitionselect change:finalreflexes change
         let miscRangedDefence = parseInt(values['miscdefenceranged']) || 0;
         let miscEvasion = parseInt(values['miscevasion']) || 0;
 
+        //Retrieve non-proficient Armour Penalties
+        let armourattackpenalty = parseInt(values['armourattackpenalty']) || 0;
+        let armourdefencepenalty = parseInt(values['armourdefencepenalty']) || 0;
+            
         // Retrieve special ammo modifiers
         let specialAmmoAttack = parseInt(values['equippedammoattackmod']) || 0;
 
@@ -10983,6 +11887,17 @@ on('change:finalstrength change:humanintuitionselect change:finalreflexes change
             finalMeleeDefence += magicShieldBonus;
             finalRangedDefence += magicShieldBonus;
         }
+        
+        // Apply non-proficient armour penalties to attack and defence
+        if (armourattackpenalty < 0) {
+            finalMeleeAttack += armourattackpenalty; // Adding a negative value effectively subtracts
+            finalRangedAttack += armourattackpenalty;
+        }
+
+        if (armourdefencepenalty < 0) {
+            finalMeleeDefence += armourdefencepenalty;
+            finalRangedDefence += armourdefencepenalty;
+        }        
 
         // Apply Death Vow Select Effect
         if (deathvowSelect === 1) {

--- a/Dragon Warriors/sheet.json
+++ b/Dragon Warriors/sheet.json
@@ -5,5 +5,6 @@
   "roll20userid": "630718",
   "preview": "Example - clean.png",
   "instructions": "",
-  "legacy": false
+  "legacy": false,
+  "printable": true
 }


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X ] The pull request title clearly contains the name of the sheet I am editing.
- [X ] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X ] The pull request makes changes to files in only one sub-folder.
- [X ] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

Demonologist Spells have been implemented.
Fixed errors in the layout for Custom Classes - skills and abilities sections. Removed "readonly" from Secondary Skills and Paths textboxes to allow for custom edits. The Ammunition Repeating section event listener has been made more specific so that it does not overwrite custom data unless the Ammo type is changed. Multiple buttons beside Stealth and Perception were confusing some users. A toggle option has been added on the settings page, switching which button is visible. Armour penalties (from non-profession) were not being included in their relevant calculations; Javascript has been added to support it properly. Many of the AF3 armour options were incorrectly classified as AF4; this has now been fixed. Custom classes were not able to see spell lists; this has been corrected. Rearranged the front character sheet so that the most commonly used items are at the top - please send feedback, as it can always be changed back. Renamed the first two tabs to better reflect their purpose. The level advancement math was totally wrong! It has been adjusted and should be working properly now - please report any math errors.

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->




