### PR TITLE
[Dark Heresy]: fix success template being shown for small negative de…

### DIFF
--- a/Dark_Heresy/DarkHeresy.html
+++ b/Dark_Heresy/DarkHeresy.html
@@ -1287,22 +1287,14 @@
             <td><span class="sheet-inlinerollresult">{{weapondiceroll}}</span></td>
         </tr>
         {{/rollLess() weapondiceroll 97}}
-        {{#rollGreater() roll 0}}
+        {{#^rollLess() roll 0}}
         <tr class="sheet-success">
             <th colspan="2">
                 <span data-i18n="success">Success</span> <span data-i18n="with">with</span> {{roll}} <span
                     data-i18n="degrees">degrees</span>
             </th>
         </tr>
-        {{/rollGreater() roll 0}}
-        {{#rollTotal() roll 0}}
-        <tr class="sheet-success">
-            <th colspan="2">
-                <span data-i18n="success">Success</span> <span data-i18n="with">with</span> {{roll}} <span
-                    data-i18n="degrees">degrees</span>
-            </th>
-        </tr>
-        {{/rollTotal() roll 0}}
+        {{/^rollLess() roll 0}}
         {{#rollLess() roll 0}}
         <tr class="sheet-failure">
             <th colspan="2">


### PR DESCRIPTION
…cimal results

e.g.  -0.9 to -0.1

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

Small negative decimal roll results like -0.1 lead to the success Template beeing shown which is confusing. 
Guessing this has to to with the 3-Way check that has been used here where there should only be one decision: less than or not less than 0



