### PR TITLE
[PokemonTabletopAdventures_v3] New Feature: Roll Template & More Collapsing Sections

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -596,6 +596,10 @@ div.sheet-wrapper {
   position: relative;
 }
 
+div.sheet-no-background {
+  background-color: #00000000;
+}
+
 div.sheet-pokemon-move,
 div.sheet-class-feature {
   background-image: var(--background-image);
@@ -659,11 +663,10 @@ div.sheet-skill-selection .sheet-no-dropdown {
 }
 
 .sheet-logo {
-  width: 280px;
-  height: 150px;
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: -15px;
+  min-height: 150px;
+  background-image: url("https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/PokemonTabletopAdventures_v3/images/PTA3SmallLogo.png");
+  background-position: center top;
+  background-repeat: no-repeat;
 }
 
 .sheet-form-buttons {
@@ -1926,6 +1929,11 @@ button[type="roll"].sheet-stat-roller:hover {
   visibility: visible;
 }
 
+.sheet-extra-max-height .sheet-options-flag:not(:checked) ~ div.sheet-display,
+.sheet-extra-max-height .sheet-options-flag:checked ~ div.sheet-options {
+  max-height: 1800px;
+}
+
 .sheet-options-flag:checked ~ div.sheet-display,
 .sheet-options-flag:not(:checked) ~ div.sheet-options {
   max-height: 0px;
@@ -1996,6 +2004,13 @@ h3.sheet-section-header {
   color: var(--foreground-color);
   margin-bottom: 8px;
   padding-left: 40px;
+}
+
+b.sheet-subsection-header {
+  display: block;
+  line-height: 24px;
+  margin-bottom: 8px;
+  padding-left: 32px;
 }
 
 .sheet-options-flag {
@@ -2215,6 +2230,15 @@ input.sheet-capitalize {
   .sheet-character-skill-labels {
     grid-template-columns: 1fr 5fr 1fr 1fr;
   }
+
+  .sheet-feature-container > .sheet-options-flag,
+  .sheet-feature-container > .sheet-options-flag + span,
+  .sheet-feature-container > .sheet-options-flag:checked,
+  .sheet-feature-container > .sheet-options-flag:checked + span {
+    left: 8px;
+    top: 22px;
+  }  
+
 
   .sheet-rolltemplate-move-roll .sheet-container table.sheet-move-template,
   .sheet-rolltemplate-dual-hit-move-roll .sheet-container table.sheet-move-template,

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -4,7 +4,8 @@
 .sheet-rolltemplate-ten-hit-move-roll,
 .sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
-.sheet-rolltemplate-feature-output {
+.sheet-rolltemplate-feature-output,
+.sheet-rolltemplate-inline-skill-roll {
   --poke-bug: #c6d16e;
   --poke-bug-background: #ffffb280;
   --poke-bug-shaded: #828d2a;
@@ -98,6 +99,7 @@
   --stat-ro-spd: #ff99ff80;
 }
 
+.sheet-rolltemplate-inline-skill-roll,
 .sheet-rolltemplate-skill-roll {
   --atk-gradient: #bb5555;
   --atk-header: #ff9999;
@@ -1222,27 +1224,151 @@ button[type="roll"].sheet-stat-roller:hover {
 
 /* Roll Templates */
 
+/* Inline Skill Roll */
+
+.sheet-rolltemplate-inline-skill-roll {
+  --header-text: #000000;
+  --main-text: #000000;
+  --odd-row-bg: #d9d9d6;
+  --row-bg: #e9e9e9;
+}
+
+.sheet-rolltemplate-darkmode.sheet-rolltemplate-inline-skill-roll {
+  --header-text: #dddddd;
+  --main-text: #dddddd;
+  --odd-row-bg: #303030;
+  --row-bg: #404040;
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-labelled-table-wrapper {
+  display: grid;
+  grid-column-gap: 0px;
+  grid-template-columns: 5% 95%;
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-labelled-table-wrapper span.sheet-border-label {
+  background: var(--header-bg);
+  border: 1px solid var(--border-color);
+  border-left: none;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  border-collapse: separate;
+  color: var(--main-text);
+  font-size: 12px;
+  height: auto;
+  padding-right: 2px;
+  text-align: center;
+  text-transform: uppercase;
+  font-weight: bold;
+  transform: scale(-1, -1);
+  width: 100%;
+  writing-mode: vertical-lr;
+  -webkit-text-stroke: 0.5px var(--poke-all-dark-background);
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-container table.sheet-inline-skill-template {
+  background: var(--row-bg);
+  border: 1px solid var(--border-color);
+  border-left: none;
+  border-bottom-right-radius: 4px;
+  border-top-right-radius: 4px;
+  border-collapse: separate;
+  box-sizing: border-box;
+  color: var(--main-text);
+  font-size: 12px;
+  height: 100%;
+  line-height: 2em;
+  overflow: clip;
+  padding-left: 2px;
+  width: 100%;
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-container table.sheet-inline-skill-template td.sheet-label {
+  font-weight: bold;
+  padding-left: 4px;
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-container table.sheet-inline-skill-template td.sheet-subhead {
+  border-bottom: 1px solid var(--odd-row-bg);
+  font-size: 12px;
+  font-style: italic;
+  padding-left: 4px;
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-container table.sheet-inline-skill-template a {
+  color: var(--header-text);
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-container table.sheet-inline-skill-template .sheet-skill-roll .inlinerollresult {
+  background: inherit;
+  border: none;
+  font-size: inherit;
+  padding: 0px;
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-atk-skill {
+  --border-color: var(--poke-all-dark-background);
+  --header-bg: var(--atk-gradient);
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-def-skill {
+  --border-color: var(--poke-all-dark-background);
+  --header-bg: var(--def-gradient);
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-spatk-skill {
+  --border-color: var(--poke-all-dark-background);
+  --header-bg: var(--spatk-gradient);
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-spdef-skill {
+  --border-color: var(--poke-all-dark-background);
+  --header-bg: var(--spdef-gradient);
+}
+
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-spd-skill {
+  --border-color: var(--poke-all-dark-background);
+  --header-bg: var(--spd-gradient);
+}
+
+
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-atk-skill {
+  --border-color: var(--atk-gradient);
+  --header-bg: var(--atk-header-dark);
+}
+
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-def-skill {
+  --border-color: var(--def-gradient);
+  --header-bg: var(--def-header-dark);
+}
+
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spatk-skill {
+  --border-color: var(--spatk-gradient);
+  --header-bg: var(--spatk-header-dark);
+}
+
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spdef-skill {
+  --border-color: var(--spdef-gradient);
+  --header-bg: var(--spdef-header-dark);
+}
+
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spd-skill {
+  --border-color: var(--spd-gradient);
+  --header-bg: var(--spd-header-dark);
+}
+
+
+/* Other Templates */
+
 .sheet-rolltemplate-move-roll,
 .sheet-rolltemplate-dual-hit-move-roll,
 .sheet-rolltemplate-ten-hit-move-roll,
 .sheet-rolltemplate-multi-hit-move-roll,
 .sheet-rolltemplate-triple-hit-move-roll,
-.sheet-rolltemplate-feature-output {
-  --header-text: black;
-}
-
+.sheet-rolltemplate-feature-output,
 .sheet-rolltemplate-skill-roll {
-  --header-text: black;
-}
-
-.sheet-rolltemplate-move-roll,
-.sheet-rolltemplate-dual-hit-move-roll,
-.sheet-rolltemplate-ten-hit-move-roll,
-.sheet-rolltemplate-multi-hit-move-roll,
-.sheet-rolltemplate-triple-hit-move-roll,
-.sheet-rolltemplate-skill-roll,
-.sheet-rolltemplate-feature-output {
-  --main-text: black;
+  --header-text: #000000;
+  --main-text: #000000;
   --odd-row-bg: #d9d9d6;
   --row-bg: #e9e9e9;
   text-transform: capitalize;
@@ -1259,6 +1385,7 @@ button[type="roll"].sheet-stat-roller:hover {
   --main-text: #dddddd;
   --odd-row-bg: #303030;
   --row-bg: #404040;
+  text-transform: capitalize;
 }
 
 .sheet-rolltemplate-color-setting-bug-move {
@@ -1521,8 +1648,12 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template,
 .sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template,
 .sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template {
-  border: 1px solid;
-  border-color: var(--border-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  border-collapse: separate;
+  border-spacing: 0px;
+  box-sizing: border-box;
+  overflow: clip;
   color: var(--main-text);
   font-size: 12px;
   line-height: 1em;
@@ -1738,8 +1869,8 @@ button[type="roll"].sheet-stat-roller:hover {
 .sheet-rolltemplate-ten-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-multi-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
 .sheet-rolltemplate-triple-hit-move-roll .sheet-container table.sheet-move-template td.sheet-subhead,
-.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead,
-.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-subhead {
+.sheet-rolltemplate-feature-output .sheet-container table.sheet-feature-template td.sheet-subhead,
+.sheet-rolltemplate-skill-roll .sheet-container table.sheet-skill-template td.sheet-subhead {
   padding: 4px;
   background: var(--box-bg);
   font-size: 12px;

--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -585,11 +585,15 @@ div.sheet-pokemon-move span.sheet-readonly-field input[type="number"] {
   font-style: italic;
 }
 
-div.sheet-wrapper,
+div.sheet-collapsible-feature,
+div.sheet-feature-container,
 div.sheet-pokemon-move,
-div.sheet-collapsible-feature {
+div.sheet-wrapper {
   background-color: var(--background-color);
   border-color: var(--foreground-color);
+  display: grid;
+  grid-template: "top-left" 1fr / 1fr;
+  position: relative;
 }
 
 div.sheet-pokemon-move,
@@ -1913,12 +1917,35 @@ button[type="roll"].sheet-stat-roller:hover {
 
 .sheet-options-flag:not(:checked) ~ div.sheet-display,
 .sheet-options-flag:checked ~ div.sheet-options {
-  display: block;
+  max-height: 1200px;
+  opacity: 1;
+  overflow: scroll;
+  transition-property: max-height, opacity, visibility;
+  transition-duration: 400ms;
+  transition-timing-function: cubic-bezier(.55,.06,.68,.19);
+  visibility: visible;
 }
 
 .sheet-options-flag:checked ~ div.sheet-display,
 .sheet-options-flag:not(:checked) ~ div.sheet-options {
-  display: none;
+  max-height: 0px;
+  opacity: 0;
+  overflow: hidden;
+  transition-property: max-height, opacity, visibility;
+  transition-duration: 400ms;
+  transition-timing-function: cubic-bezier(.22,.61,.36,1);
+  visibility: hidden;
+}
+
+div.sheet-collapsible-feature div.sheet-display,
+div.sheet-collapsible-feature div.sheet-options,
+div.sheet-feature-container div.sheet-display,
+div.sheet-feature-container div.sheet-options,
+div.sheet-pokemon-move div.sheet-display,
+div.sheet-pokemon-move div.sheet-options,
+div.sheet-wrapper div.sheet-display,
+div.sheet-wrapper div.sheet-options {
+  grid-area: top-left;
 }
 
 button[type="roll"].sheet-inline-roller:hover {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -347,7 +347,7 @@
     <br />
 
     <div class="sheet-tab-trainer sheet-tab-pokemon sheet-tab-hybrid">
-      <div class="sheet-feature-container" style="position: relative;">
+      <div class="sheet-feature-container">
         <input checked class="sheet-options-flag" name="attr_avatar_options_flag" type="checkbox" />
         <span name="attr_avatar_flag">-</span>
         <div class="sheet-display">
@@ -479,7 +479,7 @@
     </div>
 
     <div class="sheet-tab-trainer">
-      <div class="sheet-collapsible-feature" style="position: relative;">
+      <div class="sheet-collapsible-feature">
         <input checked class="sheet-options-flag" name="attr_options_stat_flag" type="checkbox" />
         <span name="attr_stat_flag">-</span>
         <div class="sheet-display">
@@ -568,7 +568,7 @@
     </div>
 
     <div class="sheet-tab-pokemon sheet-tab-hybrid">
-      <div class="sheet-collapsible-feature" style="position: relative;">
+      <div class="sheet-collapsible-feature">
         <input checked class="sheet-options-flag" name="attr_options_stat_flag" type="checkbox" />
         <span name="attr_stat_flag">-</span>
         <div class="sheet-display">
@@ -994,7 +994,7 @@
     <div class="sheet-tab-trainer sheet-tab-hybrid">
       <h3 class="sheet-section-header">Origin Feature</h3>
       <input class="sheet-color-setting-feature" name="attr_feature_color" type="hidden" value="@{type1}" />
-      <div class="sheet-class-feature sheet-collapsible-feature" style="position: relative;">
+      <div class="sheet-class-feature sheet-collapsible-feature">
         <input checked class="sheet-options-flag" name="attr_origin_options_flag" type="checkbox" />
         <span name="attr_origin_flag">-</span>
         <div class="sheet-display">
@@ -1063,7 +1063,7 @@
         </div>
       </div>
       <br />
-      <div class="sheet-feature-container" style="position: relative;">
+      <div class="sheet-feature-container">
         <input checked class="sheet-options-flag" name="attr_class_features_options_flag" type="checkbox" />
         <span name="attr_class_features_flag">-</span>
         <div class="sheet-display">

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -8,6 +8,9 @@
     <input name="attr_publicity_label" type="hidden" value="Rolling Publicly" />
     <input name="attr_publicity_roll" type="hidden" value="" />
     <button class="sheet-page-selection-option" name="act_toggle-roll-publicity" type="action"><span name="attr_publicity_label"></span></button>
+    <input name="attr_skill_template_label" type="hidden" value="Original Style" />
+    <input name="attr_skill_template" type="hidden" value="skill-roll" />
+    <button class="sheet-page-selection-option" name="act_toggle-skill-template" type="action"><span name="attr_skill_template_label"></span></button>
   </div>
 
   <input class="sheet-selected-page" name="attr_selected-page" type="hidden" value="configuration-page" />
@@ -359,7 +362,7 @@
               <b>Attack</b><br />
               <input class="sheet-stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_attack_check" type="roll"
-                value="@{publicity_roll} &{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_ATKMOD" title="Attribute: ATKMOD"></span>
               </button>
               <br />
@@ -369,7 +372,7 @@
               <b>Defense</b><br />
               <input class="sheet-stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_defense_check" type="roll"
-                value="@{publicity_roll} &{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_DEFMOD" title="Attribute: DEFMOD"></span>
               </button>
               <br />
@@ -379,7 +382,7 @@
               <b>Special Attack</b><br />
               <input class="sheet-stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_special_attack_check" type="roll"
-                value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_SPATKMOD" title="Attribute: SPATKMOD"></span>
               </button>
               <br />
@@ -389,7 +392,7 @@
               <b>Special Defense</b><br />
               <input class="sheet-stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_special_defense_check" type="roll"
-                value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_SPDEFMOD" title="Attribute: SPDEFMOD"></span>
               </button>
               <br />
@@ -399,7 +402,7 @@
               <b>Speed</b><br />
               <input class="sheet-stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_speed_check" type="roll"
-                value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_SPDMOD" title="Attribute: SPDMOD"></span>
               </button>
               <br />
@@ -423,7 +426,7 @@
                 <b>Attack</b><br />
                 <input class="sheet-stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_attack_check" type="roll"
-                  value="@{publicity_roll} &{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_ATKMOD" title="Attribute: ATKMOD"></span>
                 </button>
                 <br />
@@ -433,7 +436,7 @@
                 <b>Defense</b><br />
                 <input class="sheet-stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_defense_check" type="roll"
-                  value="@{publicity_roll} &{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_DEFMOD" title="Attribute: DEFMOD"></span>
                 </button>
                 <br />
@@ -443,7 +446,7 @@
                 <b>Special Attack</b><br />
                 <input class="sheet-stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_special_attack_check" type="roll"
-                  value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_SPATKMOD" title="Attribute: SPATKMOD"></span>
                 </button>
                 <br />
@@ -453,7 +456,7 @@
                 <b>Special Defense</b><br />
                 <input class="sheet-stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_special_defense_check" type="roll"
-                  value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_SPDEFMOD" title="Attribute: SPDEFMOD"></span>
                 </button>
                 <br />
@@ -463,7 +466,7 @@
                 <b>Speed</b><br />
                 <input class="sheet-stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_speed_check" type="roll"
-                  value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_SPDMOD" title="Attribute: SPDMOD"></span>
                 </button>
                 <br />
@@ -705,7 +708,7 @@
           <input class="sheet-skill-color-setting" name="attr_acrobatics_ability_mod" type="hidden" value="SPD" />
           <input class="sheet-skill-total" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
           <button class="sheet-skill-roller" name="roll_acrobaticscheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Acrobatics (<span name="attr_acrobatics_ability_mod"></span>)
           </button>
           <input name="attr_acrobaticstalent1" value="2" title="Attribute: acrobaticstalent1" type="checkbox" />
@@ -714,7 +717,7 @@
           <input class="sheet-skill-color-setting" name="attr_athletics_ability_mod" type="hidden" value="ATK" />
           <input class="sheet-skill-total" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
           <button class="sheet-skill-roller" name="roll_athleticscheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Athletics (<span name="attr_athletics_ability_mod"></span>)
           </button>
           <input name="attr_athleticstalent1" value="2" title="Attribute: athleticstalent1" type="checkbox" />
@@ -723,7 +726,7 @@
           <input class="sheet-skill-color-setting" name="attr_bluff_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
           <button class="sheet-skill-roller" name="roll_bluffcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Bluff/Deception (<span name="attr_bluff_ability_mod"></span>)
           </button>
           <input name="attr_blufftalent1" value="2" title="Attribute: blufftalent1" type="checkbox" />
@@ -732,7 +735,7 @@
           <input class="sheet-skill-color-setting" name="attr_concentration_ability_mod" type="hidden" value="DEF" />
           <input class="sheet-skill-total" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
           <button class="sheet-skill-roller" name="roll_concentrationcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Concentration (<span name="attr_concentration_ability_mod"></span>)
           </button>
           <input name="attr_concentrationtalent1" value="2" title="Attribute: concentrationtalent1" type="checkbox" />
@@ -741,7 +744,7 @@
           <input class="sheet-skill-color-setting" name="attr_constitution_ability_mod" type="hidden" value="DEF" />
           <input class="sheet-skill-total" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
           <button class="sheet-skill-roller" name="roll_constitutioncheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Constitution (<span name="attr_constitution_ability_mod"></span>)
           </button>
           <input name="attr_constitutiontalent1" value="2" title="Attribute: constitutiontalent1" type="checkbox" />
@@ -750,7 +753,7 @@
           <input class="sheet-skill-color-setting" name="attr_diplomacy_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
           <button class="sheet-skill-roller" name="roll_diplomacycheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Diplomacy/Persuasion (<span name="attr_diplomacy_ability_mod"></span>)
           </button>
           <input name="attr_diplomacytalent1" value="2" title="Attribute: diplomacytalent1" type="checkbox" />
@@ -759,7 +762,7 @@
           <input class="sheet-skill-color-setting" name="attr_engineering_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
           <button class="sheet-skill-roller" name="roll_engineeringcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Engineering/Operation (<span name="attr_engineering_ability_mod"></span>)
           </button>
           <input name="attr_engineeringtalent1" value="2" title="Attribute: engineeringtalent1" type="checkbox" />
@@ -768,7 +771,7 @@
           <input class="sheet-skill-color-setting" name="attr_history_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
           <button class="sheet-skill-roller" name="roll_historycheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}">
             History (<span name="attr_history_ability_mod"></span>)
           </button>
           <input name="attr_historytalent1" value="2" title="Attribute: historytalent1" type="checkbox" />
@@ -777,7 +780,7 @@
           <input class="sheet-skill-color-setting" name="attr_insight_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
           <button class="sheet-skill-roller" name="roll_insightcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Insight (<span name="attr_insight_ability_mod"></span>)
           </button>
           <input name="attr_insighttalent1" value="2" title="Attribute: insighttalent1" type="checkbox" />
@@ -788,7 +791,7 @@
           <input class="sheet-skill-color-setting" name="attr_investigate_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
           <button class="sheet-skill-roller" name="roll_investigatecheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Investigate (<span name="attr_investigate_ability_mod"></span>)
           </button>
           <input name="attr_investigatetalent1" value="2" title="Attribute: investigatetalent1" type="checkbox" />
@@ -797,7 +800,7 @@
           <input class="sheet-skill-color-setting" name="attr_medicine_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
           <button class="sheet-skill-roller" name="roll_medicinecheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Medicine (<span name="attr_medicine_ability_mod"></span>)
           </button>
           <input name="attr_medicinetalent1" value="2" title="Attribute: medicinetalent1" type="checkbox" />
@@ -806,7 +809,7 @@
           <input class="sheet-skill-color-setting" name="attr_nature_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
           <button class="sheet-skill-roller" name="roll_naturecheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Nature (<span name="attr_nature_ability_mod"></span>)
           </button>
           <input name="attr_naturetalent1" value="2" title="Attribute: naturetalent1" type="checkbox" />
@@ -815,7 +818,7 @@
           <input class="sheet-skill-color-setting" name="attr_perception_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
           <button class="sheet-skill-roller" name="roll_perceptioncheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Perception (<span name="attr_perception_ability_mod"></span>)
           </button>
           <input name="attr_perceptiontalent1" value="2" title="Attribute: perceptiontalent1" type="checkbox" />
@@ -824,7 +827,7 @@
           <input class="sheet-skill-color-setting" name="attr_perform_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
           <button class="sheet-skill-roller" name="roll_performcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Perform (<span name="attr_perform_ability_mod"></span>)
           </button>
           <input name="attr_performtalent1" value="2" title="Attribute: performtalent1" type="checkbox" />
@@ -833,7 +836,7 @@
           <input class="sheet-skill-color-setting" name="attr_handling_ability_mod" type="hidden" value="SPDEF" />
           <input class="sheet-skill-total" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
           <button class="sheet-skill-roller" name="roll_handlingcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Pokémon Handling (<span name="attr_handling_ability_mod"></span>)
           </button>
           <input name="attr_handlingtalent1" value="2" title="Attribute: handlingtalent1" type="checkbox" />
@@ -841,7 +844,7 @@
           <input name="attr_handling" value="0" title="Attribute: handling" type="number" />
           <input class="sheet-skill-color-setting" name="attr_programming_ability_mod" type="hidden" value="SPATK" />
           <input class="sheet-skill-total" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll" value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}">
+          <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll" value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Programming (<span name="attr_programming_ability_mod"></span>)
           </button>
           <input name="attr_programmingtalent1" value="2" title="Attribute: programmingtalent1" type="checkbox" />
@@ -850,7 +853,7 @@
           <input class="sheet-skill-color-setting" name="attr_sleight_ability_mod" type="hidden" value="SPD" />
           <input class="sheet-skill-total" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
           <button class="sheet-skill-roller" name="roll_sleightofhandcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Sleight of Hand (<span name="attr_sleight_ability_mod"></span>)
           </button>
           <input name="attr_sleightofhandtalent1" value="2" title="Attribute: sleightofhandtalent1" type="checkbox" />
@@ -859,7 +862,7 @@
           <input class="sheet-skill-color-setting" name="attr_stealth_ability_mod" type="hidden" value="SPD" />
           <input class="sheet-skill-total" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
           <button class="sheet-skill-roller" name="roll_stealthcheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}">
             Stealth (<span name="attr_stealth_ability_mod"></span>)
           </button>
           <input name="attr_stealthtalent1" value="2" title="Attribute: stealthtalent1" type="checkbox" />
@@ -878,7 +881,7 @@
           <input class="sheet-skill-total" name="attr_capture_total" readonly title="The value added to your skill check to hit a Pokémon with a Pokéball. Note - this can be ignored if the target Pokémon is at or below half of their max HP.
           Attribute: capture_total" type="number" />
           <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
             Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
           </button>
           <input name="attr_capture_default_custom_modifier" type="hidden" value="0" />
@@ -933,7 +936,7 @@
           <input class="sheet-skill-total" name="attr_capture_total" readonly title="The value added to your skill check to hit a Pokémon with a Pokéball. Note - this can be ignored if the target Pokémon is at or below half of their max HP.
           Attribute: capture_total" type="number" />
           <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-            value="@{publicity_roll} &{template:skill-roll} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
+            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
             Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
           </button>
           <input name="attr_capture_roll_bonus" title="Use this field to assign a static modifier to your capture rolls - things like a Capture Specialist's Capture Point feature.
@@ -3336,6 +3339,26 @@
     </div>
   </rolltemplate>
 
+  <rolltemplate class="sheet-rolltemplate-inline-skill-roll">
+    <div class="sheet-container sheet-rolltemplate-color-setting-{{base-attribute}}-skill">
+      <div class="sheet-labelled-table-wrapper">
+        <span class="sheet-border-label">skill</span>
+        <table class="sheet-inline-skill-template">
+          <tbody>
+            <tr class="sheet-hide-on-mobile">
+              <td class="sheet-subhead">[performed by {{character-name}}](https://journal.roll20.net/character/{{character-id}}" name="name-link")</td>
+            </tr>
+            <tr>
+              <td class="sheet-label sheet-skill-roll">
+                <span>{{skill-name}}: {{skill-roll}}</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </rolltemplate>
+
   <rolltemplate class="sheet-rolltemplate-feature-output">
     <div class="sheet-container sheet-rolltemplate-color-setting-{{type-color}}-move">
       <table class="sheet-feature-template">
@@ -3375,6 +3398,24 @@
       setAttrs({
         publicity_label: publicityLabel,
         publicity_roll: publicityRoll,
+      });
+    });
+  });
+
+  on(`clicked:toggle-skill-template`, function () {
+    getAttrs(["skill_template_label"], function (values) {
+      const template = values["skill_template_label"];
+      var templateLabel = "Original Style";
+      var skillTemplate = "skill-roll";
+
+      if (template == templateLabel) {
+        templateLabel = "Redesigned Style";
+        skillTemplate = "inline-skill-roll";
+      }
+
+      setAttrs({
+        skill_template_label: templateLabel,
+        skill_template: skillTemplate,
       });
     });
   });

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -2,6 +2,9 @@
 <input class="sheet-color-setting" name="attr_active_type1" type="hidden" value="typeless" />
 <input class="sheet-form-setting" name="attr_display-form" type="hidden" value="" />
 <div class="sheet-wrapper">
+
+  <!-- PAGE SELECTION -->
+
   <div class="sheet-page-selection">
     <button class="sheet-page-selection-option" name="act_character-page" type="action">Character</button>
     <button class="sheet-page-selection-option" name="act_configuration-page" type="action">Configuration</button>
@@ -16,14 +19,14 @@
   <input class="sheet-selected-page" name="attr_selected-page" type="hidden" value="configuration-page" />
 
   <!-- CHARACTER PAGE -->
+
   <div class="sheet-character-page">
     <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
 
-    <p class="sheet-logo">
-      <img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/PokemonTabletopAdventures_v3/images/PTA3SmallLogo.png" />
-    </p>
+    <div class="sheet-logo"></div>
 
-    <!-- Form Activation buttons -->
+    <!-- FORM ACTIVATION BUTTONS -->
+
     <div class="sheet-tab-pokemon sheet-tab-hybrid">
       <div class="sheet-form-buttons">
         <input class="sheet-enable-tera" name="attr_enable-tera" readonly hidden type="checkbox" />
@@ -56,298 +59,333 @@
       </div>
     </div>
 
-    <div class="sheet-tab-trainer">
-      <div class="sheet-2col-centered">
-        <div class="sheet-character-name-grid">
-          <b>Name</b>
-          <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
-          <!-- Swap Origin and Honors order on the mobile sheets -->
-          <b class="sheet-show-on-mobile">Honors</b>
-          <input class="sheet-top-information sheet-show-on-mobile" name="attr_honor_count" title="Attribute: honor_count" type="number" />
-          <b>Origin</b>
-          <input class="sheet-top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
-          <b class="sheet-hide-on-mobile">Honors</b>
-          <input class="sheet-top-information sheet-hide-on-mobile" name="attr_honor_count" title="Attribute: honor_count" type="number" />
-          <b>Credits</b>
-          <input class="sheet-top-information sheet-long-number" name="attr_credits" title="Attribute: credits" type="number" />
-          <!-- Add extra space here on mobile -->
-          <p class="sheet-show-on-mobile"></br></p>
-        </div>
+    <!-- INFO SECTIONS -->
 
-        <div class="sheet-character-class-grid">
-          <b>Class</b>
-          <input class="sheet-top-information" name="attr_class1" spellcheck="false" title="Attribute: class1" type="text" />
-          <b>Level</b>
-          <input class="sheet-top-information" name="attr_level1" title="Attribute: level1" type="number" />
-          <b>Class</b>
-          <input class="sheet-top-information" name="attr_class2" spellcheck="false" title="Attribute: class2" type="text" />
-          <b>Level</b>
-          <input class="sheet-top-information" name="attr_level2" title="Attribute: level2" type="number" />
-          <b>Class</b>
-          <input class="sheet-top-information" name="attr_class3" spellcheck="false" title="Attribute: class3" type="text" />
-          <b>Level</b>
-          <input class="sheet-top-information" name="attr_level3" title="Attribute: level3" type="number" />
-          <b>Class</b>
-          <input class="sheet-top-information" name="attr_class4" spellcheck="false" title="Attribute: class4" type="text" />
-          <b>Level</b>
-          <input class="sheet-top-information" name="attr_level4" title="Attribute: level4" type="number" />
+    <div class="sheet-tab-trainer">
+      <div class="sheet-feature-container sheet-no-background">
+        <input checked class="sheet-options-flag" name="attr_info_header_options_flag" type="checkbox" />
+        <span name="attr_info_header">-</span>
+        <div class="sheet-display">
+          <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_class1"></span> (Level <span name="attr_level1"></span>)</h3>
+        </div>
+        <div class="sheet-options">
+          <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_class1"></span> (Level <span name="attr_level1"></span>)</h3>
+          <div class="sheet-2col-centered">
+            <div class="sheet-character-name-grid">
+              <b>Name</b>
+              <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
+              <!-- Swap Origin and Honors order on the mobile sheets -->
+              <b class="sheet-show-on-mobile">Honors</b>
+              <input class="sheet-top-information sheet-show-on-mobile" name="attr_honor_count" title="Attribute: honor_count" type="number" />
+              <b>Origin</b>
+              <input class="sheet-top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
+              <b class="sheet-hide-on-mobile">Honors</b>
+              <input class="sheet-top-information sheet-hide-on-mobile" name="attr_honor_count" title="Attribute: honor_count" type="number" />
+              <b>Credits</b>
+              <input class="sheet-top-information sheet-long-number" name="attr_credits" title="Attribute: credits" type="number" />
+              <!-- Add extra space here on mobile -->
+              <p class="sheet-show-on-mobile"></br></p>
+            </div>
+    
+            <div class="sheet-character-class-grid">
+              <b>Class</b>
+              <input class="sheet-top-information" name="attr_class1" spellcheck="false" title="Attribute: class1" type="text" />
+              <b>Level</b>
+              <input class="sheet-top-information" name="attr_level1" title="Attribute: level1" type="number" />
+              <b>Class</b>
+              <input class="sheet-top-information" name="attr_class2" spellcheck="false" title="Attribute: class2" type="text" />
+              <b>Level</b>
+              <input class="sheet-top-information" name="attr_level2" title="Attribute: level2" type="number" />
+              <b>Class</b>
+              <input class="sheet-top-information" name="attr_class3" spellcheck="false" title="Attribute: class3" type="text" />
+              <b>Level</b>
+              <input class="sheet-top-information" name="attr_level3" title="Attribute: level3" type="number" />
+              <b>Class</b>
+              <input class="sheet-top-information" name="attr_class4" spellcheck="false" title="Attribute: class4" type="text" />
+              <b>Level</b>
+              <input class="sheet-top-information" name="attr_level4" title="Attribute: level4" type="number" />
+            </div>
+          </div>
         </div>
       </div>
     </div>
 
     <div class="sheet-tab-pokemon">
-      <div class="sheet-2col-centered">
-        <div class="sheet-character-name-grid">
-          <b>Name</b>
-          <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
-          <b>Species</b>
-          <input class="sheet-top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" />
-          <input class="sheet-active_type-transformation" name="attr_active_type-transformation" readonly hidden type="checkbox" />
-          <div class="sheet-display-when-type-not-transformed">
-            <b>Type</b>
-          </div>
-          <div class="sheet-display-when-type-transformed">
-            <b>Type Shift</b>
-          </div>
-          <div class="sheet-display-when-type-not-transformed">
-            <span>
-              <select class="sheet-half-text sheet-no-dropdown" name="attr_type1" title="Attribute: type1">
-                <option value="bug">Bug</option>
-                <option value="dark">Dark</option>
-                <option value="dragon">Dragon</option>
-                <option value="electric">Electric</option>
-                <option value="fairy">Fairy</option>
-                <option value="fighting">Fighting</option>
-                <option value="fire">Fire</option>
-                <option value="flying">Flying</option>
-                <option value="ghost">Ghost</option>
-                <option value="grass">Grass</option>
-                <option value="ground">Ground</option>
-                <option value="ice">Ice</option>
-                <option value="normal">Normal</option>
-                <option value="poison">Poison</option>
-                <option value="psychic">Psychic</option>
-                <option value="rock">Rock</option>
-                <option value="steel">Steel</option>
-                <option value="typeless" selected>Typeless</option>
-                <option value="water">Water</option>
-              </select>
-              <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="Attribute: type2">
-                <option value=""></option>
-                <option value="bug">Bug</option>
-                <option value="dark">Dark</option>
-                <option value="dragon">Dragon</option>
-                <option value="electric">Electric</option>
-                <option value="fairy">Fairy</option>
-                <option value="fighting">Fighting</option>
-                <option value="fire">Fire</option>
-                <option value="flying">Flying</option>
-                <option value="ghost">Ghost</option>
-                <option value="grass">Grass</option>
-                <option value="ground">Ground</option>
-                <option value="ice">Ice</option>
-                <option value="normal">Normal</option>
-                <option value="poison">Poison</option>
-                <option value="psychic">Psychic</option>
-                <option value="rock">Rock</option>
-                <option value="steel">Steel</option>
-                <option value="typeless">Typeless</option>
-                <option value="water">Water</option>
-              </select>
-            </span>
-          </div>
-          <div class="sheet-display-when-type-transformed">
-            <span>
-              <input class="sheet-top-information sheet-half-text sheet-capitalize" name="attr_active_type1" readonly spellcheck="false" title="Attribute: active_type1" type="text" />
-              </select>
-              <input class="sheet-top-information sheet-half-text sheet-capitalize" name="attr_active_type2" readonly spellcheck="false" title="Attribute: active_type2" type="text" />
-              </select>
-            </span>
-          </div>
-          <b>Nature</b>
-          <select class="sheet-no-dropdown sheet-top-select" name="attr_nature-type" title="Attribute: nature-type">
-            <option value=""></option>
-            <option value="lonely">Lonely (+Atk, -Def)</option>
-            <option value="brave">Brave (+Atk, -Spd)</option>
-            <option value="adamant">Adamant (+Atk, -SpAtk)</option>
-            <option value="naughty">Naughty (+Atk, -SpDef)</option>
-            <option value="bold">Bold (+Def, -Atk)</option>
-            <option value="relaxed">Relaxed (+Def, -Spd)</option>
-            <option value="impish">Impish (+Def, -SpAtk)</option>
-            <option value="lax">Lax (+Def, -SpDef)</option>
-            <option value="timid">Timid (+Spd, -Atk)</option>
-            <option value="hasty">Hasty (+Spd, -Def)</option>
-            <option value="jolly">Jolly (+Spd, -SpAtk)</option>
-            <option value="naïve">Naïve (+Spd, -SpDef)</option>
-            <option value="modest">Modest (+SpAtk, -Atk)</option>
-            <option value="mild">Mild (+SpAtk, -Def)</option>
-            <option value="quiet">Quiet (+SpAtk, -Spd)</option>
-            <option value="rash">Rash (+SpAtk, -SpDef)</option>
-            <option value="calm">Calm (+SpDef, -Atk)</option>
-            <option value="gentle">Gentle (+SpDef, -Def)</option>
-            <option value="sassy">Sassy (+SpDef, -Spd)</option>
-            <option value="careful">Careful (+SpDef, -SpAtk)</option>
-            <option value="hardy">Hardy</option>
-            <option value="docile">Docile</option>
-            <option value="serious">Serious</option>
-            <option value="bashful">Bashful</option>
-            <option value="quirky">Quirky</option>
-            <option value="other">Other</option>
-          </select>
-          <!-- Moved to other column on Mobile -->
-          <b class="sheet-hide-on-mobile">Held Item</b>
-          <input class="sheet-top-information sheet-hide-on-mobile" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
-          <!-- Add extra space here on mobile -->
-          <p class="sheet-show-on-mobile"></br></p>
+      <div class="sheet-feature-container sheet-no-background">
+        <input checked class="sheet-options-flag" name="attr_info_header_options_flag" type="checkbox" />
+        <span name="attr_info_header">-</span>
+        <div class="sheet-display">
+          <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_species"></span></h3>
         </div>
+        <div class="sheet-options">
+          <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
+          <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_species"></span></h3>
+          <div class="sheet-2col-centered">
+            <div class="sheet-character-name-grid">
+              <b>Name</b>
+              <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
+              <b>Species</b>
+              <input class="sheet-top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" value="Pokémon" />
+              <input class="sheet-active_type-transformation" name="attr_active_type-transformation" readonly hidden type="checkbox" />
+              <div class="sheet-display-when-type-not-transformed">
+                <b>Type</b>
+              </div>
+              <div class="sheet-display-when-type-transformed">
+                <b>Type Shift</b>
+              </div>
+              <div class="sheet-display-when-type-not-transformed">
+                <span>
+                  <select class="sheet-half-text sheet-no-dropdown" name="attr_type1" title="Attribute: type1">
+                    <option value="bug">Bug</option>
+                    <option value="dark">Dark</option>
+                    <option value="dragon">Dragon</option>
+                    <option value="electric">Electric</option>
+                    <option value="fairy">Fairy</option>
+                    <option value="fighting">Fighting</option>
+                    <option value="fire">Fire</option>
+                    <option value="flying">Flying</option>
+                    <option value="ghost">Ghost</option>
+                    <option value="grass">Grass</option>
+                    <option value="ground">Ground</option>
+                    <option value="ice">Ice</option>
+                    <option value="normal">Normal</option>
+                    <option value="poison">Poison</option>
+                    <option value="psychic">Psychic</option>
+                    <option value="rock">Rock</option>
+                    <option value="steel">Steel</option>
+                    <option value="typeless" selected>Typeless</option>
+                    <option value="water">Water</option>
+                  </select>
+                  <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="Attribute: type2">
+                    <option value=""></option>
+                    <option value="bug">Bug</option>
+                    <option value="dark">Dark</option>
+                    <option value="dragon">Dragon</option>
+                    <option value="electric">Electric</option>
+                    <option value="fairy">Fairy</option>
+                    <option value="fighting">Fighting</option>
+                    <option value="fire">Fire</option>
+                    <option value="flying">Flying</option>
+                    <option value="ghost">Ghost</option>
+                    <option value="grass">Grass</option>
+                    <option value="ground">Ground</option>
+                    <option value="ice">Ice</option>
+                    <option value="normal">Normal</option>
+                    <option value="poison">Poison</option>
+                    <option value="psychic">Psychic</option>
+                    <option value="rock">Rock</option>
+                    <option value="steel">Steel</option>
+                    <option value="typeless">Typeless</option>
+                    <option value="water">Water</option>
+                  </select>
+                </span>
+              </div>
+              <div class="sheet-display-when-type-transformed">
+                <span>
+                  <input class="sheet-top-information sheet-half-text sheet-capitalize" name="attr_active_type1" readonly spellcheck="false" title="Attribute: active_type1" type="text" />
+                  </select>
+                  <input class="sheet-top-information sheet-half-text sheet-capitalize" name="attr_active_type2" readonly spellcheck="false" title="Attribute: active_type2" type="text" />
+                  </select>
+                </span>
+              </div>
+              <b>Nature</b>
+              <select class="sheet-no-dropdown sheet-top-select" name="attr_nature-type" title="Attribute: nature-type">
+                <option value=""></option>
+                <option value="lonely">Lonely (+Atk, -Def)</option>
+                <option value="brave">Brave (+Atk, -Spd)</option>
+                <option value="adamant">Adamant (+Atk, -SpAtk)</option>
+                <option value="naughty">Naughty (+Atk, -SpDef)</option>
+                <option value="bold">Bold (+Def, -Atk)</option>
+                <option value="relaxed">Relaxed (+Def, -Spd)</option>
+                <option value="impish">Impish (+Def, -SpAtk)</option>
+                <option value="lax">Lax (+Def, -SpDef)</option>
+                <option value="timid">Timid (+Spd, -Atk)</option>
+                <option value="hasty">Hasty (+Spd, -Def)</option>
+                <option value="jolly">Jolly (+Spd, -SpAtk)</option>
+                <option value="naïve">Naïve (+Spd, -SpDef)</option>
+                <option value="modest">Modest (+SpAtk, -Atk)</option>
+                <option value="mild">Mild (+SpAtk, -Def)</option>
+                <option value="quiet">Quiet (+SpAtk, -Spd)</option>
+                <option value="rash">Rash (+SpAtk, -SpDef)</option>
+                <option value="calm">Calm (+SpDef, -Atk)</option>
+                <option value="gentle">Gentle (+SpDef, -Def)</option>
+                <option value="sassy">Sassy (+SpDef, -Spd)</option>
+                <option value="careful">Careful (+SpDef, -SpAtk)</option>
+                <option value="hardy">Hardy</option>
+                <option value="docile">Docile</option>
+                <option value="serious">Serious</option>
+                <option value="bashful">Bashful</option>
+                <option value="quirky">Quirky</option>
+                <option value="other">Other</option>
+              </select>
+              <!-- Moved to other column on Mobile -->
+              <b class="sheet-hide-on-mobile">Held Item</b>
+              <input class="sheet-top-information sheet-hide-on-mobile" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
+              <!-- Add extra space here on mobile -->
+              <p class="sheet-show-on-mobile"></br></p>
+            </div>
 
-        <div class="sheet-character-name-grid">
-          <input class="sheet-active_dyna" name="attr_active_dyna" readonly hidden type="checkbox" />
-          <b>Size</b>
-          <div class="sheet-display-when-not-dyna">
-            <input class="sheet-top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
+            <div class="sheet-character-name-grid">
+              <input class="sheet-active_dyna" name="attr_active_dyna" readonly hidden type="checkbox" />
+              <b>Size</b>
+              <div class="sheet-display-when-not-dyna">
+                <input class="sheet-top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
+              </div>
+              <div class="sheet-display-when-dyna-inline">
+                <input class="sheet-top-information" name="dynasize" spellcheck="false" value="Dynamic" type="text" readonly />
+              </div>
+              <b>Weight</b>
+              <div class="sheet-display-when-not-dyna">
+                <input class="sheet-top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
+              </div>
+              <div class="sheet-display-when-dyna-inline">
+                <input class="sheet-top-information" name="dynaweight" spellcheck="false" value="Dynamic" type="text" readonly />
+              </div>
+              <b>Sex</b>
+              <input class="sheet-top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
+              <b>Diet</b>
+              <input class="sheet-top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
+              <!-- Moved here for Mobile, intentionally arranged with Egg Group for two-word sizes -->
+              <b class="sheet-show-on-mobile">Held Item</b>
+              <input class="sheet-top-information sheet-show-on-mobile" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
+              <b>Egg Group</b>
+              <input class="sheet-top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
+            </div>
           </div>
-          <div class="sheet-display-when-dyna-inline">
-            <input class="sheet-top-information" name="dynasize" spellcheck="false" value="Dynamic" type="text" readonly />
-          </div>
-          <b>Weight</b>
-          <div class="sheet-display-when-not-dyna">
-            <input class="sheet-top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
-          </div>
-          <div class="sheet-display-when-dyna-inline">
-            <input class="sheet-top-information" name="dynaweight" spellcheck="false" value="Dynamic" type="text" readonly />
-          </div>
-          <b>Sex</b>
-          <input class="sheet-top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
-          <b>Diet</b>
-          <input class="sheet-top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
-          <!-- Moved here for Mobile, intentionally arranged with Egg Group for two-word sizes -->
-          <b class="sheet-show-on-mobile">Held Item</b>
-          <input class="sheet-top-information sheet-show-on-mobile" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
-          <b>Egg Group</b>
-          <input class="sheet-top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
         </div>
       </div>
     </div>
 
     <div class="sheet-tab-hybrid">
-      <div class="sheet-2col-centered">
-        <div class="sheet-character-name-grid">
-          <b>Name</b>
-          <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
-          <b>Species</b>
-          <input class="sheet-top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" />
-          <b>Nature</b>
-          <select class="sheet-no-dropdown sheet-top-select" name="attr_nature-type" title="Attribute: nature-type">
-            <option value=""></option>
-            <option value="lonely">Lonely (+Atk, -Def)</option>
-            <option value="brave">Brave (+Atk, -Spd)</option>
-            <option value="adamant">Adamant (+Atk, -SpAtk)</option>
-            <option value="naughty">Naughty (+Atk, -SpDef)</option>
-            <option value="bold">Bold (+Def, -Atk)</option>
-            <option value="relaxed">Relaxed (+Def, -Spd)</option>
-            <option value="impish">Impish (+Def, -SpAtk)</option>
-            <option value="lax">Lax (+Def, -SpDef)</option>
-            <option value="timid">Timid (+Spd, -Atk)</option>
-            <option value="hasty">Hasty (+Spd, -Def)</option>
-            <option value="jolly">Jolly (+Spd, -SpAtk)</option>
-            <option value="naïve">Naïve (+Spd, -SpDef)</option>
-            <option value="modest">Modest (+SpAtk, -Atk)</option>
-            <option value="mild">Mild (+SpAtk, -Def)</option>
-            <option value="quiet">Quiet (+SpAtk, -Spd)</option>
-            <option value="rash">Rash (+SpAtk, -SpDef)</option>
-            <option value="calm">Calm (+SpDef, -Atk)</option>
-            <option value="gentle">Gentle (+SpDef, -Def)</option>
-            <option value="sassy">Sassy (+SpDef, -Spd)</option>
-            <option value="careful">Careful (+SpDef, -SpAtk)</option>
-            <option value="hardy">Hardy</option>
-            <option value="docile">Docile</option>
-            <option value="serious">Serious</option>
-            <option value="bashful">Bashful</option>
-            <option value="quirky">Quirky</option>
-            <option value="other">Other</option>
-          </select>
-          <b>Origin</b>
-          <input class="sheet-top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
-          <b>Level / Honors</b>
-          <span>
-            <input class="sheet-top-information" name="attr_level1" title="Attribute: level1" type="number" />
-            <input class="sheet-top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
-          </span>
-          <b>Advanced Class</b>
-          <input class="sheet-top-information" name="attr_pokemon_advanced_class" spellcheck="false" title="Attribute: pokemon_advanced_class" type="text" />
-          <b>Credits</b>
-          <input class="sheet-top-information sheet-long-number" name="attr_credits" title="Attribute: credits" type="number" />
+      <div class="sheet-feature-container sheet-no-background">
+        <input checked class="sheet-options-flag" name="attr_info_header_options_flag" type="checkbox" />
+        <span name="attr_info_header">-</span>
+        <div class="sheet-display">
+          <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_pokemon_advanced_class"></span> <span name="attr_species"></span> (Level <span name="attr_level1"></span>)</h3>
         </div>
+        <div class="sheet-options">
+          <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
+          <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_pokemon_advanced_class"></span> <span name="attr_species"></span> (Level <span name="attr_level1"></span>)</h3>
+          <div class="sheet-2col-centered">
+            <div class="sheet-character-name-grid">
+              <b>Name</b>
+              <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
+              <b>Species</b>
+              <input class="sheet-top-information" name="attr_species" spellcheck="false" title="Attribute: species" type="text" value="Pokémon" />
+              <b>Nature</b>
+              <select class="sheet-no-dropdown sheet-top-select" name="attr_nature-type" title="Attribute: nature-type">
+                <option value=""></option>
+                <option value="lonely">Lonely (+Atk, -Def)</option>
+                <option value="brave">Brave (+Atk, -Spd)</option>
+                <option value="adamant">Adamant (+Atk, -SpAtk)</option>
+                <option value="naughty">Naughty (+Atk, -SpDef)</option>
+                <option value="bold">Bold (+Def, -Atk)</option>
+                <option value="relaxed">Relaxed (+Def, -Spd)</option>
+                <option value="impish">Impish (+Def, -SpAtk)</option>
+                <option value="lax">Lax (+Def, -SpDef)</option>
+                <option value="timid">Timid (+Spd, -Atk)</option>
+                <option value="hasty">Hasty (+Spd, -Def)</option>
+                <option value="jolly">Jolly (+Spd, -SpAtk)</option>
+                <option value="naïve">Naïve (+Spd, -SpDef)</option>
+                <option value="modest">Modest (+SpAtk, -Atk)</option>
+                <option value="mild">Mild (+SpAtk, -Def)</option>
+                <option value="quiet">Quiet (+SpAtk, -Spd)</option>
+                <option value="rash">Rash (+SpAtk, -SpDef)</option>
+                <option value="calm">Calm (+SpDef, -Atk)</option>
+                <option value="gentle">Gentle (+SpDef, -Def)</option>
+                <option value="sassy">Sassy (+SpDef, -Spd)</option>
+                <option value="careful">Careful (+SpDef, -SpAtk)</option>
+                <option value="hardy">Hardy</option>
+                <option value="docile">Docile</option>
+                <option value="serious">Serious</option>
+                <option value="bashful">Bashful</option>
+                <option value="quirky">Quirky</option>
+                <option value="other">Other</option>
+              </select>
+              <b>Origin</b>
+              <input class="sheet-top-information" name="attr_origin" spellcheck="false" title="Attribute: origin" type="text" />
+              <b>Level / Honors</b>
+              <span>
+                <input class="sheet-top-information" name="attr_level1" title="Attribute: level1" type="number" />
+                <input class="sheet-top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
+              </span>
+              <b>Advanced Class</b>
+              <input class="sheet-top-information" name="attr_pokemon_advanced_class" spellcheck="false" title="Attribute: pokemon_advanced_class" type="text" value="Advanced"/>
+              <b>Credits</b>
+              <input class="sheet-top-information sheet-long-number" name="attr_credits" title="Attribute: credits" type="number" />
+            </div>
 
-        <div class="sheet-character-name-grid">
-          <b>Type</b>
-          <span>
-            <select class="sheet-half-text sheet-no-dropdown" name="attr_type1" title="type1">
-              <option value="bug">Bug</option>
-              <option value="dark">Dark</option>
-              <option value="dragon">Dragon</option>
-              <option value="electric">Electric</option>
-              <option value="fairy">Fairy</option>
-              <option value="fighting">Fighting</option>
-              <option value="fire">Fire</option>
-              <option value="flying">Flying</option>
-              <option value="ghost">Ghost</option>
-              <option value="grass">Grass</option>
-              <option value="ground">Ground</option>
-              <option value="ice">Ice</option>
-              <option value="normal">Normal</option>
-              <option value="poison">Poison</option>
-              <option value="psychic">Psychic</option>
-              <option value="rock">Rock</option>
-              <option value="steel">Steel</option>
-              <option value="typeless" selected>Typeless</option>
-              <option value="water">Water</option>
-            </select>
-            <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="type2">
-              <option value=""></option>
-              <option value="bug">Bug</option>
-              <option value="dark">Dark</option>
-              <option value="dragon">Dragon</option>
-              <option value="electric">Electric</option>
-              <option value="fairy">Fairy</option>
-              <option value="fighting">Fighting</option>
-              <option value="fire">Fire</option>
-              <option value="flying">Flying</option>
-              <option value="ghost">Ghost</option>
-              <option value="grass">Grass</option>
-              <option value="ground">Ground</option>
-              <option value="ice">Ice</option>
-              <option value="normal">Normal</option>
-              <option value="poison">Poison</option>
-              <option value="psychic">Psychic</option>
-              <option value="rock">Rock</option>
-              <option value="steel">Steel</option>
-              <option value="typeless">Typeless</option>
-              <option value="water">Water</option>
-            </select>
-          </span>
-          <b>Size / Weight</b>
-          <span>
-            <input class="sheet-half-text sheet-top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
-            <input class="sheet-half-text sheet-top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
-          </span>
-          <b>Sex</b>
-          <input class="sheet-top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
-          <b>Egg Group</b>
-          <input class="sheet-top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
-          <b>Diet</b>
-          <input class="sheet-top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
-          <b>Held Item</b>
-          <input class="sheet-top-information" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
+            <div class="sheet-character-name-grid">
+              <b>Type</b>
+              <span>
+                <select class="sheet-half-text sheet-no-dropdown" name="attr_type1" title="type1">
+                  <option value="bug">Bug</option>
+                  <option value="dark">Dark</option>
+                  <option value="dragon">Dragon</option>
+                  <option value="electric">Electric</option>
+                  <option value="fairy">Fairy</option>
+                  <option value="fighting">Fighting</option>
+                  <option value="fire">Fire</option>
+                  <option value="flying">Flying</option>
+                  <option value="ghost">Ghost</option>
+                  <option value="grass">Grass</option>
+                  <option value="ground">Ground</option>
+                  <option value="ice">Ice</option>
+                  <option value="normal">Normal</option>
+                  <option value="poison">Poison</option>
+                  <option value="psychic">Psychic</option>
+                  <option value="rock">Rock</option>
+                  <option value="steel">Steel</option>
+                  <option value="typeless" selected>Typeless</option>
+                  <option value="water">Water</option>
+                </select>
+                <select class="sheet-half-text sheet-no-dropdown" name="attr_type2" title="type2">
+                  <option value=""></option>
+                  <option value="bug">Bug</option>
+                  <option value="dark">Dark</option>
+                  <option value="dragon">Dragon</option>
+                  <option value="electric">Electric</option>
+                  <option value="fairy">Fairy</option>
+                  <option value="fighting">Fighting</option>
+                  <option value="fire">Fire</option>
+                  <option value="flying">Flying</option>
+                  <option value="ghost">Ghost</option>
+                  <option value="grass">Grass</option>
+                  <option value="ground">Ground</option>
+                  <option value="ice">Ice</option>
+                  <option value="normal">Normal</option>
+                  <option value="poison">Poison</option>
+                  <option value="psychic">Psychic</option>
+                  <option value="rock">Rock</option>
+                  <option value="steel">Steel</option>
+                  <option value="typeless">Typeless</option>
+                  <option value="water">Water</option>
+                </select>
+              </span>
+              <b>Size / Weight</b>
+              <span>
+                <input class="sheet-half-text sheet-top-information" name="attr_size" spellcheck="false" title="Attribute: size" type="text" />
+                <input class="sheet-half-text sheet-top-information" name="attr_weight" spellcheck="false" title="Attribute: weight" type="text" />
+              </span>
+              <b>Sex</b>
+              <input class="sheet-top-information" name="attr_pokemon_sex" spellcheck="false" title="Attribute: pokemon_sex" type="text" />
+              <b>Egg Group</b>
+              <input class="sheet-top-information" name="attr_egg_group" spellcheck="false" title="Attribute: egg_group" type="text" />
+              <b>Diet</b>
+              <input class="sheet-top-information" name="attr_diet" spellcheck="false" title="Attribute: diet" type="text" />
+              <b>Held Item</b>
+              <input class="sheet-top-information" name="attr_item" spellcheck="false" title="Attribute: item" type="text" />
+            </div>
+          </div>
         </div>
       </div>
     </div>
-
     <br />
 
+    <!-- AVATAR -->
+
     <div class="sheet-tab-trainer sheet-tab-pokemon sheet-tab-hybrid">
-      <div class="sheet-feature-container">
+      <div class="sheet-feature-container sheet-no-background">
         <input checked class="sheet-options-flag" name="attr_avatar_options_flag" type="checkbox" />
         <span name="attr_avatar_flag">-</span>
         <div class="sheet-display">
@@ -478,8 +516,10 @@
       </div>
     </div>
 
+    <!-- TRAINER STATS -->
+
     <div class="sheet-tab-trainer">
-      <div class="sheet-collapsible-feature">
+      <div class="sheet-collapsible-feature sheet-no-background">
         <input checked class="sheet-options-flag" name="attr_options_stat_flag" type="checkbox" />
         <span name="attr_stat_flag">-</span>
         <div class="sheet-display">
@@ -567,8 +607,10 @@
       </div>
     </div>
 
+    <!-- POKEMON STATS -->
+
     <div class="sheet-tab-pokemon sheet-tab-hybrid">
-      <div class="sheet-collapsible-feature">
+      <div class="sheet-collapsible-feature sheet-no-background">
         <input checked class="sheet-options-flag" name="attr_options_stat_flag" type="checkbox" />
         <span name="attr_stat_flag">-</span>
         <div class="sheet-display">
@@ -688,6 +730,8 @@
       <div class="sheet-display-when-custom2"><textarea class="sheet-2row-textarea-wide" name="attr_custom2-notes" placeholder="Additional Notes" spellcheck="false" title="Attribute: custom2-notes"></textarea></div>
       <div class="sheet-display-when-custom3"><textarea class="sheet-2row-textarea-wide" name="attr_custom3-notes" placeholder="Additional Notes" spellcheck="false" title="Attribute: custom3-notes"></textarea></div>
     </div>
+
+    <!-- SKILLS -->
 
     <div class="sheet-tab-trainer sheet-tab-pokemon sheet-tab-hybrid">
       <br />
@@ -872,6 +916,8 @@
       </div>
     </div>
 
+    <!-- CAPTURE POKEMON -->
+
     <div class="sheet-tab-trainer">
       <div>
         <hr class="sheet-skill-separator" />
@@ -992,77 +1038,92 @@
     <br />
 
     <div class="sheet-tab-trainer sheet-tab-hybrid">
-      <h3 class="sheet-section-header">Origin Feature</h3>
-      <input class="sheet-color-setting-feature" name="attr_feature_color" type="hidden" value="@{type1}" />
-      <div class="sheet-class-feature sheet-collapsible-feature">
-        <input checked class="sheet-options-flag" name="attr_origin_options_flag" type="checkbox" />
-        <span name="attr_origin_flag">-</span>
+      
+      <!-- ORIGIN FEATURE -->
+      
+      <div class="sheet-feature-container">
+        <input checked class="sheet-options-flag" name="attr_origin_feature_options_flag" type="checkbox" />
+        <span name="attr_origin_feature_flag">-</span>
         <div class="sheet-display">
-          <div class="sheet-class-feature-info-header">
-            <span class="sheet-fill-space">
-              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information." type="roll"
-              value="@{publicity_roll} &{template:feature-output} {{type-color=@{feature_color}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
-                <span name="attr_originfeaturename"></span>
-              </button>
-              <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information.">ℹ</b>
-            </span>
-            <span>
-              <b class="sheet-hide-on-mobile">Feature Usage</b>
-              <input name="attr_origin_usage" type="number" value="0" />
-              <button name="act_incrementoriginusage" type="action">+</button>
-              <button name="act_resetoriginusage" type="action">Reset</button>
-            </span>
-          </div>
+          <h3 class="sheet-section-header">Origin Feature</h3>
         </div>
         <div class="sheet-options">
-          <div class="sheet-pokemon-move-info-header">
-            <input name="attr_originfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
-            <span class="sheet-fill-space sheet-hide-on-mobile">
-              <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log." type="roll"
-              value="@{publicity_roll} &{template:feature-output} {{type-color=@{feature_color}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
-                  Send to Chat
-                </button>
-                <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log.">ℹ</b>
-            </span>
-            <span>
-              <b class="sheet-hide-on-mobile">Feature Usage</b>
-              <input name="attr_origin_usage" type="number" value="0" />
-              <button name="act_incrementoriginusage" type="action">+</button>
-              <button name="act_resetoriginusage" type="action">Reset</button>
-            </span>
+          <h3 class="sheet-section-header">Origin Feature</h3>
+          <input class="sheet-color-setting-feature" name="attr_feature_color" type="hidden" value="@{type1}" />
+          <div class="sheet-class-feature sheet-collapsible-feature">
+            <input checked class="sheet-options-flag" name="attr_origin_options_flag" type="checkbox" />
+            <span name="attr_origin_flag">-</span>
+            <div class="sheet-display">
+              <div class="sheet-class-feature-info-header">
+                <span class="sheet-fill-space">
+                  <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information." type="roll"
+                  value="@{publicity_roll} &{template:feature-output} {{type-color=@{feature_color}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
+                    <span name="attr_originfeaturename"></span>
+                  </button>
+                  <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log. Click the Plus to allow editing the information.">ℹ</b>
+                </span>
+                <span>
+                  <b class="sheet-hide-on-mobile">Feature Usage</b>
+                  <input name="attr_origin_usage" type="number" value="0" />
+                  <button name="act_incrementoriginusage" type="action">+</button>
+                  <button name="act_resetoriginusage" type="action">Reset</button>
+                </span>
+              </div>
+            </div>
+            <div class="sheet-options">
+              <div class="sheet-pokemon-move-info-header">
+                <input name="attr_originfeaturename" placeholder="Feature Name" spellcheck="false" type="text" />
+                <span class="sheet-fill-space sheet-hide-on-mobile">
+                  <button class="sheet-inline-roller sheet-skill-roller" name="roll-origin-feature-output" title="Click this to send this feature to the chat log." type="roll"
+                  value="@{publicity_roll} &{template:feature-output} {{type-color=@{feature_color}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{feature-name=@{originfeaturename}}} {{feature-text=@{originfeaturedesc}}}">
+                      Send to Chat
+                    </button>
+                    <b class="sheet-info-tooltip" title="Click this to send this feature to the chat log.">ℹ</b>
+                </span>
+                <span>
+                  <b class="sheet-hide-on-mobile">Feature Usage</b>
+                  <input name="attr_origin_usage" type="number" value="0" />
+                  <button name="act_incrementoriginusage" type="action">+</button>
+                  <button name="act_resetoriginusage" type="action">Reset</button>
+                </span>
+              </div>
+              <div class="sheet-class-feature-info-header">
+              <span>
+                <b>Select a Feature Color:</b>
+                <select class="sheet-no-dropdown" name="attr_feature_color" title="Attribute: feature_color">
+                  <option value="@{type1}" selected>Match Character Sheet</option>
+                  <option value="bug">Bug</option>
+                  <option value="dark">Dark</option>
+                  <option value="dragon">Dragon</option>
+                  <option value="electric">Electric</option>
+                  <option value="fairy">Fairy</option>
+                  <option value="fighting">Fighting</option>
+                  <option value="fire">Fire</option>
+                  <option value="flying">Flying</option>
+                  <option value="ghost">Ghost</option>
+                  <option value="grass">Grass</option>
+                  <option value="ground">Ground</option>
+                  <option value="ice">Ice</option>
+                  <option value="normal">Normal</option>
+                  <option value="poison">Poison</option>
+                  <option value="psychic">Psychic</option>
+                  <option value="rock">Rock</option>
+                  <option value="steel">Steel</option>
+                  <option value="typeless">Typeless</option>
+                  <option value="water">Water</option>
+                </select>
+                <b class="sheet-info-tooltip" title="Select a type to have this feature show in that color.">ℹ</b>
+              </span>
+            </div>
+              <textarea name="attr_originfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
+            </div>
           </div>
-          <div class="sheet-class-feature-info-header">
-          <span>
-            <b>Select a Feature Color:</b>
-            <select class="sheet-no-dropdown" name="attr_feature_color" title="Attribute: feature_color">
-              <option value="@{type1}" selected>Match Character Sheet</option>
-              <option value="bug">Bug</option>
-              <option value="dark">Dark</option>
-              <option value="dragon">Dragon</option>
-              <option value="electric">Electric</option>
-              <option value="fairy">Fairy</option>
-              <option value="fighting">Fighting</option>
-              <option value="fire">Fire</option>
-              <option value="flying">Flying</option>
-              <option value="ghost">Ghost</option>
-              <option value="grass">Grass</option>
-              <option value="ground">Ground</option>
-              <option value="ice">Ice</option>
-              <option value="normal">Normal</option>
-              <option value="poison">Poison</option>
-              <option value="psychic">Psychic</option>
-              <option value="rock">Rock</option>
-              <option value="steel">Steel</option>
-              <option value="typeless">Typeless</option>
-              <option value="water">Water</option>
-            </select>
-            <b class="sheet-info-tooltip" title="Select a type to have this feature show in that color.">ℹ</b>
-          </span>
-        </div>
-          <textarea name="attr_originfeaturedesc" placeholder="Feature Description" spellcheck="false"></textarea>
         </div>
       </div>
       <br />
+
+      <!-- CLASS FEATURES -->
+
       <div class="sheet-feature-container">
         <input checked class="sheet-options-flag" name="attr_class_features_options_flag" type="checkbox" />
         <span name="attr_class_features_flag">-</span>
@@ -1147,282 +1208,353 @@
       <br />
     </div>
 
+    <!-- PASSIVES -->
+
     <div class="sheet-tab-hybrid sheet-tab-pokemon">
-      <b>Skills</b>
-      <textarea class="sheet-3row-textarea" name="attr_pokemonskills" placeholder="Capabilities to be used both in and out of battle, such as Firestarter, Invisibility, and Telekinetic" spellcheck="false" title="Attribute: pokemonskills"></textarea>
-
-      <b>Stat Passives</b>
-      <textarea class="sheet-3row-textarea" name="attr_statpassives" placeholder="Passives that affect Pokémon stats, such as Nasty Plot and Play Nice" spellcheck="false" title="Attribute: statpassives"></textarea>
-
-      <b>Other Passives</b>
-      <textarea class="sheet-4row-textarea" name="attr_otherpassives" placeholder="Passives that do not affect stats, such as Cute Charm and Static" spellcheck="false" title="Attribute: otherpassives"></textarea>
-    </div>
-
-    <b>Modifiers for All Moves</b>
-    <div>
-      <span class="sheet-move-modifiers">
-        <span>
-          <b title="This value will be added to all accuracy checks">Accuracy Modifier</b>
-          <b class="sheet-info-tooltip" title="This value will be added to all accuracy checks">ℹ</b>
-          <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusaccuracy" title="Attribute: move_bonusaccuracy" type="number" value="0" />
-        </span>
-        <span>
-          <b title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold">Critical Threshold</b>
-          <b class="sheet-info-tooltip" title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold">ℹ</b>
-          <input class="sheet-top-information sheet-thin-number" max="20" min="1" name="attr_move_critthreshold" title="Attribute: move_critthreshold" type="number" value="20" />
-        </span>
-        <span>
-          <b title="Additional damage for moves that use the Attack stat, such as for Ace Trainer">Attack Damage Bonus</b>
-          <b class="sheet-info-tooltip" title="Additional damage for moves that use the Attack stat, such as for Ace Trainer">ℹ</b>
-          <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusattack" title="Attribute: move_bonusattack" type="number" value="0" />
-        </span>
-        <span>
-          <b title="Additional damage for moves that use the Special Attack stat, such as for Ace Trainer">Special Attack Damage Bonus</b>
-          <b class="sheet-info-tooltip" title="Additional damage for moves that use the Special Attack stat, such as for Ace Trainer">ℹ</b>
-          <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusspecialattack" title="Attribute: move_bonusspecialattack" type="number" value="0" />
-        </span>
-      </span>
-    </div>
-
-    <h3 class="sheet-section-header">Moves</h3>
-    <fieldset class="repeating_moves">
-      <input name="attr_move_category_defense" type="hidden" />
-      <input class="sheet-color-setting-move" name="attr_move_type" type="hidden" value="typeless" />
-      <div class="sheet-pokemon-move">
-        <input checked class="sheet-options-flag" name="attr_options_flag" type="checkbox" />
-        <span name="attr_flag">-</span>
+      <div class="sheet-feature-container">
+        <input checked class="sheet-options-flag" name="attr_passives_options_flag" type="checkbox" />
+        <span name="attr_passives_flag">-</span>
         <div class="sheet-display">
-          <div class="sheet-pokemon-move-info-header">
-            <span class="sheet-fill-space">
-              <button class="sheet-inline-roller sheet-skill-roller" name="roll-movetemplate" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} @{attack_rolls}">
-                <span name="attr_move_name"></span>
-              </button>
-              <b class="sheet-info-tooltip" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness.">ℹ</b>
-            </span>
+          <h3 class="sheet-section-header">Passives</h3>
+        </div>
+        <div class="sheet-options">
+          <h3 class="sheet-section-header">Passives</h3>
+          <b>Skills</b>
+          <textarea class="sheet-3row-textarea" name="attr_pokemonskills" placeholder="Capabilities to be used both in and out of battle, such as Firestarter, Invisibility, and Telekinetic" spellcheck="false" title="Attribute: pokemonskills"></textarea>
+          <b>Stat Passives</b>
+          <textarea class="sheet-3row-textarea" name="attr_statpassives" placeholder="Passives that affect Pokémon stats, such as Nasty Plot and Play Nice" spellcheck="false" title="Attribute: statpassives"></textarea>
+          <b>Other Passives</b>
+          <textarea class="sheet-4row-textarea" name="attr_otherpassives" placeholder="Passives that do not affect stats, such as Cute Charm and Static" spellcheck="false" title="Attribute: otherpassives"></textarea>
+        </div>
+      </div>
+      <br />
+    </div>
 
-            <span class="sheet-fill-space sheet-hide-on-mobile">
-              <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} @{quick_attack_rolls}">
-                Quick Roll
-              </button>
-              <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
-            </span>
-
+    <!-- MOVES -->
+    
+    <div class="sheet-feature-container sheet-extra-max-height">
+      <input checked class="sheet-options-flag" name="attr_moves_options_flag" type="checkbox" />
+      <span name="attr_moves_flag">-</span>
+      <div class="sheet-display">
+        <h3 class="sheet-section-header">Moves</h3>
+      </div>
+      <div class="sheet-options">
+        <h3 class="sheet-section-header">Moves</h3>
+        <b>Modifiers for All Moves</b>
+        <div>
+          <span class="sheet-move-modifiers">
             <span>
-              <b class="sheet-hide-on-mobile">Move Usage</b>
-              <input name="attr_move_usage" title="Attribute: move_usage" type="number" value="0" />
-              <button name="act_incrementmoveusage" type="action">+</button>
-              <button name="act_resetmoveusage" type="action">Reset</button>
+              <b title="This value will be added to all accuracy checks">Accuracy Modifier</b>
+              <b class="sheet-info-tooltip" title="This value will be added to all accuracy checks">ℹ</b>
+              <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusaccuracy" title="Attribute: move_bonusaccuracy" type="number" value="0" />
             </span>
+            <span>
+              <b title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold">Critical Threshold</b>
+              <b class="sheet-info-tooltip" title="Modify to change critical hits based on the dice roll, as per Focus Energy and Super Luck. For moves like Slash, see Effect Threshold">ℹ</b>
+              <input class="sheet-top-information sheet-thin-number" max="20" min="1" name="attr_move_critthreshold" title="Attribute: move_critthreshold" type="number" value="20" />
+            </span>
+            <span>
+              <b title="Additional damage for moves that use the Attack stat, such as for Ace Trainer">Attack Damage Bonus</b>
+              <b class="sheet-info-tooltip" title="Additional damage for moves that use the Attack stat, such as for Ace Trainer">ℹ</b>
+              <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusattack" title="Attribute: move_bonusattack" type="number" value="0" />
+            </span>
+            <span>
+              <b title="Additional damage for moves that use the Special Attack stat, such as for Ace Trainer">Special Attack Damage Bonus</b>
+              <b class="sheet-info-tooltip" title="Additional damage for moves that use the Special Attack stat, such as for Ace Trainer">ℹ</b>
+              <input class="sheet-top-information sheet-thin-number" name="attr_move_bonusspecialattack" title="Attribute: move_bonusspecialattack" type="number" value="0" />
+            </span>
+          </span>
+        </div>    
+        <fieldset class="repeating_moves">
+          <input name="attr_move_category_defense" type="hidden" />
+          <input class="sheet-color-setting-move" name="attr_move_type" type="hidden" value="typeless" />
+          <div class="sheet-pokemon-move">
+            <input checked class="sheet-options-flag" name="attr_options_flag" type="checkbox" />
+            <span name="attr_flag">-</span>
+            <div class="sheet-display">
+              <div class="sheet-pokemon-move-info-header">
+                <span class="sheet-fill-space">
+                  <button class="sheet-inline-roller sheet-skill-roller" name="roll-movetemplate" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness." type="roll"
+                    value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} @{attack_rolls}">
+                    <span name="attr_move_name"></span>
+                  </button>
+                  <b class="sheet-info-tooltip" title="Click this to roll this attack with the option of choosing temporary modifiers or effectiveness.">ℹ</b>
+                </span>
+
+                <span class="sheet-fill-space sheet-hide-on-mobile">
+                  <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
+                    value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} @{quick_attack_rolls}">
+                    Quick Roll
+                  </button>
+                  <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
+                </span>
+
+                <span>
+                  <b class="sheet-hide-on-mobile">Move Usage</b>
+                  <input name="attr_move_usage" title="Attribute: move_usage" type="number" value="0" />
+                  <button name="act_incrementmoveusage" type="action">+</button>
+                  <button name="act_resetmoveusage" type="action">Reset</button>
+                </span>
+              </div>
+              <div class="sheet-pokemon-move-info-grid-3">
+                <span class="sheet-readonly-field">
+                  <b>Accuracy Roll:</b>
+                  <input name="attr_move_totalaccuracy" type="hidden" />
+                  <input class="sheet-top-information sheet-total-display" name="attr_move_totalaccuracy_display" readonly title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)" type="text" value="d20 + 0" />
+                </span>
+
+                <span class="sheet-readonly-field">
+                  <b>Damage Roll:</b>
+                  <input name="attr_move_totaldamage" type="hidden" />
+                  <input class="sheet-top-information sheet-total-display" name="attr_move_totaldamage_display" readonly title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)" type="text" value="" />
+                </span>
+
+              </div>
+            </div>
+
+            <div class="sheet-options">
+              <div class="sheet-pokemon-move-info-header">
+                <input name="attr_move_name" placeholder="Move" spellcheck="false" title="Attribute: move_name" type="text" />
+
+                <span class="sheet-fill-space sheet-hide-on-mobile">
+                  <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
+                    value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} @{quick_attack_rolls}">
+                    Quick Roll
+                  </button>
+                  <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
+                </span>
+
+                <span>
+                  <b class="sheet-hide-on-mobile">Move Usage</b>
+                  <input name="attr_move_usage" title="Attribute: move_usage" type="number" value="0" />
+                  <button name="act_incrementmoveusage" type="action">+</button>
+                  <button name="act_resetmoveusage" type="action">Reset</button>
+                </span>
+              </div>
+
+              <div class="sheet-pokemon-move-info-grid-1">
+                <input class="sheet-move-text" name="attr_move_range" placeholder="Range" spellcheck="false" title="Attribute: move_range" type="text" />
+                <select class="sheet-move-text sheet-no-dropdown" name="attr_move_type" title="Attribute: move_type">
+                  <option value="bug">Bug</option>
+                  <option value="dark">Dark</option>
+                  <option value="dragon">Dragon</option>
+                  <option value="electric">Electric</option>
+                  <option value="fairy">Fairy</option>
+                  <option value="fighting">Fighting</option>
+                  <option value="fire">Fire</option>
+                  <option value="flying">Flying</option>
+                  <option value="ghost">Ghost</option>
+                  <option value="grass">Grass</option>
+                  <option value="ground">Ground</option>
+                  <option value="ice">Ice</option>
+                  <option value="normal">Normal</option>
+                  <option value="poison">Poison</option>
+                  <option value="psychic">Psychic</option>
+                  <option value="rock">Rock</option>
+                  <option value="steel">Steel</option>
+                  <option value="typeless" selected>Typeless</option>
+                  <option value="water">Water</option>
+                </select>
+                <select class="sheet-move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
+                  <option value="0">Category</option>
+                  <option value="1">Attack</option>
+                  <option value="2">Special Attack</option>
+                  <option value="3">Effect</option>
+                </select>
+                <select class="sheet-move-text sheet-no-dropdown" name="attr_move_frequency" title="Attribute: move_frequency">
+                  <option value="">Frequency</option>
+                  <option value="atwill">At-Will</option>
+                  <!-- 1day and 3day are switched, I know, but if we fix it we mess up existing sheets -->
+                  <option value="1day">3/day</option>
+                  <option value="3day">1/day</option>
+                  <option value="1combat">1/combat</option>
+                </select>
+
+                <span>
+                  <b>Damage</b>
+                  <input class="sheet-damage-dice-count sheet-top-information" name="attr_move_dicenumber" title="Attribute: move_dicenumber" type="number" value="0" />
+                  <select class="sheet-damage-dice" name="attr_damage_dice">
+                    <option value="4">d4</option>
+                    <option value="6">d6</option>
+                    <option value="8">d8</option>
+                    <option value="10">d10</option>
+                    <option value="12">d12</option>
+                    <option value="20">d20</option>
+                  </select>
+                </span>
+              </div>
+
+              <div class="sheet-pokemon-move-info-grid-2">
+                <span>
+                  <b>Accuracy Modifier</b>
+                  <input class="sheet-top-information sheet-thin-number" name="attr_move_acmod" title="Attribute: move_acmod" type="number" value="0" />
+                </span>
+
+                <span>
+                  <b>Extra Damage</b>
+                  <input class="sheet-top-information sheet-thin-number" name="attr_move_damagebonus" title="Attribute: move_damagebonus" type="number" value="0" />
+                </span>
+
+                <span>
+                  <b title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">Scatter</b>
+                  <b class="sheet-info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">ℹ</b>
+                </span>
+                <span>
+                  <input name="attr_attack_rolls" type="hidden" value="{{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}}"/>
+                  <input name="attr_quick_attack_rolls" type="hidden" value="{{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}}" />
+                  <select class="sheet-move-text" name="attr_move_template" title="Attribute: move_template">
+                    <option value="move-roll" selected>One Hit</option>
+                    <option value="dual-hit-move-roll">Two Hits</option>
+                    <option value="triple-hit-move-roll">Three Hits</option>
+                    <option value="multi-hit-move-roll">Up to Five Hits</option>
+                    <option value="ten-hit-move-roll">Up to Ten Hits</option>
+          </select>
+                </span>
+
+                <span>
+                  <b title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">Effect Threshold</b>
+                  <b class="sheet-info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
+                  <input class="sheet-top-information sheet-thin-number" max="20" min="0" name="attr_move_effect1_threshold" title="Attribute: move_effect1_threshold" type="number" value="0" />
+                </span>
+
+                <span>
+                  <select class="sheet-move-text" name="attr_move_effect1" title="Attribute: move_effect1_name (move_effect1 for the numerical value used in calculations)">
+                    <option value="98" selected>None</option>
+                    <option value="99">Critical Hit</option>
+                    <option value="1">Asleep</option>
+                    <option value="2">Burned</option>
+                    <option value="3">Confused</option>
+                    <option value="4">Cursed</option>
+                    <option value="5">Frozen</option>
+                    <option value="6">Infatuated</option>
+                    <option value="7">Paralyzed</option>
+                    <option value="8">Poisoned</option>
+                    <option value="9">Toxified</option>
+                    <option value="10">Stunned</option>
+                    <option value="11">Other</option>
+                  </select>
+                  <input type="hidden" name="attr_move_effect1_name" />
+                  <b class="sheet-info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop">ℹ</b>
+                </span>
+
+                <span>
+                  <b>Effect Threshold</b>
+                  <input class="sheet-top-information sheet-thin-number" max="20" min="0" name="attr_move_effect2_threshold" title="Attribute: move_effect2_threshold" type="number" value="0" />
+                </span>
+
+                <span>
+                  <input name="attr_move_effect2_name" type="hidden" />
+                  <select class="sheet-move-text" name="attr_move_effect2" title="Attribute: move_effect2_name (move_effect2 for the numerical value used in calculations)">
+                    <option value="98" selected>None</option>
+                    <option value="1">Asleep</option>
+                    <option value="2">Burned</option>
+                    <option value="3">Confused</option>
+                    <option value="4">Cursed</option>
+                    <option value="5">Frozen</option>
+                    <option value="6">Infatuated</option>
+                    <option value="7">Paralyzed</option>
+                    <option value="8">Poisoned</option>
+                    <option value="9">Toxified</option>
+                    <option value="10">Stunned</option>
+                    <option value="11">Other</option>
+                  </select>
+                </span>
+              </div>
+
+              <div class="sheet-pokemon-move-info-grid-3">
+                <span class="sheet-readonly-field">
+                  <b>Accuracy Roll:</b>
+                  <input name="attr_move_totalaccuracy" type="hidden" />
+                  <input class="sheet-top-information sheet-total-display" name="attr_move_totalaccuracy_display" readonly title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)" type="text" value="d20 + 0" />
+                </span>
+
+                <span class="sheet-readonly-field">
+                  <b>Damage Roll:</b>
+                  <input name="attr_move_totaldamage" type="hidden" />
+                  <input class="sheet-top-information sheet-total-display" name="attr_move_totaldamage_display" readonly title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)" type="text" value="" />
+                </span>
+
+              </div>          
+
+              <div class="sheet-move-notes-roller">
+                <textarea class="sheet-3row-textarea" name="attr_move_effect" placeholder="Additional Effect Notes" spellcheck="false" title="Attribute: move_effect"></textarea>
+                <button class="sheet-move-roller" name="roll-movetemplate" type="roll"
+                  value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} @{attack_rolls}">
+                  T
+                </button>
+              </div>
+            </div>
           </div>
-          <div class="sheet-pokemon-move-info-grid-3">
-            <span class="sheet-readonly-field">
-              <b>Accuracy Roll:</b>
-              <input name="attr_move_totalaccuracy" type="hidden" />
-              <input class="sheet-top-information sheet-total-display" name="attr_move_totalaccuracy_display" readonly title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)" type="text" value="d20 + 0" />
-            </span>
+        </fieldset>
+      </div>
+    </div>
+    <br />
 
-            <span class="sheet-readonly-field">
-              <b>Damage Roll:</b>
-              <input name="attr_move_totaldamage" type="hidden" />
-              <input class="sheet-top-information sheet-total-display" name="attr_move_totaldamage_display" readonly title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)" type="text" value="" />
-            </span>
+    <!-- NOTES -->
 
+    <div class="sheet-feature-container">
+      <input checked class="sheet-options-flag" name="attr_notes_options_flag" type="checkbox" />
+      <span name="attr_notes_flag">-</span>
+      <div class="sheet-display">
+        <h3 class="sheet-section-header">Notes</h3>
+      </div>
+      <div class="sheet-options">
+        <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
+        <h3 class="sheet-section-header">Notes</h3>
+        <div class="sheet-tab-hybrid sheet-tab-trainer">
+          <div class="sheet-feature-container">
+            <input checked class="sheet-options-flag" name="attr_notes_inventory_options_flag" type="checkbox" />
+            <span name="attr_notes_inventory_flag">.</span>
+            <div class="sheet-display">
+              <b class="sheet-subsection-header">Inventory</b>
+            </div>
+            <div class="sheet-options">
+              <b class="sheet-subsection-header">Inventory</b>
+              <textarea name="attr_inventory" placeholder="Pokéballs, Berries, Medicine, Accessories, etc." spellcheck="false" title="Attribute: inventory"></textarea>
+            </div>
+          </div>
+
+          <div class="sheet-feature-container">
+            <input checked class="sheet-options-flag" name="attr_notes_honors_options_flag" type="checkbox" />
+            <span name="attr_notes_honors_flag">.</span>
+            <div class="sheet-display">
+              <b class="sheet-subsection-header">Honors</b>
+            </div>
+            <div class="sheet-options">
+              <b class="sheet-subsection-header">Honors</b>
+              <textarea spellcheck="false" name="attr_honors" placeholder="Gym Badges, Contest Ribbons, Recognitions, etc."></textarea>
+            </div>
           </div>
         </div>
 
-        <div class="sheet-options">
-          <div class="sheet-pokemon-move-info-header">
-            <input name="attr_move_name" placeholder="Move" spellcheck="false" title="Attribute: move_name" type="text" />
-
-            <span class="sheet-fill-space sheet-hide-on-mobile">
-              <button class="sheet-inline-roller sheet-skill-roller" name="roll-quick-move" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers." type="roll"
-                value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=0}} {{effectiveness-roll=[[2]]}} {{critical-damage=[[ @{move_dicenumber} * @{damage_dice} + @{move_totaldamage} ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ @{move_dicenumber} * @{damage_dice} ]]}} @{quick_attack_rolls}">
-                Quick Roll
-              </button>
-              <b class="sheet-info-tooltip" title="Click this to roll this attack without the fuss of choosing temporary modifiers or effectiveness - it will be rolled with Neutral effectiveness, and no modifiers.">ℹ</b>
-            </span>
-
-            <span>
-              <b class="sheet-hide-on-mobile">Move Usage</b>
-              <input name="attr_move_usage" title="Attribute: move_usage" type="number" value="0" />
-              <button name="act_incrementmoveusage" type="action">+</button>
-              <button name="act_resetmoveusage" type="action">Reset</button>
-            </span>
+        <div class="sheet-tab-trainer">
+          <div class="sheet-feature-container">
+            <input checked class="sheet-options-flag" name="attr_notes_owned_options_flag" type="checkbox" />
+            <span name="attr_notes_owned_flag">.</span>
+            <div class="sheet-display">
+              <b class="sheet-subsection-header">Owned Pokémon</b>
+            </div>
+            <div class="sheet-options">
+              <b class="sheet-subsection-header">Owned Pokémon</b>
+              <textarea name="attr_ownedpokemon" placeholder="All Pokémon owned by this Trainer" spellcheck="false" title="Attribute: ownedpokemon"></textarea>
+            </div>
           </div>
+        </div>
 
-          <div class="sheet-pokemon-move-info-grid-1">
-            <input class="sheet-move-text" name="attr_move_range" placeholder="Range" spellcheck="false" title="Attribute: move_range" type="text" />
-            <select class="sheet-move-text sheet-no-dropdown" name="attr_move_type" title="Attribute: move_type">
-              <option value="bug">Bug</option>
-              <option value="dark">Dark</option>
-              <option value="dragon">Dragon</option>
-              <option value="electric">Electric</option>
-              <option value="fairy">Fairy</option>
-              <option value="fighting">Fighting</option>
-              <option value="fire">Fire</option>
-              <option value="flying">Flying</option>
-              <option value="ghost">Ghost</option>
-              <option value="grass">Grass</option>
-              <option value="ground">Ground</option>
-              <option value="ice">Ice</option>
-              <option value="normal">Normal</option>
-              <option value="poison">Poison</option>
-              <option value="psychic">Psychic</option>
-              <option value="rock">Rock</option>
-              <option value="steel">Steel</option>
-              <option value="typeless" selected>Typeless</option>
-              <option value="water">Water</option>
-            </select>
-            <select class="sheet-move-text sheet-no-dropdown" name="attr_move_category" title="Attribute: move_category">
-              <option value="0">Category</option>
-              <option value="1">Attack</option>
-              <option value="2">Special Attack</option>
-              <option value="3">Effect</option>
-            </select>
-            <select class="sheet-move-text sheet-no-dropdown" name="attr_move_frequency" title="Attribute: move_frequency">
-              <option value="">Frequency</option>
-              <option value="atwill">At-Will</option>
-              <!-- 1day and 3day are switched, I know, but if we fix it we mess up existing sheets -->
-              <option value="1day">3/day</option>
-              <option value="3day">1/day</option>
-              <option value="1combat">1/combat</option>
-            </select>
-
-            <span>
-              <b>Damage</b>
-              <input class="sheet-damage-dice-count sheet-top-information" name="attr_move_dicenumber" title="Attribute: move_dicenumber" type="number" value="0" />
-              <select class="sheet-damage-dice" name="attr_damage_dice">
-                <option value="4">d4</option>
-                <option value="6">d6</option>
-                <option value="8">d8</option>
-                <option value="10">d10</option>
-                <option value="12">d12</option>
-                <option value="20">d20</option>
-              </select>
-            </span>
+        <div class="sheet-feature-container">
+          <input checked class="sheet-options-flag" name="attr_notes_notes_options_flag" type="checkbox" />
+          <span name="attr_notes_notes_flag">.</span>
+          <div class="sheet-display">
+            <b class="sheet-subsection-header">General Notes</b>
           </div>
-
-          <div class="sheet-pokemon-move-info-grid-2">
-            <span>
-              <b>Accuracy Modifier</b>
-              <input class="sheet-top-information sheet-thin-number" name="attr_move_acmod" title="Attribute: move_acmod" type="number" value="0" />
-            </span>
-
-            <span>
-              <b>Extra Damage</b>
-              <input class="sheet-top-information sheet-thin-number" name="attr_move_damagebonus" title="Attribute: move_damagebonus" type="number" value="0" />
-            </span>
-
-            <span>
-              <b title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">Scatter</b>
-              <b class="sheet-info-tooltip" title="Choose the Scatter type of the attack. This will effect which roll template is used for the chat log output.">ℹ</b>
-            </span>
-            <span>
-              <input name="attr_attack_rolls" type="hidden" value="{{accuracy=[[ d20cf0cs>@{move_critthreshold} + [[ @{move_totalaccuracy} + ?{Temp Accuracy Bonus|0} ]] ]]}} {{damage=[[ ([[@{move_dicenumber} + ?{Effectiveness}]])d@{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus}]] ]]}}"/>
-              <input name="attr_quick_attack_rolls" type="hidden" value="{{accuracy=[[ d20cf0cs>@{move_critthreshold} + @{move_totalaccuracy} ]]}} {{damage=[[ @{move_dicenumber}d@{damage_dice} + @{move_totaldamage} ]]}}" />
-              <select class="sheet-move-text" name="attr_move_template" title="Attribute: move_template">
-                <option value="move-roll" selected>One Hit</option>
-                <option value="dual-hit-move-roll">Two Hits</option>
-                <option value="triple-hit-move-roll">Three Hits</option>
-                <option value="multi-hit-move-roll">Up to Five Hits</option>
-                <option value="ten-hit-move-roll">Up to Ten Hits</option>
-      </select>
-            </span>
-
-            <span>
-              <b title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">Effect Threshold</b>
-              <b class="sheet-info-tooltip" title="Enter the value shown in the move notes for effects like Burned, Poisoned, and Stunned">ℹ</b>
-              <input class="sheet-top-information sheet-thin-number" max="20" min="0" name="attr_move_effect1_threshold" title="Attribute: move_effect1_threshold" type="number" value="0" />
-            </span>
-
-            <span>
-              <select class="sheet-move-text" name="attr_move_effect1" title="Attribute: move_effect1_name (move_effect1 for the numerical value used in calculations)">
-                <option value="98" selected>None</option>
-                <option value="99">Critical Hit</option>
-                <option value="1">Asleep</option>
-                <option value="2">Burned</option>
-                <option value="3">Confused</option>
-                <option value="4">Cursed</option>
-                <option value="5">Frozen</option>
-                <option value="6">Infatuated</option>
-                <option value="7">Paralyzed</option>
-                <option value="8">Poisoned</option>
-                <option value="9">Toxified</option>
-                <option value="10">Stunned</option>
-                <option value="11">Other</option>
-              </select>
-              <input type="hidden" name="attr_move_effect1_name" />
-              <b class="sheet-info-tooltip" title="Choose Critical Hit for moves where a high accuracy check scores a critical hit, like Slash and Karate Chop">ℹ</b>
-            </span>
-
-            <span>
-              <b>Effect Threshold</b>
-              <input class="sheet-top-information sheet-thin-number" max="20" min="0" name="attr_move_effect2_threshold" title="Attribute: move_effect2_threshold" type="number" value="0" />
-            </span>
-
-            <span>
-              <input name="attr_move_effect2_name" type="hidden" />
-              <select class="sheet-move-text" name="attr_move_effect2" title="Attribute: move_effect2_name (move_effect2 for the numerical value used in calculations)">
-                <option value="98" selected>None</option>
-                <option value="1">Asleep</option>
-                <option value="2">Burned</option>
-                <option value="3">Confused</option>
-                <option value="4">Cursed</option>
-                <option value="5">Frozen</option>
-                <option value="6">Infatuated</option>
-                <option value="7">Paralyzed</option>
-                <option value="8">Poisoned</option>
-                <option value="9">Toxified</option>
-                <option value="10">Stunned</option>
-                <option value="11">Other</option>
-              </select>
-            </span>
-          </div>
-
-          <div class="sheet-pokemon-move-info-grid-3">
-            <span class="sheet-readonly-field">
-              <b>Accuracy Roll:</b>
-              <input name="attr_move_totalaccuracy" type="hidden" />
-              <input class="sheet-top-information sheet-total-display" name="attr_move_totalaccuracy_display" readonly title="Attribute: move_totalaccuracy_display (move_totalaccuracy for only the numerical bonus)" type="text" value="d20 + 0" />
-            </span>
-
-            <span class="sheet-readonly-field">
-              <b>Damage Roll:</b>
-              <input name="attr_move_totaldamage" type="hidden" />
-              <input class="sheet-top-information sheet-total-display" name="attr_move_totaldamage_display" readonly title="Attribute: move_totaldamage_display (move_totaldamage for only the numerical bonus)" type="text" value="" />
-            </span>
-
-          </div>          
-
-          <div class="sheet-move-notes-roller">
-            <textarea class="sheet-3row-textarea" name="attr_move_effect" placeholder="Additional Effect Notes" spellcheck="false" title="Attribute: move_effect"></textarea>
-            <button class="sheet-move-roller" name="roll-movetemplate" type="roll"
-              value="@{publicity_roll} &{template:@{move_template}} {{move-type=@{move_type}}} {{character-name=@{character_name}}} {{character-id=@{character_id}}} {{move-name=@{move_name}}} {{target=@{move_category_defense}}} {{effectiveness=?{Effectiveness|Neutral, 0|Super Effective, 1|Extremely Effective, 2|Resisted, -1|Shielded, -2}}} {{effectiveness-roll=[[ 1d1 + 1 + ?{Effectiveness} ]]}} {{critical-damage=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} + [[ @{move_totaldamage} + ?{Temp Damage Bonus|0} ]] ]]}} {{effect1=@{move_effect1}}} {{effect1_roll=[[ 0 + @{move_effect1} ]]}} {{effect1_name=@{move_effect1_name}}} {{effect1_threshold=[[ 0 + @{move_effect1_threshold} ]]}} {{effect2=@{move_effect2}}} {{effect2_roll=[[ 0 + @{move_effect2} ]]}} {{effect2_name=@{move_effect2_name}}} {{effect2_threshold=[[ 0 + @{move_effect2_threshold} ]]}} {{notes=@{move_effect}}} {{critical-damage-extra=[[ ([[ @{move_dicenumber} + ?{Effectiveness} ]]) * @{damage_dice} ]]}} @{attack_rolls}">
-              T
-            </button>
+          <div class="sheet-options">
+            <b class="sheet-subsection-header">General Notes</b>
+            <textarea name="attr_notes" spellcheck="false" title="Attribute: notes"></textarea>
           </div>
         </div>
       </div>
-    </fieldset>
-
-    <div class="sheet-tab-hybrid sheet-tab-trainer">
-      <b>Inventory</b>
-      <textarea name="attr_inventory" placeholder="Pokéballs, Berries, Medicine, Accessories, etc."
-      spellcheck="false" title="Attribute: inventory"></textarea>
-
-      <b>Honors</b>
-      <textarea spellcheck="false" name="attr_honors" placeholder="Gym Badges, Contest Ribbons, Recognitions, etc."></textarea>
     </div>
-
-    <div class="sheet-tab-trainer">
-      <b>Owned Pokémon</b>
-      <textarea name="attr_ownedpokemon" placeholder="All Pokémon owned by this Trainer" spellcheck="false" title="Attribute: ownedpokemon"></textarea>
-    </div>
-
-    <b>Notes</b>
-    <textarea name="attr_notes" spellcheck="false" title="Attribute: notes"></textarea>
+    <br />
   </div>
 
   <!-- CONFIGURATION PAGE -->
@@ -4369,6 +4501,10 @@
     setAttrs({ repeating_moves_flag: flag });
   });
 
+  on("change:info_header_options_flag", function(eventInfo) {
+    updateFlagAttr("info_header_flag", eventInfo.newValue);
+  });
+
   on("change:avatar_options_flag", function(eventInfo) {
     updateFlagAttr("avatar_flag", eventInfo.newValue);
   });
@@ -4377,8 +4513,40 @@
     updateFlagAttr("origin_flag", eventInfo.newValue);
   });
 
+  on("change:origin_feature_options_flag", function (eventInfo) {
+    updateFlagAttr("origin_feature_flag", eventInfo.newValue);
+  });
+
   on("change:class_features_options_flag", function (eventInfo) {
     updateFlagAttr("class_features_flag", eventInfo.newValue);
+  });
+
+  on("change:moves_options_flag", function (eventInfo) {
+    updateFlagAttr("moves_flag", eventInfo.newValue);
+  });
+
+  on("change:notes_options_flag", function (eventInfo) {
+    updateFlagAttr("notes_flag", eventInfo.newValue);
+  });
+
+  on("change:notes_inventory_options_flag", function (eventInfo) {
+    updateSubsectionFlagAttr("notes_inventory_flag", eventInfo.newValue);
+  });
+
+  on("change:notes_honors_options_flag", function (eventInfo) {
+    updateSubsectionFlagAttr("notes_honors_flag", eventInfo.newValue);
+  });
+
+  on("change:notes_owned_options_flag", function (eventInfo) {
+    updateSubsectionFlagAttr("notes_owned_flag", eventInfo.newValue);
+  });
+
+  on("change:notes_notes_options_flag", function (eventInfo) {
+    updateSubsectionFlagAttr("notes_notes_flag", eventInfo.newValue);
+  });
+
+  on("change:passives_options_flag", function (eventInfo) {
+    updateFlagAttr("passives_flag", eventInfo.newValue);
   });
 
   on("change:options_stat_flag", function (eventInfo) {
@@ -4391,6 +4559,11 @@
 
   function updateFlagAttr(targetAttr, flagValue) {
     const attrValue = flagValue == "on" ? "-" : "+";
+    setAttrs({ [targetAttr]: attrValue });
+  }
+
+  function updateSubsectionFlagAttr(targetAttr, flagValue) {
+    const attrValue = ".";
     setAttrs({ [targetAttr]: attrValue });
   }
 
@@ -4657,7 +4830,3 @@
   }
 
 </script>
-
-
-
-

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,6 +23,12 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Nov 17, 2024
+- Adds a new roll template used by skills that has a more streamlined appearance
+- Adds a new toggle button at the top of the sheet to toggle between skill roll templates, that defaults to the existing style
+- Adds transitions for all collapsible sections of the sheet to make it more pleasing to use
+- Adds collapsing sections for all areas of the sheet's character page
+
 ### Apr 10, 2024
 - Added support for collapsing the character avatar/stat grid section to show only the stat grid when collapsed
 - Resolved a small issue with the background when the sheet scrolled sideways for the mobile app


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Adds a new roll template used by skills that has a more streamlined appearance
- Adds a new toggle button at the top of the sheet to toggle between skill roll templates, that defaults to the existing style
- Adds transitions for all collapsible sections of the sheet to make it more pleasing to use
- Adds collapsing sections for all areas of the sheet's character page