### PR TITLE
[TOR 2e] added favoured rolls for combat proficiencies (new feature)

### DIFF
--- a/The One Ring 2e/release-notes.md
+++ b/The One Ring 2e/release-notes.md
@@ -4,6 +4,10 @@ This is a rewrite based on the early 2e (basic) and 1e edition that also include
 
 # Release History
 
+## 03.12.00 (Build 34)
+
+- added "Favoured" modifier for pc combat proficiencies to allow handling of specific cultural virtues (e.g. Hobbit Cultural Virtue Sure At The Mark)
+
 ## 03.11.00 (Build 33)
 
 - fixed stance toggle attack bonus bug 

--- a/The One Ring 2e/sheet.css
+++ b/The One Ring 2e/sheet.css
@@ -209,8 +209,8 @@
     width: 12px !important;
 }
 
-.charsheet :is(#skill-strength, #skill-heart, #skill-wits, #virtues, #rewards, #protection) input[type="checkbox"]:checked+label,
-.charsheet :is(#skill-strength, #skill-heart, #skill-wits, #virtues, #rewards, #protection) input[type="checkbox"]:checked+span {
+.charsheet :is(#skill-strength, #skill-heart, #skill-wits, #virtues, #rewards, #protection, #combat) input[type="checkbox"]:checked+label,
+.charsheet :is(#skill-strength, #skill-heart, #skill-wits, #virtues, #rewards) input[type="checkbox"]:checked+span {
     text-decoration: underline;
 }
 

--- a/The One Ring 2e/sheet.html
+++ b/The One Ring 2e/sheet.html
@@ -1,4 +1,4 @@
-<input type="hidden" name="attr_version" value="03-11-00" />
+<input type="hidden" name="attr_version" value="03-12-00" />
 <input type="hidden" class="sheet-tabstoggle" name="attr_sheetTab" />
 <input type="checkbox" name="attr_parsedrolls" value="1" class="hidden config-parsed-rolls" checked="checked" hidden
     readonly />
@@ -416,6 +416,7 @@
                 </span>
                 -->
                 &nbsp;
+                <input type="checkbox" value="1" name="attr_axes_favoured" title="Toggle favoured" />
                 <label data-i18n="axes">Axes</label>
                 <div class="sheet-hover-info" data-i18n="axes-description"></div>
                 <div class="sheet-dots">
@@ -449,6 +450,7 @@
                 </span>
                 -->
                 &nbsp;
+                <input type="checkbox" value="1" name="attr_bows_favoured" title="Toggle favoured" />                
                 <label data-i18n="bows">Bows</label>
                 <div class="sheet-hover-info" data-i18n="bows-description"></div>
                 <div class="sheet-dots">
@@ -483,6 +485,7 @@
                 </span>
                 -->
                 &nbsp;
+                <input type="checkbox" value="1" name="attr_spears_favoured" title="Toggle favoured" />
                 <label data-i18n="spears">Spears</label>
                 <div class="sheet-hover-info" data-i18n="spears-description"></div>
                 <div class="sheet-dots">
@@ -517,6 +520,7 @@
                 </span>
                 -->
                 &nbsp;
+                <input type="checkbox" value="1" name="attr_swords_favoured" title="Toggle favoured" />
                 <label data-i18n="swords">Swords</label>
                 <div class="sheet-hover-info" data-i18n="swords-description"></div>
                 <div class="sheet-dots">
@@ -880,10 +884,10 @@
                         value='@{weapon_1_target_action}'
                         title="Use this button when you have an adversary token to target."></button>
                     &nbsp;
-                    <input type="checkbox" value="1" name="attr_weapon_active_1" checked="checked">
+                    <input type="checkbox" value="1" name="attr_weapon_active_1" checked="checked" title="Toggle weapon is equipped on/off.">
                     &nbsp;
                 </span>
-                <input name="attr_weapon_skill_name_1" type="text"></input>
+                <input name="attr_weapon_skill_name_1" type="text" />
                 <select name="attr_weapon_combat_prof_1">
                     <option value="" selected default></option>
                     <option value="axes" data-i18n="axes">Axes</option>
@@ -923,10 +927,10 @@
                         value='@{weapon_2_target_action}'
                         title="Use this button when you have an adversary token to target."></button>
                     &nbsp;
-                    <input type="checkbox" value="1" name="attr_weapon_active_2" checked="checked">
+                    <input type="checkbox" value="1" name="attr_weapon_active_2" checked="checked" title="Toggle weapon is equipped on/off.">
                     &nbsp;
                 </span>
-                <input name="attr_weapon_skill_name_2" type="text">
+                <input name="attr_weapon_skill_name_2" type="text" />
                 <select name="attr_weapon_combat_prof_2">
                     <option value="" selected default></option>
                     <option value="axes" data-i18n="axes">Axes</option>
@@ -966,10 +970,10 @@
                         value='@{weapon_3_target_action}'
                         title="Use this button when you have an adversary token to target."></button>
                     &nbsp;
-                    <input type="checkbox" value="1" name="attr_weapon_active_3" checked="checked">
+                    <input type="checkbox" value="1" name="attr_weapon_active_3" checked="checked" title="Toggle weapon is equipped on/off.">
                     &nbsp;
                 </span>
-                <input name="attr_weapon_skill_name_3" type="text">
+                <input name="attr_weapon_skill_name_3" type="text" />
                 <select name="attr_weapon_combat_prof_3">
                     <option value="" selected default></option>
                     <option value="axes" data-i18n="axes">Axes</option>
@@ -998,7 +1002,7 @@
                 <input name="attr_weapon_note_3" type="text">
                 <span class="table-rolls" />
                 <span class="parsed-rolls">
-                    <input type='hidden' name='attr_weapon_4_action' value=''>
+                    <input type='hidden' name='attr_weapon_4_action' value='' />
                     <button type='action' name='act_weapon_4_action' style="display: none;"></button>
                     <button type='roll' name='roll_weapon_4' class="parsed-rolls" value='@{weapon_4_action}'
                         title="Use this button when you have a Parry Rating that you can enter manually."></button>
@@ -1009,10 +1013,10 @@
                         value='@{weapon_4_target_action}'
                         title="Use this button when you have an adversary token to target."></button>
                     &nbsp;
-                    <input type="checkbox" value="1" name="attr_weapon_active_4" checked="checked">
+                    <input type="checkbox" value="1" name="attr_weapon_active_4" checked="checked" title="Toggle weapon is equipped on/off.">
                     &nbsp;
                 </span>
-                <input name="attr_weapon_skill_name_4" type="text">
+                <input name="attr_weapon_skill_name_4" type="text" />
                 <select name="attr_weapon_combat_prof_4">
                     <option value="" selected default></option>
                     <option value="axes" data-i18n="axes">Axes</option>
@@ -1052,10 +1056,10 @@
                         value='@{weapon_5_target_action}'
                         title="Use this button when you have an adversary token to target."></button>
                     &nbsp;
-                    <input type="checkbox" value="1" name="attr_weapon_active_5" checked="checked">
+                    <input type="checkbox" value="1" name="attr_weapon_active_5" checked="checked" title="Toggle weapon is equipped on/off.">
                     &nbsp;
                 </span>
-                <input name="attr_weapon_skill_name_5" type="text"></input>
+                <input name="attr_weapon_skill_name_5" type="text" />
                 <select name="attr_weapon_combat_prof_5">
                     <option value="" selected default></option>
                     <option value="axes" data-i18n="axes">Axes</option>
@@ -1081,7 +1085,7 @@
                     <option value="9">9+</option>
                     <option value="8">8+</option>
                 </select>
-                <input name="attr_weapon_note_5" type="text">
+                <input name="attr_weapon_note_5" type="text" />
                 <span class="table-rolls" />
                 <span class="parsed-rolls">
                     <input type='hidden' name='attr_weapon_6_action' value=''>
@@ -1095,10 +1099,10 @@
                         value='@{weapon_6_target_action}'
                         title="Use this button when you have an adversary token to target."></button>
                     &nbsp;
-                    <input type="checkbox" value="1" name="attr_weapon_active_6" checked="checked">
+                    <input type="checkbox" value="1" name="attr_weapon_active_6" checked="checked" title="Toggle weapon is equipped on/off.">
                     &nbsp;
                 </span>
-                <input name="attr_weapon_skill_name_6" type="text"></input>
+                <input name="attr_weapon_skill_name_6" type="text" />
                 <select name="attr_weapon_combat_prof_6">
                     <option value="" selected default></option>
                     <option value="axes" data-i18n="axes">Axes</option>
@@ -1139,7 +1143,7 @@
                 <label class="center" data-i18n="cunning-make">CM</label>
                 <div class="sheet-hover-info" data-i18n="cunning-make-description"></div>
 
-                <input type="checkbox" name="attr_armourprot_active" value=1 checked="checked">
+                <input type="checkbox" name="attr_armourprot_active" value=1 checked="checked" title="Toggle armour is equipped on/off.">
                 <input class="text" type="text" placeholder="Armour" title="Armour" data-i18n-title="armour"
                     data-i18n-placeholder="armour-placeholder" name="attr_armour">
                 <input class="center number" type="number" name="attr_armourprot" value="0">
@@ -1155,7 +1159,7 @@
                     <option value="-3">-3</option>
                 </select>
 
-                <input type="checkbox" name="attr_helmprot_active" value=1 checked="checked">
+                <input type="checkbox" name="attr_helmprot_active" value=1 checked="checked" title="Toggle armour is equipped on/off.">
                 <input class="text" type="text" placeholder="Helm" title="Helm" data-i18n-title="helm"
                     data-i18n-placeholder="helm-placeholder" name="attr_helm">
                 <input class="center number" type="number" name="attr_helmprot" value="0">
@@ -1171,7 +1175,7 @@
                     <option value="-3">-3</option>
                 </select>
 
-                <input type="checkbox" name="attr_otherprot_active" value=1 checked="checked">
+                <input type="checkbox" name="attr_otherprot_active" value=1 checked="checked" title="Toggle armour is equipped on/off.">
                 <input type="text" class="text" name="attr_otherprot_name" placeholder="Other"
                     title="Other modifiers for Protection" data-i18n-title="Other-protection"
                     data-i18n-placeholder="other-placeholder">
@@ -1196,7 +1200,7 @@
                 <div class="sheet-hover-info" data-i18n="reinforced-description"></div>
                 <label class="center" data-i18n="cunning-make">CM</label>
                 <div class="sheet-hover-info" data-i18n="cunning-make-description"></div>
-                <input type="checkbox" name="attr_shieldparry_active" value="1" checked="checked">
+                <input type="checkbox" name="attr_shieldparry_active" value="1" checked="checked" title="Toggle shield is equipped on/off.">
                 <input class="text" type="text" placeholder="Shield" data-i18n-title="shield"
                     data-i18n-placeholder="shield-placeholder" name="attr_shield">
                 <input class="center number" type="number" name="attr_shieldparry" value="0">
@@ -1768,11 +1772,13 @@
         // FEAT DIE ROLL DATA
         if (rolltype === "custom" ) {
             favId = act_fav; 
+        /* since we now have favoured state for combat actions, we don't need to check for combat actions
         } else if (rolltype.startsWith("combat")) {
             // combat actions don't have local favoured state
             favId = favourill_id;
+        */
         } else {
-            if (act_fav === "1" || act_fav === "on") {
+            if (act_fav == "1" || act_fav === "on") {
                 // global illfavoured + local favoured
                 if (favourill_id == 0) {
                     //normal 
@@ -2541,27 +2547,29 @@
                 `weapon_fell_${index}`, `weapon_grievous_${index}`, `weapon_keen_${index}`, 
                 `weapon_fell_val_${index}`, `weapon_grievous_val_${index}`, `weapon_keen_val_${index}`, 
                 'stanceattack_active', 'stanceattackbonus', 'stancedamagebonus',
-                'axes', 'bows', 'spears', 'swords']),
-            action = data[`weapon_skill_name_${index}`],
-            combatprof = data[`weapon_combat_prof_${index}`],
-            damage = data[`weapon_damage_${index}`],
-            injury = data[`weapon_injury_${index}`],
-            note = data[`weapon_note_${index}`],
-            fell_val = int(data[`weapon_fell_val_${index}`],0),
-            grievous_val = int(data[`weapon_grievous_val_${index}`],0),
-            keen_val = int(data[`weapon_keen_val_${index}`],0),
-            fell = fell_val === 0 ? "" : "Fell, ",
-            grievous = grievous_val === 0 ? "" : "Grievous, ",
-            keen = keen_val === 10 ? "" : "Keen, ",
-            actdice = int(data[`${combatprof}`]),
-            stanceattack_active = int(data['stanceattack_active']),
-            stanceattackbonus = int(data['stanceattackbonus']),
-            stancedamagebonus = int(data['stancedamagebonus']);
+                'axes', 'bows', 'spears', 'swords',
+                'axes_favoured', 'bows_favoured', 'spears_favoured', 'swords_favoured']),
+        action = data[`weapon_skill_name_${index}`],
+        combatprof = data[`weapon_combat_prof_${index}`],
+        damage = data[`weapon_damage_${index}`],
+        injury = data[`weapon_injury_${index}`],
+        note = data[`weapon_note_${index}`],
+        fell_val = int(data[`weapon_fell_val_${index}`],0),
+        grievous_val = int(data[`weapon_grievous_val_${index}`],0),
+        keen_val = int(data[`weapon_keen_val_${index}`],0),
+        fell = fell_val === 0 ? "" : "Fell, ",
+        grievous = grievous_val === 0 ? "" : "Grievous, ",
+        keen = keen_val === 10 ? "" : "Keen, ",
+        actdice = int(data[`${combatprof}`]),
+        stanceattack_active = int(data['stanceattack_active']),
+        stanceattackbonus = int(data['stanceattackbonus']),
+        stancedamagebonus = int(data['stancedamagebonus']);
         damage_bonus = stanceattack_active == 1 ? stancedamagebonus + grievous_val : grievous_val;
         damage = (damage_bonus > 0) ? `${damage}+${damage_bonus}` : damage;
         injury = (fell_val > 0) ? `${injury}+${fell_val}` : injury;
-        clog(`First roll: ${JSON.stringify(data)}, Action: ${action}, Dice: ${actdice}, tn: ${data.strengthtn}`);
-        await rollFirst(data.character_name, action, actdice, data.strengthtn, 0, "combat"+target, `weapon='${keen}${fell}${grievous}Damage:${damage}, Injury:${injury}'; additional='Notes: ${note}';keen='${keen_val}';`, false);
+        act_fav = int(data[`${combatprof}_favoured`], 0);
+        clog(`First roll: ${JSON.stringify(data)}, Action: ${action}, Dice: ${actdice}, tn: ${data.strengthtn}, act_fav: ${act_fav}`);
+        await rollFirst(data.character_name, action, actdice, data.strengthtn, act_fav, "combat"+target, `weapon='${keen}${fell}${grievous}Damage:${damage}, Injury:${injury}'; additional='Notes: ${note}';keen='${keen_val}';`, false);
         clog(`Completed first roll: weapon_${index}`);
     });
 
@@ -3169,6 +3177,24 @@
                         hlog(`
 ### Fixed
 - fixed stance toggle
+                        `, releaselog);
+                        hlog("==============", releaselog);
+                        attrs['releaselog'] =  releaselog.msg + values['releaselog'];
+                        if (Object.keys(attrs).length) {
+                            setAttrs(attrs);
+                        }
+                    });
+                }
+            }
+            if (build < 34) {
+                attrs["build"] = 34;
+                let releaselog = {msg:""};
+                hlog(`Release 03.12.00 - ${new Date().toLocaleString()}`, releaselog);
+                if (v.sheettab === "isPC"){
+                    getAttrs(['releaselog'], function(values){
+                        hlog(`
+### New
+- added "Favoured" modifier for pc combat proficiencies to allow handling of specific cultural virtues (e.g. Hobbit Cultural Virtue Sure At The Mark)
                         `, releaselog);
                         hlog("==============", releaselog);
                         attrs['releaselog'] =  releaselog.msg + values['releaselog'];

--- a/The One Ring 2e/sheet.json
+++ b/The One Ring 2e/sheet.json
@@ -1,6 +1,6 @@
 {
   "title": "The One Ring 2e",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "html": "sheet.html",
   "css": "sheet.css",
   "authors": "Bodo Hüsemann, Richard W, Michael (aka Aragent) I, Paul Venner, Michael Heilemann, Stefan Unterhuber, Stuart Johnson, David DomÃ­nguez, Eric Le Bourvellec",


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

## 03.12.00 (Build 34)
- added "Favoured" modifier for pc combat proficiencies to allow handling of specific cultural virtues (e.g. Hobbit Cultural Virtue Sure At The Mark)




