### PR TITLE
AD&D 2E - Bugfix: Fixed monster weapon autofill for +1 magic weapons

### DIFF
--- a/ADnD_2E_Revised/javascript/sheetWorkers.js
+++ b/ADnD_2E_Revised/javascript/sheetWorkers.js
@@ -2074,7 +2074,7 @@ on('change:repeating_monsterweapons:weaponname', function(eventInfo) {
         return comparerFields.every(f => weapon1[f] === weapon2[f]);
     }
     let setWeaponFunc = function (weapon) {
-        if (weapon['bonusInt'] > 1) {
+        if (weapon['bonusInt'] > 0) {
             weapon['small-medium'] += weapon['bonus'];
             weapon['large'] += weapon['bonus'];
             weapon['thac0'] = weapon['thac0'] - weapon['bonusInt'];


### PR DESCRIPTION
# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Fix monster weapons to correctly apply bonuses when the modifier is a +1.



