### PR TITLE
[PokemonTabletopAdventures_v3] Bugfix: Removes scrollbars from sections

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -1923,10 +1923,17 @@ button[type="roll"].sheet-stat-roller:hover {
   max-height: 1200px;
   opacity: 1;
   overflow: scroll;
+  scrollbar-width: none;
   transition-property: max-height, opacity, visibility;
   transition-duration: 400ms;
   transition-timing-function: cubic-bezier(.55,.06,.68,.19);
   visibility: visible;
+}
+
+.sheet-options-flag:not(:checked) ~ div.sheet-display::-webkit-scrollbar,
+.sheet-options-flag:checked ~ div.sheet-options::-webkit-scrollbar {
+  height: 0;
+  width: 0;
 }
 
 .sheet-extra-max-height .sheet-options-flag:not(:checked) ~ div.sheet-display,

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,11 +23,14 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Nov 27, 2024
+- Removed scrollbars from the collapsing sections
+
 ### Nov 17, 2024
-- Adds a new roll template used by skills that has a more streamlined appearance
-- Adds a new toggle button at the top of the sheet to toggle between skill roll templates, that defaults to the existing style
-- Adds transitions for all collapsible sections of the sheet to make it more pleasing to use
-- Adds collapsing sections for all areas of the sheet's character page
+- Added a new roll template used by skills that has a more streamlined appearance
+- Added a new toggle button at the top of the sheet to toggle between skill roll templates, that defaults to the existing style
+- Added transitions for all collapsible sections of the sheet to make it more pleasing to use
+- Added collapsing sections for all areas of the sheet's character page
 
 ### Apr 10, 2024
 - Added support for collapsing the character avatar/stat grid section to show only the stat grid when collapsed


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Adds `scrollbar-width: none;` to the visible component of the collapsible sections
- Also set webkit scrollbar height and width properties to zero
- Updates readme



