### PR TITLE
[Warhammer 4e Character Sheet] v1.75 Add Talents

### DIFF
--- a/Warhammer 4e Character Sheet/README.md
+++ b/Warhammer 4e Character Sheet/README.md
@@ -81,6 +81,13 @@ Note conditions are not intended for out of combat situations, GM simply makes t
  
 ///// ============ Change Log ============ /////  
 
+Jan 20th 2025 v1.75
+
+- Add Cantor Talent from Heart of Glass/Ubersreik Adventures 1, situational test bonus for entertain singing.
+- Add Chanty Talent from Sea of Claws, situational test bonus for entertain singing.
+- Fix Master of Disguise Talent, now shows situational test bonus for entertain acting.
+
+
 Jan 10th 2025 v1.74d
 
 - Fix for the sheet background and images sometimes not working in roll20. Sheet Assets moved to prevent url encoding problem.

--- a/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
+++ b/Warhammer 4e Character Sheet/Warhammer 4e Character Sheet.html
@@ -20311,6 +20311,14 @@
 						</div>
 						<div class="row">
 							<div class="col-3-4 left">
+								<span data-i18n="CANTOR" class="nowrap"></span>
+							</div>
+							<div class="col-1-4 center">
+						<input class="meleeshow-check" type="checkbox" name="attr_ShowCantor" value="1"/>
+							</div>
+						</div>
+						<div class="row">
+							<div class="col-3-4 left">
 								<span data-i18n="CARDSHARP" class="nowrap"></span>
 							</div>
 							<div class="col-1-4 center">
@@ -20347,6 +20355,14 @@
 							</div>
 							<div class="col-1-4 center">
 						<input class="meleeshow-check" type="checkbox" name="attr_ShowCattongued" value="1"/>
+							</div>
+						</div>
+						<div class="row">
+							<div class="col-3-4 left">
+								<span data-i18n="CHANTY" class="nowrap"></span>
+							</div>
+							<div class="col-1-4 center">
+						<input class="meleeshow-check" type="checkbox" name="attr_ShowChanty" value="1"/>
 							</div>
 						</div>
 						<div class="row" style="height: 13px">
@@ -20536,6 +20552,9 @@
 						<input class="meleeshow-check" type="checkbox" name="attr_ShowCraftsman3" value="1"/>
 							</div>
 						</div>
+					</div>
+
+					<div class="col-19-100 vert-top">
 						<div class="row">
 							<div class="col-3-4 left">
 								<span data-i18n="CREW-COMMANDER" class="nowrap"></span>
@@ -20544,9 +20563,6 @@
 						<input class="meleeshow-check" type="checkbox" name="attr_ShowCrewCommander" value="1"/>
 							</div>
 						</div>
-					</div>
-
-					<div class="col-19-100 vert-top">
 						<div class="row">
 							<div class="col-3-4 left">
 								<span data-i18n="CRIMINAL" class="nowrap"></span>
@@ -21367,9 +21383,6 @@
 						<input class="meleeshow-check" type="checkbox" name="attr_ShowPharmacist" value="1"/>
 							</div>
 						</div>
-					</div>
-
-					<div class="col-19-100 vert-top" >
 						<div class="row">
 							<div class="col-3-4 left">
 								<span data-i18n="PILOT" class="nowrap"></span>
@@ -21378,6 +21391,9 @@
 						<input class="meleeshow-check" type="checkbox" name="attr_ShowPilot" value="1"/>
 							</div>
 						</div>
+					</div>
+
+					<div class="col-19-100 vert-top" >
 						<div class="row">
 							<div class="col-3-4 left">
 								<span data-i18n="PUBLIC-SPEAKER" class="nowrap"></span>
@@ -21740,9 +21756,6 @@
 						<input class="meleeshow-check" type="checkbox" name="attr_ShowStoneSoup" value="1"/>
 							</div>
 						</div>
-					</div>
-
-					<div class="col-19-100 vert-top" >
 						<div class="row">
 							<div class="col-3-4 left">
 								<span data-i18n="STOUT-HEARTED" class="nowrap"></span>
@@ -21804,6 +21817,9 @@
 						<input class="meleeshow-check" type="checkbox" name="attr_ShowStrider3" value="1"/>
 							</div>
 						</div>
+					</div>
+
+					<div class="col-19-100 vert-top" >
 						<div class="row">
 							<div class="col-3-4 left">
 								<span data-i18n="SPRINTER" class="nowrap"></span>
@@ -22899,6 +22915,26 @@
 							<button class="right" type="compendium" value="Talents:Briber" data-i18n-title="COMPENDIUM-LINK"></button>
 							<span style="font-family: pictos; color: #55b800;" data-i18n-title="INTEGRATION" >j</span>
 						</div>
+		<input type="checkbox" name="attr_ShowCantor" class="hidden hider" value="1" />
+						<div class="col-1-2 vert-top">
+							<div class="col-1-10 center vert-middle">
+								<input type="checkbox" name="attr_CarrierCantor" value="1" />
+							</div>
+							<div class="col-1-2 left vert-middle">
+								<span data-i18n="CANTOR">Cantor</span>
+							</div>
+							<div class="col-8-100 center talents-border2">
+								<span style="color: white">/</span>
+							</div>
+							<div class="col-8-100 center vert-middle">
+								<input class="center" type="number" name="attr_Talent_CantorLvl" value="0" min="0" />
+								<input class="hidden" type="number" name="attr_Talent_CantorXP" value="0" />
+							</div>
+							<div class="col-8-100 center vert-middle">
+								<input class="center" type="number" name="attr_Talent_CantorMax" value="1" disabled />
+							</div>
+							<span style="padding-left: 7px; font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+						</div>
 		<input type="checkbox" name="attr_ShowCardsharp" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
 							<div class="col-1-10 center vert-middle">
@@ -22999,10 +23035,30 @@
 								<input class="hidden" type="number" name="attr_Talent_CattonguedXP" value="0" />
 							</div>
 							<div class="col-8-100 center vert-middle">
-								<input class="center" type="number" name="attr_Talent_CattonguedlMax" value="@{FellowshipBonus}" disabled />
+								<input class="center" type="number" name="attr_Talent_CattonguedMax" value="@{FellowshipBonus}" disabled />
 							</div>
 							<button class="right" type="compendium" value="Talents:Catfall" data-i18n-title="COMPENDIUM-LINK"></button>
 							<span style="font-family: pictos; color: #55b800;" data-i18n-title="INTEGRATION" >j</span>
+						</div>
+		<input type="checkbox" name="attr_ShowChanty" class="hidden hider" value="1" />
+						<div class="col-1-2 vert-top">
+							<div class="col-1-10 center vert-middle">
+								<input type="checkbox" name="attr_CarrierChanty" value="1" />
+							</div>
+							<div class="col-1-2 left vert-middle">
+								<span data-i18n="CHANTY">Chanty</span>
+							</div>
+							<div class="col-8-100 center talents-border2">
+								<span data-i18n="ABBREVIATE-INTELLIGENCE"></span>
+							</div>
+							<div class="col-8-100 center vert-middle">
+								<input class="center" type="number" name="attr_Talent_ChantyLvl" value="0" min="0" />
+								<input class="hidden" type="number" name="attr_Talent_ChantyXP" value="0" />
+							</div>
+							<div class="col-8-100 center vert-middle">
+								<input class="center" type="number" name="attr_Talent_ChantyMax" value="@{IntelligenceBonus}" disabled />
+							</div>
+							<span style="padding-left: 7px; font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowChaosMagic1" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -23613,7 +23669,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_DragonBelcherMax" value="@{BallisticSkillBonus}" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #55b800;" data-i18n-title="INTEGRATION" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #55b800;" data-i18n-title="INTEGRATION" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowDrilled" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -25090,7 +25146,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_MasterRuneMagicMax" value="@{WillpowerBonus}" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowMasterTradesman1" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -25188,7 +25244,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_MaverickMax" value="@{AgilityBonus}" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowMenacing" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -25871,7 +25927,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_RuneMagicMax" value="@{WillpowerBonus}+@{IntelligenceBonus}" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowSavant1" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -26200,7 +26256,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_ShortFuseMax" value="@{IntelligenceBonus}" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowSixthSense" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -26937,7 +26993,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_TirelessMax" value="@{ToughnessBonus}" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowTenacious" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -27104,7 +27160,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_UnderminerMax" value="@{AgilityBonus}" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowVeryResilient" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -27313,7 +27369,7 @@
 							<div class="col-8-100 center vert-middle">
 								<input class="center" type="number" name="attr_Talent_WhirlwindofDeathMax" value="1" disabled />
 							</div>
-							<span style="padding-left: 5px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
+							<span style="padding-left: 7px;font-family: pictos; color: #b89000;" data-i18n-title="INTEGRATION-PART" >j</span>
 						</div>
 		<input type="checkbox" name="attr_ShowWitch" class="hidden hider" value="1" />
 						<div class="col-1-2 vert-top">
@@ -32893,7 +32949,7 @@
 		<div class="spacer-xl"></div>
 		<!-- FOOTER -->
 		<div class="row footer">
-			<div class="col-1 small-label center">Sheet version 1.74c : Jan 4th 2025 | by Djjus & Pote</div>
+			<div class="col-1 small-label center">Sheet version 1.75 : Jan 20th 2025 | by Djjus & Pote</div>
 		</div>
 			</div>
 		</div>
@@ -34831,6 +34887,15 @@
 							{{#rollGreater() diceman 0}}
 								<div class="col-1 center pad-l-md pad-r-md rt-slmod" style="color: #858585">+{{diceman}}SL <span  data-i18n="DICEMAN" data-i18n-title="DICEMAN-SIT"></span></div>
 							{{/rollGreater() diceman 0}}
+							{{#rollGreater() masterofdisguise 0}}
+								<div class="col-1 center pad-l-md pad-r-md rt-slmod" style="color: #858585">+{{masterofdisguise}}SL <span  data-i18n="MASTER-OF-DISGUISE" data-i18n-title="MASTER-OF-DISGUISE-SIT"></span></div>
+							{{/rollGreater() masterofdisguise 0}}
+							{{#rollGreater() cantor 0}}
+								<div class="col-1 center pad-l-md pad-r-md rt-slmod" style="color: #858585">+{{cantor}}SL <span  data-i18n="CANTOR" data-i18n-title="CANTOR-SIT"></span></div>
+							{{/rollGreater() cantor 0}}
+							{{#rollGreater() chanty 0}}
+								<div class="col-1 center pad-l-md pad-r-md rt-slmod" style="color: #858585">+{{chanty}}SL <span  data-i18n="CHANTY" data-i18n-title="CHANTY-SIT"></span></div>
+							{{/rollGreater() chanty 0}}
 							{{#rollGreater() enclosedfighter 0}}
 								<div class="col-1 center pad-l-md pad-r-md rt-slmod" style="color: #858585">+{{enclosedfighter}}SL <span  data-i18n="ENCLOSED-FIGHTER" data-i18n-title="ENCLOSED-FIGHTER-SIT"></span></div>
 							{{/rollGreater() enclosedfighter 0}}
@@ -46212,7 +46277,7 @@ on('sheet:opened change:repeating_otherxp:otherxp change:repeating_otherxp:other
 		});
 		});
 			
-	const talents = ['AccurateShot', 'AcuteSense1', 'AcuteSense2', 'AethyricAttunement', 'AlleyCat', 'Ambidextrous', 'AnimalAffinity', 'ArcaneMagic1', 'ArcaneMagic2', 'ArcaneMagic3', 'ArcaneMagic4', 'Argumentative', 'Artistic', 'Attractive', 'BattleRage', 'BeatBlade', 'BeneathNotice', 'BerserkCharge', 'BreakandEnter', 'Blather', 'Bless', 'Bookish', 'Briber', 'Cardsharp', 'CarefulStrike', 'Carouser', 'Catfall', 'Cattongued', 'ChaosMagic1', 'ChaosMagic2', 'ChaosMagic3', 'ChaosMagic4', 'CombatAware', 'CombatMaster', 'CombatReflexes', 'CommandingPresence', 'Concoct', 'Contortionist', 'Coolheaded', 'CracktheWhip', 'Craftsman1', 'Craftsman2', 'Craftsman3', 'CrewCommander', 'Criminal', 'DeadeyeShot', 'Dealmaker', 'DetectArtefact', 'Diceman', 'DirtyFighting', 'Disarm', 'Distract', 'Drilled', 'DualWielder', 'Embezzle', 'EnclosedFighter', 'Etiquette1', 'Etiquette2', 'Etiquette3', 'Etiquette4', 'Etiquette5', 'Etiquette6', 'FastHands', 'FastShot', 'Fearless1', 'Fearless2', 'Fearless3', 'Fearless4', 'Feint', 'FieldDressing', 'Fisherman', 'Flagellant', 'Flee', 'FleetFooted', 'Frenzy', 'Frightening', 'FuriousAssault', 'Gregarious', 'Gunner', 'Hardy', 'Hatred1', 'Hatred2', 'Hatred3', 'Hatred4', 'HolyHatred', 'HolyVisions', 'HuntersEye', 'ImpassionedZeal', 'Implacable' , 'Infighter', 'Inspiring', 'InstinctiveDiction', 'Invoke', 'IronJaw', 'IronWill', 'JumpUp', 'Kingpin', 'LightningReflexes', 'Linguistics', 'LipReading', 'Luck', 'MagicalSense', 'MagicalAssistant', 'MagicResistance', 'MagnumOpus', 'Marksman', 'MasterAndCommander', 'MasterOfDisguise', 'MasterOrator', 'MasterTradsman1', 'MasterTradsman2', 'MasterTradsman3', 'Menacing', 'Mimic', 'NightVision', 'NimbleFingers', 'NobleBlood', 'NoseForTrouble', 'Numismatics', 'OldSalt', 'Orientation', 'Panhandle', 'PerfectPitch', 'PettyMagic', 'Pharmacist', 'Pilot', 'PublicSpeaker', 'PureSoul', 'RapidReload', 'ReactionStrike', 'ReadWrite', 'Relentless', 'Resistance1', 'Resistance2', 'Resistance3', 'Resolute', 'Reversal', 'Riposte', 'RiverGuide', 'Robust', 'Roughrider', 'Rover', 'Savant1', 'Savant2', 'Savant3', 'Savvy', 'ScaleSheerSurface', 'Schemer', 'SeaLegs', 'SeasonedTraveller', 'SecondSight', 'SecretIdentity', 'Shadow', 'Sharp', 'Sharpshooter', 'Shieldsman', 'SixthSense', 'Slayer', 'Sniper', 'Speedreader', 'Sprinter', 'StepAside', 'StoneSoup', 'StoutHearted', 'Strider1', 'Strider2', 'Strider3', 'Sprinter', 'StrikeMightyBlow', 'StriketoInjure', 'StriketoStun', 'StrongBack', 'StrongLegs', 'Strongminded', 'StrongSwimmer', 'Sturdy', 'Suave', 'SuffusedWithAqshy', 'SuffusedWithAzyr', 'SuffusedWithChamon', 'SuffusedWithChamon', 'SuffusedWithGhur', 'SuffusedWithGhyran', 'SuffusedWithHysh', 'SuffusedWithShyish', 'SuffusedWithUglu', 'SuperNumerate', 'Supportive', 'SureShot', 'Surgery', 'Tenacious', 'Tinker', 'TowerOfMemories', 'Trapper', 'TrickRiding', 'TunnelRat', 'Unshakable', 'VeryResilient', 'VeryStrong', 'Vice', 'WarLeader', 'WarWizard', 'WarriorBorn', 'Waterman', 'Wealthy', 'Wellprepared', 'Witch'];
+	const talents = ['AccurateShot', 'AcuteSense1', 'AcuteSense2', 'AethyricAttunement', 'AlleyCat', 'Ambidextrous', 'AnimalAffinity', 'ArcaneMagic1', 'ArcaneMagic2', 'ArcaneMagic3', 'ArcaneMagic4', 'Argumentative', 'Artistic', 'Attractive', 'BattleRage', 'BeatBlade', 'BeneathNotice', 'BerserkCharge', 'BreakandEnter', 'Blather', 'Bless', 'Bookish', 'Briber', 'Cantor', 'Cardsharp', 'CarefulStrike', 'Carouser', 'Catfall', 'Cattongued', 'Chanty', 'ChaosMagic1', 'ChaosMagic2', 'ChaosMagic3', 'ChaosMagic4', 'CombatAware', 'CombatMaster', 'CombatReflexes', 'CommandingPresence', 'Concoct', 'Contortionist', 'Coolheaded', 'CracktheWhip', 'Craftsman1', 'Craftsman2', 'Craftsman3', 'CrewCommander', 'Criminal', 'DeadeyeShot', 'Dealmaker', 'DetectArtefact', 'Diceman', 'DirtyFighting', 'Disarm', 'Distract', 'Drilled', 'DualWielder', 'Embezzle', 'EnclosedFighter', 'Etiquette1', 'Etiquette2', 'Etiquette3', 'Etiquette4', 'Etiquette5', 'Etiquette6', 'FastHands', 'FastShot', 'Fearless1', 'Fearless2', 'Fearless3', 'Fearless4', 'Feint', 'FieldDressing', 'Fisherman', 'Flagellant', 'Flee', 'FleetFooted', 'Frenzy', 'Frightening', 'FuriousAssault', 'Gregarious', 'Gunner', 'Hardy', 'Hatred1', 'Hatred2', 'Hatred3', 'Hatred4', 'HolyHatred', 'HolyVisions', 'HuntersEye', 'ImpassionedZeal', 'Implacable' , 'Infighter', 'Inspiring', 'InstinctiveDiction', 'Invoke', 'IronJaw', 'IronWill', 'JumpUp', 'Kingpin', 'LightningReflexes', 'Linguistics', 'LipReading', 'Luck', 'MagicalSense', 'MagicalAssistant', 'MagicResistance', 'MagnumOpus', 'Marksman', 'MasterAndCommander', 'MasterOfDisguise', 'MasterOrator', 'MasterTradsman1', 'MasterTradsman2', 'MasterTradsman3', 'Menacing', 'Mimic', 'NightVision', 'NimbleFingers', 'NobleBlood', 'NoseForTrouble', 'Numismatics', 'OldSalt', 'Orientation', 'Panhandle', 'PerfectPitch', 'PettyMagic', 'Pharmacist', 'Pilot', 'PublicSpeaker', 'PureSoul', 'RapidReload', 'ReactionStrike', 'ReadWrite', 'Relentless', 'Resistance1', 'Resistance2', 'Resistance3', 'Resolute', 'Reversal', 'Riposte', 'RiverGuide', 'Robust', 'Roughrider', 'Rover', 'Savant1', 'Savant2', 'Savant3', 'Savvy', 'ScaleSheerSurface', 'Schemer', 'SeaLegs', 'SeasonedTraveller', 'SecondSight', 'SecretIdentity', 'Shadow', 'Sharp', 'Sharpshooter', 'Shieldsman', 'SixthSense', 'Slayer', 'Sniper', 'Speedreader', 'Sprinter', 'StepAside', 'StoneSoup', 'StoutHearted', 'Strider1', 'Strider2', 'Strider3', 'Sprinter', 'StrikeMightyBlow', 'StriketoInjure', 'StriketoStun', 'StrongBack', 'StrongLegs', 'Strongminded', 'StrongSwimmer', 'Sturdy', 'Suave', 'SuffusedWithAqshy', 'SuffusedWithAzyr', 'SuffusedWithChamon', 'SuffusedWithChamon', 'SuffusedWithGhur', 'SuffusedWithGhyran', 'SuffusedWithHysh', 'SuffusedWithShyish', 'SuffusedWithUglu', 'SuperNumerate', 'Supportive', 'SureShot', 'Surgery', 'Tenacious', 'Tinker', 'TowerOfMemories', 'Trapper', 'TrickRiding', 'TunnelRat', 'Unshakable', 'VeryResilient', 'VeryStrong', 'Vice', 'WarLeader', 'WarWizard', 'WarriorBorn', 'Waterman', 'Wealthy', 'Wellprepared', 'Witch'];
 	
 	total = 0;	
 	
@@ -46249,7 +46314,7 @@ on('sheet:opened change:repeating_otherxp:otherxp change:repeating_otherxp:other
 	
 	on(`change:Talent_${talent}XP`, function (eventInfo) {		
 
-	getAttrs(["sheetcheck", 'Talent_AccurateShotXP', 'Talent_AccurateShotLvl', 'Talent_AcuteSense1XP', 'Talent_AcuteSense1Lvl', 'Talent_AcuteSense1', 'Talent_AcuteSense2XP', 'Talent_AcuteSense2Lvl', 'Talent_AcuteSense2', 'Talent_AethyricAttunementXP', 'Talent_AethyricAttunementLvl', 'Talent_AlleyCatXP', 'Talent_AlleyCatLvl', 'Talent_AmbidextrousXP', 'Talent_AmbidextrousLvl', 'Talent_AnimalAffinityXP', 'Talent_AnimalAffinityLvl', 'Talent_ArcaneMagic1XP', 'Talent_ArcaneMagic1Lvl', 'Talent_ArcaneMagic1', 'Talent_ArcaneMagic2XP', 'Talent_ArcaneMagic2Lvl', 'Talent_ArcaneMagic2', 'Talent_ArcaneMagic3XP', 'Talent_ArcaneMagic3Lvl', 'Talent_ArcaneMagic3', 'Talent_ArcaneMagic4XP', 'Talent_ArcaneMagic4Lvl', 'Talent_ArcaneMagic4', 'Talent_ArgumentativeXP', 'Talent_ArgumentativeLvl', 'Talent_ArtisticXP', 'Talent_ArtisticLvl', 'Talent_AttractiveXP', 'Talent_AttractiveLvl', 'Talent_BattleRageXP', 'Talent_BattleRageLvl', 'Talent_BeneathNoticeXP', 'Talent_BeneathNoticeLvl', 'Talent_BeatBladeXP', 'Talent_BeatBladeLvl', 'Talent_BerserkChargeXP', 'Talent_BerserkChargeLvl', 'Talent_BreakandEnterXP', 'Talent_BreakandEnterLvl', 'Talent_BlatherXP', 'Talent_BlatherLvl', 'Talent_BlessXP', 'Talent_BlessLvl', 'Talent_Bless', 'Talent_BookishXP', 'Talent_BookishLvl', 'Talent_BriberXP', 'Talent_BriberLvl', 'Talent_CardsharpXP', 'Talent_CardsharpLvl', 'Talent_CarefulStrikeXP', 'Talent_CarefulStrikeLvl', 'Talent_CarouserXP', 'Talent_CarouserLvl', 'Talent_CatfallXP', 'Talent_CatfallLvl', 'Talent_CattonguedXP', 'Talent_CattonguedLvl', 'Talent_ChaosMagic1XP', 'Talent_ChaosMagic1Lvl', 'Talent_ChaosMagic1', 'Talent_ChaosMagic2XP', 'Talent_ChaosMagic2Lvl', 'Talent_ChaosMagic2', 'Talent_ChaosMagic3XP', 'Talent_ChaosMagic3Lvl', 'Talent_ChaosMagic3', 'Talent_ChaosMagic4XP', 'Talent_ChaosMagic4Lvl', 'Talent_ChaosMagic4', 'Talent_CombatAwareXP', 'Talent_CombatAwareLvl', 'Talent_CombatMasterXP', 'Talent_CombatMasterLvl', 'Talent_CombatReflexesXP', 'Talent_CombatReflexesLvl', 'Talent_CommandingPresenceXP', 'Talent_CommandingPresenceLvl', 'Talent_ConcoctXP', 'Talent_ConcoctLvl', 'Talent_ContortionistXP', 'Talent_ContortionistLvl', 'Talent_CoolheadedXP', 'Talent_CoolheadedLvl', 'Talent_CracktheWhipXP', 'Talent_CracktheWhipLvl', 'Talent_Craftsman1XP', 'Talent_Craftsman1Lvl', 'Talent_Craftsman1', 'Talent_Craftsman2XP', 'Talent_Craftsman2Lvl', 'Talent_Craftsman2', 'Talent_Craftsman3XP', 'Talent_Craftsman3Lvl', 'Talent_Craftsman3', 'Talent_CrewCommanderXP', 'Talent_CrewCommanderLvl', 'Talent_CriminalXP', 'Talent_CriminalLvl', 'Talent_DeadeyeShotXP', 'Talent_DeadeyeShotLvl', 'Talent_DealmakerXP', 'Talent_DealmakerLvl', 'Talent_DetectArtefactXP', 'Talent_DetectArtefactLvl', 'Talent_DicemanXP', 'Talent_DicemanLvl', 'Talent_DirtyFightingXP', 'Talent_DirtyFightingLvl', 'Talent_DisarmXP', 'Talent_DisarmLvl', 'Talent_DistractXP', 'Talent_DistractLvl', 'Talent_DrilledXP', 'Talent_DrilledLvl', 'Talent_DualWielderXP', 'Talent_DualWielderLvl', 'Talent_EmbezzleXP', 'Talent_EmbezzleLvl', 'Talent_EnclosedFighterXP', 'Talent_EnclosedFighterLvl', 'Talent_Etiquette1XP', 'Talent_Etiquette1Lvl', 'Talent_Etiquette2XP', 'Talent_Etiquette2Lvl', 'Talent_Etiquette3XP', 'Talent_Etiquette3Lvl', 'Talent_Etiquette4XP', 'Talent_Etiquette4Lvl', 'Talent_Etiquette5XP', 'Talent_Etiquette5Lvl', 'Talent_Etiquette6XP', 'Talent_Etiquette6Lvl', 'Talent_FastHandsXP', 'Talent_FastHandsLvl', 'Talent_FastShotXP', 'Talent_FastShotLvl', 'Talent_Fearless1XP', 'Talent_Fearless1Lvl', 'Talent_Fearless2XP', 'Talent_Fearless2Lvl', 'Talent_Fearless3XP', 'Talent_Fearless3Lvl', 'Talent_Fearless4XP', 'Talent_Fearless4Lvl', 'Talent_FeintXP', 'Talent_FeintLvl', 'Talent_FieldDressingXP', 'Talent_FieldDressingLvl', 'Talent_FishermanXP', 'Talent_FishermanLvl', 'Talent_FlagellantXP', 'Talent_FlagellantLvl', 'Talent_FleeXP', 'Talent_FleeLvl', 'Talent_FleetFootedXP', 'Talent_FleetFootedLvl', 'Talent_FrenzyXP', 'Talent_FrenzyLvl', 'Talent_FrighteningXP', 'Talent_FrighteningLvl', 'Talent_FuriousAssaultXP', 'Talent_FuriousAssaultLvl', 'Talent_GregariousXP', 'Talent_GregariousLvl', 'Talent_GunnerXP', 'Talent_GunnerLvl', 'Talent_HardyXP', 'Talent_HardyLvl', 'Talent_Hatred1XP', 'Talent_Hatred1Lvl', 'Talent_Hatred2XP', 'Talent_Hatred2Lvl', 'Talent_Hatred3XP', 'Talent_Hatred3Lvl', 'Talent_Hatred4XP', 'Talent_Hatred4Lvl', 'Talent_HolyHatredXP', 'Talent_HolyHatredLvl', 'Talent_HolyVisionsXP', 'Talent_HolyVisionsLvl', 'Talent_HuntersEyeXP', 'Talent_HuntersEyeLvl', 'Talent_ImpassionedZealXP', 'Talent_ImpassionedZealLvl', 'Talent_ImplacableXP', 'Talent_ImplacableLvl', 'Talent_InfighterXP', 'Talent_InfighterLvl', 'Talent_InspiringXP', 'Talent_InspiringLvl', 'Talent_InstinctiveDictionXP', 'Talent_InstinctiveDictionLvl', 'Talent_InvokeXP', 'Talent_InvokeLvl', 'Talent_Invoke', 'Talent_IronJawLvl', 'Talent_IronJawXP', 'Talent_IronWillLvl', 'Talent_IronWillXP', 'Talent_JumpUpXP', 'Talent_JumpUpLvl', 'Talent_KingpinXP', 'Talent_KingpinLvl', 'Talent_LightningReflexesXP', 'Talent_LightningReflexesLvl', 'Talent_LinguisticsXP', 'Talent_LinguisticsLvl', 'Talent_LipReadingXP', 'Talent_LipReadingLvl', 'Talent_LuckXP', 'Talent_LuckLvl', 'Talent_MagicalSenseXP', 'Talent_MagicalSenseLvl', 'Talent_MagicalAssistantXP', 'Talent_MagicalAssistantLvl', 'Talent_MagicResistanceXP', 'Talent_MagicResistanceLvl', 'Talent_MagnumOpusXP', 'Talent_MagnumOpusLvl', 'Talent_MarksmanXP', 'Talent_MarksmanLvl', 'Talent_MasterAndCommanderXP', 'Talent_MasterOfDisguiseXP', 'Talent_MasterOfDisguiseLvl', 'Talent_MasterOratorXP', 'Talent_MasterOratorLvl', 'Talent_MasterTradesman1XP', 'Talent_MasterTradesman1Lvl', 'Talent_MasterTradesman2XP', 'Talent_MasterTradesman2Lvl', 'Talent_MasterTradesman3XP', 'Talent_MasterTradesman3Lvl', 'Talent_MenacingXP', 'Talent_MenacingLvl', 'Talent_MimicXP', 'Talent_MimicLvl', 'Talent_NightVisionXP', 'Talent_NightVisionLvl', 'Talent_NimbleFingersXP', 'Talent_NimbleFingersLvl', 'Talent_NobleBloodXP', 'Talent_NobleBloodLvl', 'Talent_NoseForTroubleXP', 'Talent_NoseForTroubleLvl', 'Talent_NumismaticsXP', 'Talent_NumismaticsLvl', 'Talent_OldSaltXP', 'Talent_OldSaltLvl', 'Talent_OrientationXP', 'Talent_OrientationLvl', 'Talent_PanhandleXP', 'Talent_PanhandleLvl', 'Talent_PerfectPitchXP', 'Talent_PerfectPitchLvl', 'Talent_PettyMagicXP', 'Talent_PettyMagicLvl', 'Talent_PharmacistXP', 'Talent_PharmacistLvl', 'Talent_PilotXP', 'Talent_PilotLvl', 'Talent_PublicSpeakerXP', 'Talent_PublicSpeakerLvl', 'Talent_PureSoulXP', 'Talent_PureSoulLvl', 'Talent_RapidReloadXP', 'Talent_RapidReloadLvl', 'Talent_ReactionStrikeXP', 'Talent_ReactionStrikeLvl', 'Talent_ReadWriteXP', 'Talent_ReadWriteLvl', 'Talent_RelentlessXP', 'Talent_RelentlessLvl', 'Talent_Resistance1XP', 'Talent_Resistance1Lvl', 'Talent_Resistance1', 'Talent_Resistance2XP', 'Talent_Resistance2Lvl', 'Talent_Resistance2', 'Talent_Resistance3XP', 'Talent_Resistance3Lvl', 'Talent_Resistance3', 'Talent_ResoluteXP', 'Talent_ResoluteLvl', 'Talent_ReversalXP', 'Talent_ReversalLvl', 'Talent_RiposteXP', 'Talent_RiposteLvl', 'Talent_RiverGuideXP', 'Talent_RiverGuideLvl', 'Talent_RobustXP', 'Talent_RobustLvl', 'Talent_RoughriderXP', 'Talent_RoughriderLvl', 'Talent_RoverXP', 'Talent_RoverLvl', 'Talent_Savant1XP', 'Talent_Savant1Lvl', 'Talent_Savant2XP', 'Talent_Savant2Lvl', 'Talent_Savant3XP', 'Talent_Savant3Lvl', 'Talent_SavvyXP', 'Talent_SavvyLvl', 'Talent_ScaleSheerSurfaceXP', 'Talent_ScaleSheerSurfaceLvl', 'Talent_SchemerXP', 'Talent_SchemerLvl', 'Talent_SeaLegsXP', 'Talent_SeaLegsLvl', 'Talent_SeasonedTravellerXP', 'Talent_SeasonedTravellerLvl', 'Talent_SecondSightXP', 'Talent_SecondSightLvl', 'Talent_SecretIdentityXP', 'Talent_SecretIdentityLvl', 'Talent_ShadowXP', 'Talent_ShadowLvl', 'Talent_SharpXP', 'Talent_SharpLvl', 'Talent_SharpshooterXP', 'Talent_SharpshooterLvl', 'Talent_ShieldsmanXP', 'Talent_ShieldsmanLvl', 'Talent_SixthSenseXP', 'Talent_SixthSenseLvl', 'Talent_SlayerXP', 'Talent_SlayerLvl', 'Talent_SniperXP', 'Talent_SniperLvl', 'Talent_SpeedreaderXP', 'Talent_SpeedreaderLvl', 'Talent_SprinterXP', 'Talent_SprinterLvl', 'Talent_StepAsideXP', 'Talent_StepAsideLvl', 'Talent_StoneSoupXP', 'Talent_StoneSoupLvl', 'Talent_StoutHeartedXP', 'Talent_StoutHeartedLvl', 'Talent_Strider1XP', 'Talent_Strider1Lvl', 'Talent_Strider2XP', 'Talent_Strider2Lvl', 'Talent_Strider3XP', 'Talent_Strider3Lvl', 'Talent_StrikeMightyBlowXP', 'Talent_StrikeMightyBlowLvl', 'Talent_StriketoInjureXP', 'Talent_StriketoInjureLvl', 'Talent_StriketoStunXP', 'Talent_StriketoStunLvl', 'Talent_StrongBackXP', 'Talent_StrongBackLvl', 'Talent_StrongLegsXP', 'Talent_StrongLegsLvl', 'Talent_StrongmindedXP', 'Talent_StrongmindedLvl', 'Talent_StrongSwimmerXP', 'Talent_StrongSwimmerLvl', 'Talent_SturdyXP', 'Talent_SturdyLvl', 'Talent_SuaveXP', 'Talent_SuaveLvl', 'Talent_SuffusedWithAqshyXP', 'Talent_SuffusedWithAqshyLvl', 'Talent_SuffusedWithAzyrXP', 'Talent_SuffusedWithAzyrLvl', 'Talent_SuffusedWithChamonXP', 'Talent_SuffusedWithChamonLvl', 'Talent_SuffusedWithGhurXP', 'Talent_SuffusedWithGhurLvl', 'Talent_SuffusedWithGhyranXP', 'Talent_SuffusedWithGhyranLvl', 'Talent_SuffusedWithHyshXP', 'Talent_SuffusedWithHyshLvl', 'Talent_SuffusedWithShyishXP', 'Talent_SuffusedWithShyishLvl', 'Talent_SuffusedWithUgluXP', 'Talent_SuffusedWithUgluLvl', 'Talent_SuperNumerateXP', 'Talent_SuperNumerateLvl', 'Talent_SupportiveXP', 'Talent_SupportiveLvl', 'Talent_SureShotXP', 'Talent_SureShotLvl', 'Talent_SurgeryXP', 'Talent_SurgeryLvl', 'Talent_TenaciousXP', 'Talent_TenaciousLvl', 'Talent_TinkerXP', 'Talent_TinkerLvl', 'Talent_TowerOfMemoriesXP', 'Talent_TowerOfMemoriesLvl', 'Talent_TrapperXP', 'Talent_TrapperLvl', 'Talent_TrickRidingXP', 'Talent_TrickRidingLvl', 'Talent_TunnelRatXP', 'Talent_TunnelRatLvl', 'Talent_UnshakableXP', 'Talent_UnshakableLvl', 'Talent_VeryResilientXP', 'Talent_VeryResilientLvl', 'Talent_VeryStrongXP', 'Talent_VeryStrongLvl', 'Talent_ViceXP', 'Talent_ViceLvl', 'Talent_WarLeaderXP', 'Talent_WarLeaderLvl', 'Talent_WarWizardXP', 'Talent_WarWizardLvl', 'Talent_WarriorBornXP', 'Talent_WarriorBornLvl', 'Talent_WatermanXP', 'Talent_WatermanLvl', 'Talent_WealthyXP', 'Talent_WealthyLvl', 'Talent_WellpreparedXP', 'Talent_WellpreparedLvl', 'Talent_WitchXP', 'Talent_WitchLvl'], function (v) {
+	getAttrs(["sheetcheck", 'Talent_AccurateShotXP', 'Talent_AccurateShotLvl', 'Talent_AcuteSense1XP', 'Talent_AcuteSense1Lvl', 'Talent_AcuteSense1', 'Talent_AcuteSense2XP', 'Talent_AcuteSense2Lvl', 'Talent_AcuteSense2', 'Talent_AethyricAttunementXP', 'Talent_AethyricAttunementLvl', 'Talent_AlleyCatXP', 'Talent_AlleyCatLvl', 'Talent_AmbidextrousXP', 'Talent_AmbidextrousLvl', 'Talent_AnimalAffinityXP', 'Talent_AnimalAffinityLvl', 'Talent_ArcaneMagic1XP', 'Talent_ArcaneMagic1Lvl', 'Talent_ArcaneMagic1', 'Talent_ArcaneMagic2XP', 'Talent_ArcaneMagic2Lvl', 'Talent_ArcaneMagic2', 'Talent_ArcaneMagic3XP', 'Talent_ArcaneMagic3Lvl', 'Talent_ArcaneMagic3', 'Talent_ArcaneMagic4XP', 'Talent_ArcaneMagic4Lvl', 'Talent_ArcaneMagic4', 'Talent_ArgumentativeXP', 'Talent_ArgumentativeLvl', 'Talent_ArtisticXP', 'Talent_ArtisticLvl', 'Talent_AttractiveXP', 'Talent_AttractiveLvl', 'Talent_BattleRageXP', 'Talent_BattleRageLvl', 'Talent_BeneathNoticeXP', 'Talent_BeneathNoticeLvl', 'Talent_BeatBladeXP', 'Talent_BeatBladeLvl', 'Talent_BerserkChargeXP', 'Talent_BerserkChargeLvl', 'Talent_BreakandEnterXP', 'Talent_BreakandEnterLvl', 'Talent_BlatherXP', 'Talent_BlatherLvl', 'Talent_BlessXP', 'Talent_BlessLvl', 'Talent_Bless', 'Talent_BookishXP', 'Talent_BookishLvl', 'Talent_BriberXP', 'Talent_BriberLvl', 'Talent_CardsharpXP', 'Talent_CardsharpLvl', 'Talent_CantorXP', 'Talent_CantorLvl', 'Talent_CarefulStrikeXP', 'Talent_CarefulStrikeLvl', 'Talent_CarouserXP', 'Talent_CarouserLvl', 'Talent_CatfallXP', 'Talent_CatfallLvl', 'Talent_CattonguedXP', 'Talent_CattonguedLvl', 'Talent_ChantyXP', 'Talent_ChantyLvl', 'Talent_ChaosMagic1XP', 'Talent_ChaosMagic1Lvl', 'Talent_ChaosMagic1', 'Talent_ChaosMagic2XP', 'Talent_ChaosMagic2Lvl', 'Talent_ChaosMagic2', 'Talent_ChaosMagic3XP', 'Talent_ChaosMagic3Lvl', 'Talent_ChaosMagic3', 'Talent_ChaosMagic4XP', 'Talent_ChaosMagic4Lvl', 'Talent_ChaosMagic4', 'Talent_CombatAwareXP', 'Talent_CombatAwareLvl', 'Talent_CombatMasterXP', 'Talent_CombatMasterLvl', 'Talent_CombatReflexesXP', 'Talent_CombatReflexesLvl', 'Talent_CommandingPresenceXP', 'Talent_CommandingPresenceLvl', 'Talent_ConcoctXP', 'Talent_ConcoctLvl', 'Talent_ContortionistXP', 'Talent_ContortionistLvl', 'Talent_CoolheadedXP', 'Talent_CoolheadedLvl', 'Talent_CracktheWhipXP', 'Talent_CracktheWhipLvl', 'Talent_Craftsman1XP', 'Talent_Craftsman1Lvl', 'Talent_Craftsman1', 'Talent_Craftsman2XP', 'Talent_Craftsman2Lvl', 'Talent_Craftsman2', 'Talent_Craftsman3XP', 'Talent_Craftsman3Lvl', 'Talent_Craftsman3', 'Talent_CrewCommanderXP', 'Talent_CrewCommanderLvl', 'Talent_CriminalXP', 'Talent_CriminalLvl', 'Talent_DeadeyeShotXP', 'Talent_DeadeyeShotLvl', 'Talent_DealmakerXP', 'Talent_DealmakerLvl', 'Talent_DetectArtefactXP', 'Talent_DetectArtefactLvl', 'Talent_DicemanXP', 'Talent_DicemanLvl', 'Talent_DirtyFightingXP', 'Talent_DirtyFightingLvl', 'Talent_DisarmXP', 'Talent_DisarmLvl', 'Talent_DistractXP', 'Talent_DistractLvl', 'Talent_DrilledXP', 'Talent_DrilledLvl', 'Talent_DualWielderXP', 'Talent_DualWielderLvl', 'Talent_EmbezzleXP', 'Talent_EmbezzleLvl', 'Talent_EnclosedFighterXP', 'Talent_EnclosedFighterLvl', 'Talent_Etiquette1XP', 'Talent_Etiquette1Lvl', 'Talent_Etiquette2XP', 'Talent_Etiquette2Lvl', 'Talent_Etiquette3XP', 'Talent_Etiquette3Lvl', 'Talent_Etiquette4XP', 'Talent_Etiquette4Lvl', 'Talent_Etiquette5XP', 'Talent_Etiquette5Lvl', 'Talent_Etiquette6XP', 'Talent_Etiquette6Lvl', 'Talent_FastHandsXP', 'Talent_FastHandsLvl', 'Talent_FastShotXP', 'Talent_FastShotLvl', 'Talent_Fearless1XP', 'Talent_Fearless1Lvl', 'Talent_Fearless2XP', 'Talent_Fearless2Lvl', 'Talent_Fearless3XP', 'Talent_Fearless3Lvl', 'Talent_Fearless4XP', 'Talent_Fearless4Lvl', 'Talent_FeintXP', 'Talent_FeintLvl', 'Talent_FieldDressingXP', 'Talent_FieldDressingLvl', 'Talent_FishermanXP', 'Talent_FishermanLvl', 'Talent_FlagellantXP', 'Talent_FlagellantLvl', 'Talent_FleeXP', 'Talent_FleeLvl', 'Talent_FleetFootedXP', 'Talent_FleetFootedLvl', 'Talent_FrenzyXP', 'Talent_FrenzyLvl', 'Talent_FrighteningXP', 'Talent_FrighteningLvl', 'Talent_FuriousAssaultXP', 'Talent_FuriousAssaultLvl', 'Talent_GregariousXP', 'Talent_GregariousLvl', 'Talent_GunnerXP', 'Talent_GunnerLvl', 'Talent_HardyXP', 'Talent_HardyLvl', 'Talent_Hatred1XP', 'Talent_Hatred1Lvl', 'Talent_Hatred2XP', 'Talent_Hatred2Lvl', 'Talent_Hatred3XP', 'Talent_Hatred3Lvl', 'Talent_Hatred4XP', 'Talent_Hatred4Lvl', 'Talent_HolyHatredXP', 'Talent_HolyHatredLvl', 'Talent_HolyVisionsXP', 'Talent_HolyVisionsLvl', 'Talent_HuntersEyeXP', 'Talent_HuntersEyeLvl', 'Talent_ImpassionedZealXP', 'Talent_ImpassionedZealLvl', 'Talent_ImplacableXP', 'Talent_ImplacableLvl', 'Talent_InfighterXP', 'Talent_InfighterLvl', 'Talent_InspiringXP', 'Talent_InspiringLvl', 'Talent_InstinctiveDictionXP', 'Talent_InstinctiveDictionLvl', 'Talent_InvokeXP', 'Talent_InvokeLvl', 'Talent_Invoke', 'Talent_IronJawLvl', 'Talent_IronJawXP', 'Talent_IronWillLvl', 'Talent_IronWillXP', 'Talent_JumpUpXP', 'Talent_JumpUpLvl', 'Talent_KingpinXP', 'Talent_KingpinLvl', 'Talent_LightningReflexesXP', 'Talent_LightningReflexesLvl', 'Talent_LinguisticsXP', 'Talent_LinguisticsLvl', 'Talent_LipReadingXP', 'Talent_LipReadingLvl', 'Talent_LuckXP', 'Talent_LuckLvl', 'Talent_MagicalSenseXP', 'Talent_MagicalSenseLvl', 'Talent_MagicalAssistantXP', 'Talent_MagicalAssistantLvl', 'Talent_MagicResistanceXP', 'Talent_MagicResistanceLvl', 'Talent_MagnumOpusXP', 'Talent_MagnumOpusLvl', 'Talent_MarksmanXP', 'Talent_MarksmanLvl', 'Talent_MasterAndCommanderXP', 'Talent_MasterOfDisguiseXP', 'Talent_MasterOfDisguiseLvl', 'Talent_MasterOratorXP', 'Talent_MasterOratorLvl', 'Talent_MasterTradesman1XP', 'Talent_MasterTradesman1Lvl', 'Talent_MasterTradesman2XP', 'Talent_MasterTradesman2Lvl', 'Talent_MasterTradesman3XP', 'Talent_MasterTradesman3Lvl', 'Talent_MenacingXP', 'Talent_MenacingLvl', 'Talent_MimicXP', 'Talent_MimicLvl', 'Talent_NightVisionXP', 'Talent_NightVisionLvl', 'Talent_NimbleFingersXP', 'Talent_NimbleFingersLvl', 'Talent_NobleBloodXP', 'Talent_NobleBloodLvl', 'Talent_NoseForTroubleXP', 'Talent_NoseForTroubleLvl', 'Talent_NumismaticsXP', 'Talent_NumismaticsLvl', 'Talent_OldSaltXP', 'Talent_OldSaltLvl', 'Talent_OrientationXP', 'Talent_OrientationLvl', 'Talent_PanhandleXP', 'Talent_PanhandleLvl', 'Talent_PerfectPitchXP', 'Talent_PerfectPitchLvl', 'Talent_PettyMagicXP', 'Talent_PettyMagicLvl', 'Talent_PharmacistXP', 'Talent_PharmacistLvl', 'Talent_PilotXP', 'Talent_PilotLvl', 'Talent_PublicSpeakerXP', 'Talent_PublicSpeakerLvl', 'Talent_PureSoulXP', 'Talent_PureSoulLvl', 'Talent_RapidReloadXP', 'Talent_RapidReloadLvl', 'Talent_ReactionStrikeXP', 'Talent_ReactionStrikeLvl', 'Talent_ReadWriteXP', 'Talent_ReadWriteLvl', 'Talent_RelentlessXP', 'Talent_RelentlessLvl', 'Talent_Resistance1XP', 'Talent_Resistance1Lvl', 'Talent_Resistance1', 'Talent_Resistance2XP', 'Talent_Resistance2Lvl', 'Talent_Resistance2', 'Talent_Resistance3XP', 'Talent_Resistance3Lvl', 'Talent_Resistance3', 'Talent_ResoluteXP', 'Talent_ResoluteLvl', 'Talent_ReversalXP', 'Talent_ReversalLvl', 'Talent_RiposteXP', 'Talent_RiposteLvl', 'Talent_RiverGuideXP', 'Talent_RiverGuideLvl', 'Talent_RobustXP', 'Talent_RobustLvl', 'Talent_RoughriderXP', 'Talent_RoughriderLvl', 'Talent_RoverXP', 'Talent_RoverLvl', 'Talent_Savant1XP', 'Talent_Savant1Lvl', 'Talent_Savant2XP', 'Talent_Savant2Lvl', 'Talent_Savant3XP', 'Talent_Savant3Lvl', 'Talent_SavvyXP', 'Talent_SavvyLvl', 'Talent_ScaleSheerSurfaceXP', 'Talent_ScaleSheerSurfaceLvl', 'Talent_SchemerXP', 'Talent_SchemerLvl', 'Talent_SeaLegsXP', 'Talent_SeaLegsLvl', 'Talent_SeasonedTravellerXP', 'Talent_SeasonedTravellerLvl', 'Talent_SecondSightXP', 'Talent_SecondSightLvl', 'Talent_SecretIdentityXP', 'Talent_SecretIdentityLvl', 'Talent_ShadowXP', 'Talent_ShadowLvl', 'Talent_SharpXP', 'Talent_SharpLvl', 'Talent_SharpshooterXP', 'Talent_SharpshooterLvl', 'Talent_ShieldsmanXP', 'Talent_ShieldsmanLvl', 'Talent_SixthSenseXP', 'Talent_SixthSenseLvl', 'Talent_SlayerXP', 'Talent_SlayerLvl', 'Talent_SniperXP', 'Talent_SniperLvl', 'Talent_SpeedreaderXP', 'Talent_SpeedreaderLvl', 'Talent_SprinterXP', 'Talent_SprinterLvl', 'Talent_StepAsideXP', 'Talent_StepAsideLvl', 'Talent_StoneSoupXP', 'Talent_StoneSoupLvl', 'Talent_StoutHeartedXP', 'Talent_StoutHeartedLvl', 'Talent_Strider1XP', 'Talent_Strider1Lvl', 'Talent_Strider2XP', 'Talent_Strider2Lvl', 'Talent_Strider3XP', 'Talent_Strider3Lvl', 'Talent_StrikeMightyBlowXP', 'Talent_StrikeMightyBlowLvl', 'Talent_StriketoInjureXP', 'Talent_StriketoInjureLvl', 'Talent_StriketoStunXP', 'Talent_StriketoStunLvl', 'Talent_StrongBackXP', 'Talent_StrongBackLvl', 'Talent_StrongLegsXP', 'Talent_StrongLegsLvl', 'Talent_StrongmindedXP', 'Talent_StrongmindedLvl', 'Talent_StrongSwimmerXP', 'Talent_StrongSwimmerLvl', 'Talent_SturdyXP', 'Talent_SturdyLvl', 'Talent_SuaveXP', 'Talent_SuaveLvl', 'Talent_SuffusedWithAqshyXP', 'Talent_SuffusedWithAqshyLvl', 'Talent_SuffusedWithAzyrXP', 'Talent_SuffusedWithAzyrLvl', 'Talent_SuffusedWithChamonXP', 'Talent_SuffusedWithChamonLvl', 'Talent_SuffusedWithGhurXP', 'Talent_SuffusedWithGhurLvl', 'Talent_SuffusedWithGhyranXP', 'Talent_SuffusedWithGhyranLvl', 'Talent_SuffusedWithHyshXP', 'Talent_SuffusedWithHyshLvl', 'Talent_SuffusedWithShyishXP', 'Talent_SuffusedWithShyishLvl', 'Talent_SuffusedWithUgluXP', 'Talent_SuffusedWithUgluLvl', 'Talent_SuperNumerateXP', 'Talent_SuperNumerateLvl', 'Talent_SupportiveXP', 'Talent_SupportiveLvl', 'Talent_SureShotXP', 'Talent_SureShotLvl', 'Talent_SurgeryXP', 'Talent_SurgeryLvl', 'Talent_TenaciousXP', 'Talent_TenaciousLvl', 'Talent_TinkerXP', 'Talent_TinkerLvl', 'Talent_TowerOfMemoriesXP', 'Talent_TowerOfMemoriesLvl', 'Talent_TrapperXP', 'Talent_TrapperLvl', 'Talent_TrickRidingXP', 'Talent_TrickRidingLvl', 'Talent_TunnelRatXP', 'Talent_TunnelRatLvl', 'Talent_UnshakableXP', 'Talent_UnshakableLvl', 'Talent_VeryResilientXP', 'Talent_VeryResilientLvl', 'Talent_VeryStrongXP', 'Talent_VeryStrongLvl', 'Talent_ViceXP', 'Talent_ViceLvl', 'Talent_WarLeaderXP', 'Talent_WarLeaderLvl', 'Talent_WarWizardXP', 'Talent_WarWizardLvl', 'Talent_WarriorBornXP', 'Talent_WarriorBornLvl', 'Talent_WatermanXP', 'Talent_WatermanLvl', 'Talent_WealthyXP', 'Talent_WealthyLvl', 'Talent_WellpreparedXP', 'Talent_WellpreparedLvl', 'Talent_WitchXP', 'Talent_WitchLvl'], function (v) {
 
 			if (v.Talent_AccurateShotLvl > 0) {out = getTranslationByKey('ACCURATE-SHOT') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_AccurateShotLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_AccurateShotXP + '  ✥  '; } else {out = '';}
 			if (v.Talent_AcuteSense1Lvl > 0) {out += getTranslationByKey('ACUTE-SENSE') + ' (' + v.Talent_AcuteSense1 + ') ' + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_AcuteSense1Lvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_AcuteSense1XP + '  ✥  '; } else {out += '';}
@@ -46275,11 +46340,13 @@ on('sheet:opened change:repeating_otherxp:otherxp change:repeating_otherxp:other
 			if (v.Talent_BookishLvl > 0) {out += getTranslationByKey('BOOKISH') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_BookishLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_BookishXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_BriberLvl > 0) {out += getTranslationByKey('BRIBER') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_BriberLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_BriberXP + '  ✥  '; } else {out += '';}
 		
+			if (v.Talent_CantorLvl > 0) {out += getTranslationByKey('CANTOR') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_CantorLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_CantorXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_CardsharpLvl > 0) {out += getTranslationByKey('CARDSHARP') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_CardsharpLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_CardsharpXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_CarefulStrikeLvl > 0) {out += getTranslationByKey('CAREFUL-STRIKE') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_CarefulStrikeLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_CarefulStrikeXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_CarouserLvl > 0) {out += getTranslationByKey('CAROUSER') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_CarouserLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_CarouserXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_CatfallLvl > 0) {out += getTranslationByKey('CATFALL') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_CatfallLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_CatfallXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_CattonguedLvl > 0) {out += getTranslationByKey('CAT-TONGUED') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_CattonguedLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_CattonguedXP + '  ✥  '; } else {out += '';}
+			if (v.Talent_ChantyLvl > 0) {out += getTranslationByKey('CHANTY') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_ChantyLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_ChantyXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_ChaosMagic1Lvl > 0) {out += getTranslationByKey('CHAOS-MAGIC') + ' (' + v.Talent_ChaosMagic1 + ') ' + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_ChaosMagic1Lvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_ChaosMagic1XP + '  ✥  '; } else {out += '';}
 			if (v.Talent_ChaosMagic2Lvl > 0) {out += getTranslationByKey('CHAOS-MAGIC') + ' (' + v.Talent_ChaosMagic2 + ') ' + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_ChaosMagic2Lvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_ChaosMagic2XP + '  ✥  '; } else {out += '';}
 			if (v.Talent_ChaosMagic3Lvl > 0) {out += getTranslationByKey('CHAOS-MAGIC') + ' (' + v.Talent_ChaosMagic3 + ') ' + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_ChaosMagic3Lvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_ChaosMagic3XP + '  ✥  '; } else {out += '';}
@@ -46473,7 +46540,7 @@ on('sheet:opened change:repeating_otherxp:otherxp change:repeating_otherxp:other
 			if (v.Talent_WellpreparedLvl > 0) {out += getTranslationByKey('WELL-PREPARED') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_WellpreparedLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_WellpreparedXP + '  ✥  '; } else {out += '';}
 			if (v.Talent_WitchLvl > 0) {out += getTranslationByKey('WITCH!') + ' -' + ' ' + getTranslationByKey('LVL') + ': ' + v.Talent_WitchLvl + ' -' + ' ' + getTranslationByKey('XP') + ': ' + v.Talent_WitchXP + '  ✥  '; } else {out += '';}
 
-		total = 0 + parseInt(v.Talent_AccurateShotXP) + parseInt(v.Talent_AcuteSense1XP) + parseInt(v.Talent_AcuteSense2XP) + parseInt(v.Talent_AethyricAttunementXP) + parseInt(v.Talent_AlleyCatXP) + parseInt(v.Talent_AmbidextrousXP) + parseInt(v.Talent_AnimalAffinityXP) + parseInt(v.Talent_ArcaneMagic1XP) + parseInt(v.Talent_ArcaneMagic2XP) + parseInt(v.Talent_ArcaneMagic3XP) + parseInt(v.Talent_ArcaneMagic4XP) + parseInt(v.Talent_ArgumentativeXP) + parseInt(v.Talent_ArtisticXP) + parseInt(v.Talent_AttractiveXP) + parseInt(v.Talent_BattleRageXP) + parseInt(v.Talent_BeatBladeXP) + parseInt(v.Talent_BeneathNoticeXP) + parseInt(v.Talent_BerserkChargeXP) + parseInt(v.Talent_BreakandEnterXP) + parseInt(v.Talent_BlatherXP) + parseInt(v.Talent_BlessXP) + parseInt(v.Talent_BookishXP) + parseInt(v.Talent_BriberXP) + parseInt(v.Talent_CardsharpXP) + parseInt(v.Talent_CarefulStrikeXP) + parseInt(v.Talent_CarouserXP) + parseInt(v.Talent_CatfallXP) + parseInt(v.Talent_CattonguedXP) + parseInt(v.Talent_ChaosMagic1XP) + parseInt(v.Talent_ChaosMagic2XP) + parseInt(v.Talent_ChaosMagic3XP) + parseInt(v.Talent_ChaosMagic4XP) + parseInt(v.Talent_CombatAwareXP) + parseInt(v.Talent_CombatMasterXP) + parseInt(v.Talent_CombatReflexesXP) + parseInt(v.Talent_CommandingPresenceXP) + parseInt(v.Talent_ConcoctXP) + parseInt(v.Talent_ContortionistXP) + parseInt(v.Talent_CoolheadedXP) + parseInt(v.Talent_CracktheWhipXP) + parseInt(v.Talent_Craftsman1XP) + parseInt(v.Talent_Craftsman2XP) + parseInt(v.Talent_CrewCommanderXP) + parseInt(v.Talent_CriminalXP) + parseInt(v.Talent_DeadeyeShotXP) + parseInt(v.Talent_DealmakerXP) + parseInt(v.Talent_DetectArtefactXP) + parseInt(v.Talent_DicemanXP) + parseInt(v.Talent_DirtyFightingXP) + parseInt(v.Talent_DisarmXP) + parseInt(v.Talent_DistractXP) + parseInt(v.Talent_DrilledXP) + parseInt(v.Talent_DualWielderXP) + parseInt(v.Talent_EmbezzleXP) + parseInt(v.Talent_EnclosedFighterXP) + parseInt(v.Talent_Etiquette1XP) + parseInt(v.Talent_Etiquette2XP) + parseInt(v.Talent_Etiquette3XP) + parseInt(v.Talent_Etiquette4XP) + parseInt(v.Talent_Etiquette5XP) + parseInt(v.Talent_Etiquette6XP) + parseInt(v.Talent_FastHandsXP) + parseInt(v.Talent_FastShotXP) + parseInt(v.Talent_Fearless1XP) + parseInt(v.Talent_Fearless2XP) + parseInt(v.Talent_Fearless3XP) + parseInt(v.Talent_Fearless4XP) + parseInt(v.Talent_FeintXP) + parseInt(v.Talent_FieldDressingXP) + parseInt(v.Talent_FishermanXP) + parseInt(v.Talent_FlagellantXP) + parseInt(v.Talent_FleeXP) + parseInt(v.Talent_FleetFootedXP) + parseInt(v.Talent_FrenzyXP) + parseInt(v.Talent_FrighteningXP) + parseInt(v.Talent_FuriousAssaultXP) + parseInt(v.Talent_GregariousXP) + parseInt(v.Talent_GunnerXP) + parseInt(v.Talent_HardyXP) + parseInt(v.Talent_Hatred1XP) + parseInt(v.Talent_Hatred2XP) + parseInt(v.Talent_Hatred3XP) + parseInt(v.Talent_Hatred4XP) + parseInt(v.Talent_HolyHatredXP) + parseInt(v.Talent_HolyVisionsXP) + parseInt(v.Talent_HuntersEyeXP) + parseInt(v.Talent_ImpassionedZealXP) + parseInt(v.Talent_ImplacableXP) + parseInt(v.Talent_InfighterXP) + parseInt(v.Talent_InspiringXP) + parseInt(v.Talent_InstinctiveDictionXP) + parseInt(v.Talent_InvokeXP) + parseInt(v.Talent_IronJawXP) + parseInt(v.Talent_IronWillXP) + parseInt(v.Talent_JumpUpXP) + parseInt(v.Talent_KingpinXP) + parseInt(v.Talent_LightningReflexesXP) + parseInt(v.Talent_LinguisticsXP) + parseInt(v.Talent_LipReadingXP) + parseInt(v.Talent_LuckXP) + parseInt(v.Talent_MagicalSenseXP) + parseInt(v.Talent_MagicalAssistantXP) + parseInt(v.Talent_MagicResistanceXP) + parseInt(v.Talent_MagnumOpusXP) + parseInt(v.Talent_MarksmanXP) + parseInt(v.Talent_MasterAndCommanderXP) + parseInt(v.Talent_MasterOfDisguiseXP) + parseInt(v.Talent_MasterOratorXP) + parseInt(v.Talent_MasterTradesman1XP) + parseInt(v.Talent_MasterTradesman2XP) + parseInt(v.Talent_MasterTradesman3XP) + parseInt(v.Talent_MenacingXP) + parseInt(v.Talent_MimicXP) + parseInt(v.Talent_NightVisionXP) + parseInt(v.Talent_NimbleFingersXP) + parseInt(v.Talent_NoseForTroubleXP) + parseInt(v.Talent_NumismaticsXP) + parseInt(v.Talent_OldSaltXP) + parseInt(v.Talent_OrientationXP) + parseInt(v.Talent_PanhandleXP) + parseInt(v.Talent_PerfectPitchXP) + parseInt(v.Talent_PettyMagicXP) + parseInt(v.Talent_PharmacistXP) + parseInt(v.Talent_PilotXP) + parseInt(v.Talent_PublicSpeakerXP) + parseInt(v.Talent_PureSoulXP) + parseInt(v.Talent_RapidReloadXP) + parseInt(v.Talent_ReactionStrikeXP) + parseInt(v.Talent_ReadWriteXP) + parseInt(v.Talent_RelentlessXP) + parseInt(v.Talent_Resistance1XP) + parseInt(v.Talent_Resistance2XP) + parseInt(v.Talent_Resistance3XP) + parseInt(v.Talent_ResoluteXP) + parseInt(v.Talent_ReversalXP) + parseInt(v.Talent_RiposteXP) + parseInt(v.Talent_RiverGuideXP) + parseInt(v.Talent_RoughriderXP) + parseInt(v.Talent_RoverXP) + parseInt(v.Talent_SavvyXP) + parseInt(v.Talent_ScaleSheerSurfaceXP) + parseInt(v.Talent_SchemerXP) + parseInt(v.Talent_SeaLegsXP) + parseInt(v.Talent_SeasonedTravellerXP) + parseInt(v.Talent_SecondSightXP) + parseInt(v.Talent_SecretIdentityXP) + parseInt(v.Talent_ShadowXP) + parseInt(v.Talent_SharpXP) + parseInt(v.Talent_SharpshooterXP) + parseInt(v.Talent_ShieldsmanXP) + parseInt(v.Talent_SixthSenseXP) + parseInt(v.Talent_SlayerXP) + parseInt(v.Talent_SniperXP) + parseInt(v.Talent_SpeedreaderXP) + parseInt(v.Talent_SprinterXP) + parseInt(v.Talent_StepAsideXP) + parseInt(v.Talent_StoneSoupXP) + parseInt(v.Talent_StoutHeartedXP) + parseInt(v.Talent_Strider1XP) + parseInt(v.Talent_Strider2XP) + parseInt(v.Talent_Strider3XP) + parseInt(v.Talent_StrikeMightyBlowXP) + parseInt(v.Talent_StriketoInjureXP) + parseInt(v.Talent_StriketoStunXP) + parseInt(v.Talent_StrongBackXP) + parseInt(v.Talent_StrongLegsXP) + parseInt(v.Talent_StrongmindedXP) + parseInt(v.Talent_StrongSwimmerXP) +  parseInt(v.Talent_SturdyXP) +  parseInt(v.Talent_SuaveXP) + parseInt(v.Talent_SuffusedWithAqshyXP) + parseInt(v.Talent_SuffusedWithAzyrXP) + parseInt(v.Talent_SuffusedWithChamonXP) + parseInt(v.Talent_SuffusedWithGhurXP)  + parseInt(v.Talent_SuffusedWithGhyranXP) + parseInt(v.Talent_SuffusedWithHyshXP) + parseInt(v.Talent_SuffusedWithShyishXP) + parseInt(v.Talent_SuffusedWithUgluXP) + parseInt(v.Talent_SuperNumerateXP) + parseInt(v.Talent_SupportiveXP) + parseInt(v.Talent_SureShotXP) + parseInt(v.Talent_TenaciousXP) + parseInt(v.Talent_TinkerXP) + parseInt(v.Talent_TowerOfMemoriesXP) + parseInt(v.Talent_TrapperXP) + parseInt(v.Talent_TrickRidingXP) + parseInt(v.Talent_TunnelRatXP) + parseInt(v.Talent_UnshakableXP) + parseInt(v.Talent_VeryResilientXP) + parseInt(v.Talent_VeryStrongXP) + parseInt(v.Talent_ViceXP) + parseInt(v.Talent_WarLeaderXP) + parseInt(v.Talent_WarWizardXP) + parseInt(v.Talent_WarriorBornXP) + parseInt(v.Talent_WatermanXP) + parseInt(v.Talent_WealthyXP) + parseInt(v.Talent_WellpreparedXP) + parseInt(v.Talent_WitchXP) ;
+		total = 0 + parseInt(v.Talent_AccurateShotXP) + parseInt(v.Talent_AcuteSense1XP) + parseInt(v.Talent_AcuteSense2XP) + parseInt(v.Talent_AethyricAttunementXP) + parseInt(v.Talent_AlleyCatXP) + parseInt(v.Talent_AmbidextrousXP) + parseInt(v.Talent_AnimalAffinityXP) + parseInt(v.Talent_ArcaneMagic1XP) + parseInt(v.Talent_ArcaneMagic2XP) + parseInt(v.Talent_ArcaneMagic3XP) + parseInt(v.Talent_ArcaneMagic4XP) + parseInt(v.Talent_ArgumentativeXP) + parseInt(v.Talent_ArtisticXP) + parseInt(v.Talent_AttractiveXP) + parseInt(v.Talent_BattleRageXP) + parseInt(v.Talent_BeatBladeXP) + parseInt(v.Talent_BeneathNoticeXP) + parseInt(v.Talent_BerserkChargeXP) + parseInt(v.Talent_BreakandEnterXP) + parseInt(v.Talent_BlatherXP) + parseInt(v.Talent_BlessXP) + parseInt(v.Talent_BookishXP) + parseInt(v.Talent_BriberXP) + parseInt(v.Talent_CantorXP) + parseInt(v.Talent_CardsharpXP) + parseInt(v.Talent_CarefulStrikeXP) + parseInt(v.Talent_CarouserXP) + parseInt(v.Talent_CatfallXP) + parseInt(v.Talent_CattonguedXP) + parseInt(v.Talent_ChantyXP) + parseInt(v.Talent_ChaosMagic1XP) + parseInt(v.Talent_ChaosMagic2XP) + parseInt(v.Talent_ChaosMagic3XP) + parseInt(v.Talent_ChaosMagic4XP) + parseInt(v.Talent_CombatAwareXP) + parseInt(v.Talent_CombatMasterXP) + parseInt(v.Talent_CombatReflexesXP) + parseInt(v.Talent_CommandingPresenceXP) + parseInt(v.Talent_ConcoctXP) + parseInt(v.Talent_ContortionistXP) + parseInt(v.Talent_CoolheadedXP) + parseInt(v.Talent_CracktheWhipXP) + parseInt(v.Talent_Craftsman1XP) + parseInt(v.Talent_Craftsman2XP) + parseInt(v.Talent_CrewCommanderXP) + parseInt(v.Talent_CriminalXP) + parseInt(v.Talent_DeadeyeShotXP) + parseInt(v.Talent_DealmakerXP) + parseInt(v.Talent_DetectArtefactXP) + parseInt(v.Talent_DicemanXP) + parseInt(v.Talent_DirtyFightingXP) + parseInt(v.Talent_DisarmXP) + parseInt(v.Talent_DistractXP) + parseInt(v.Talent_DrilledXP) + parseInt(v.Talent_DualWielderXP) + parseInt(v.Talent_EmbezzleXP) + parseInt(v.Talent_EnclosedFighterXP) + parseInt(v.Talent_Etiquette1XP) + parseInt(v.Talent_Etiquette2XP) + parseInt(v.Talent_Etiquette3XP) + parseInt(v.Talent_Etiquette4XP) + parseInt(v.Talent_Etiquette5XP) + parseInt(v.Talent_Etiquette6XP) + parseInt(v.Talent_FastHandsXP) + parseInt(v.Talent_FastShotXP) + parseInt(v.Talent_Fearless1XP) + parseInt(v.Talent_Fearless2XP) + parseInt(v.Talent_Fearless3XP) + parseInt(v.Talent_Fearless4XP) + parseInt(v.Talent_FeintXP) + parseInt(v.Talent_FieldDressingXP) + parseInt(v.Talent_FishermanXP) + parseInt(v.Talent_FlagellantXP) + parseInt(v.Talent_FleeXP) + parseInt(v.Talent_FleetFootedXP) + parseInt(v.Talent_FrenzyXP) + parseInt(v.Talent_FrighteningXP) + parseInt(v.Talent_FuriousAssaultXP) + parseInt(v.Talent_GregariousXP) + parseInt(v.Talent_GunnerXP) + parseInt(v.Talent_HardyXP) + parseInt(v.Talent_Hatred1XP) + parseInt(v.Talent_Hatred2XP) + parseInt(v.Talent_Hatred3XP) + parseInt(v.Talent_Hatred4XP) + parseInt(v.Talent_HolyHatredXP) + parseInt(v.Talent_HolyVisionsXP) + parseInt(v.Talent_HuntersEyeXP) + parseInt(v.Talent_ImpassionedZealXP) + parseInt(v.Talent_ImplacableXP) + parseInt(v.Talent_InfighterXP) + parseInt(v.Talent_InspiringXP) + parseInt(v.Talent_InstinctiveDictionXP) + parseInt(v.Talent_InvokeXP) + parseInt(v.Talent_IronJawXP) + parseInt(v.Talent_IronWillXP) + parseInt(v.Talent_JumpUpXP) + parseInt(v.Talent_KingpinXP) + parseInt(v.Talent_LightningReflexesXP) + parseInt(v.Talent_LinguisticsXP) + parseInt(v.Talent_LipReadingXP) + parseInt(v.Talent_LuckXP) + parseInt(v.Talent_MagicalSenseXP) + parseInt(v.Talent_MagicalAssistantXP) + parseInt(v.Talent_MagicResistanceXP) + parseInt(v.Talent_MagnumOpusXP) + parseInt(v.Talent_MarksmanXP) + parseInt(v.Talent_MasterAndCommanderXP) + parseInt(v.Talent_MasterOfDisguiseXP) + parseInt(v.Talent_MasterOratorXP) + parseInt(v.Talent_MasterTradesman1XP) + parseInt(v.Talent_MasterTradesman2XP) + parseInt(v.Talent_MasterTradesman3XP) + parseInt(v.Talent_MenacingXP) + parseInt(v.Talent_MimicXP) + parseInt(v.Talent_NightVisionXP) + parseInt(v.Talent_NimbleFingersXP) + parseInt(v.Talent_NoseForTroubleXP) + parseInt(v.Talent_NumismaticsXP) + parseInt(v.Talent_OldSaltXP) + parseInt(v.Talent_OrientationXP) + parseInt(v.Talent_PanhandleXP) + parseInt(v.Talent_PerfectPitchXP) + parseInt(v.Talent_PettyMagicXP) + parseInt(v.Talent_PharmacistXP) + parseInt(v.Talent_PilotXP) + parseInt(v.Talent_PublicSpeakerXP) + parseInt(v.Talent_PureSoulXP) + parseInt(v.Talent_RapidReloadXP) + parseInt(v.Talent_ReactionStrikeXP) + parseInt(v.Talent_ReadWriteXP) + parseInt(v.Talent_RelentlessXP) + parseInt(v.Talent_Resistance1XP) + parseInt(v.Talent_Resistance2XP) + parseInt(v.Talent_Resistance3XP) + parseInt(v.Talent_ResoluteXP) + parseInt(v.Talent_ReversalXP) + parseInt(v.Talent_RiposteXP) + parseInt(v.Talent_RiverGuideXP) + parseInt(v.Talent_RoughriderXP) + parseInt(v.Talent_RoverXP) + parseInt(v.Talent_SavvyXP) + parseInt(v.Talent_ScaleSheerSurfaceXP) + parseInt(v.Talent_SchemerXP) + parseInt(v.Talent_SeaLegsXP) + parseInt(v.Talent_SeasonedTravellerXP) + parseInt(v.Talent_SecondSightXP) + parseInt(v.Talent_SecretIdentityXP) + parseInt(v.Talent_ShadowXP) + parseInt(v.Talent_SharpXP) + parseInt(v.Talent_SharpshooterXP) + parseInt(v.Talent_ShieldsmanXP) + parseInt(v.Talent_SixthSenseXP) + parseInt(v.Talent_SlayerXP) + parseInt(v.Talent_SniperXP) + parseInt(v.Talent_SpeedreaderXP) + parseInt(v.Talent_SprinterXP) + parseInt(v.Talent_StepAsideXP) + parseInt(v.Talent_StoneSoupXP) + parseInt(v.Talent_StoutHeartedXP) + parseInt(v.Talent_Strider1XP) + parseInt(v.Talent_Strider2XP) + parseInt(v.Talent_Strider3XP) + parseInt(v.Talent_StrikeMightyBlowXP) + parseInt(v.Talent_StriketoInjureXP) + parseInt(v.Talent_StriketoStunXP) + parseInt(v.Talent_StrongBackXP) + parseInt(v.Talent_StrongLegsXP) + parseInt(v.Talent_StrongmindedXP) + parseInt(v.Talent_StrongSwimmerXP) +  parseInt(v.Talent_SturdyXP) +  parseInt(v.Talent_SuaveXP) + parseInt(v.Talent_SuffusedWithAqshyXP) + parseInt(v.Talent_SuffusedWithAzyrXP) + parseInt(v.Talent_SuffusedWithChamonXP) + parseInt(v.Talent_SuffusedWithGhurXP)  + parseInt(v.Talent_SuffusedWithGhyranXP) + parseInt(v.Talent_SuffusedWithHyshXP) + parseInt(v.Talent_SuffusedWithShyishXP) + parseInt(v.Talent_SuffusedWithUgluXP) + parseInt(v.Talent_SuperNumerateXP) + parseInt(v.Talent_SupportiveXP) + parseInt(v.Talent_SureShotXP) + parseInt(v.Talent_TenaciousXP) + parseInt(v.Talent_TinkerXP) + parseInt(v.Talent_TowerOfMemoriesXP) + parseInt(v.Talent_TrapperXP) + parseInt(v.Talent_TrickRidingXP) + parseInt(v.Talent_TunnelRatXP) + parseInt(v.Talent_UnshakableXP) + parseInt(v.Talent_VeryResilientXP) + parseInt(v.Talent_VeryStrongXP) + parseInt(v.Talent_ViceXP) + parseInt(v.Talent_WarLeaderXP) + parseInt(v.Talent_WarWizardXP) + parseInt(v.Talent_WarriorBornXP) + parseInt(v.Talent_WatermanXP) + parseInt(v.Talent_WealthyXP) + parseInt(v.Talent_WellpreparedXP) + parseInt(v.Talent_WitchXP) ;
 		
 	console.log(total);
 	if (out === "") {out = " ";}
@@ -51192,9 +51259,9 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	else if (trigger === 'endurance') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{unconscious=[[0]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{distracted=[[@{DistractedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{resistance1=[[@{Talent_Resistance1Lvl}]]}} {{resistance1name=@{Talent_Resistance1}}} {{resistance2=[[@{Talent_Resistance2Lvl}]]}} {{resistance2name=@{Talent_Resistance2}}} {{resistance3=[[@{Talent_Resistance3Lvl}]]}} {{resistance3name=@{Talent_Resistance3}}} {{tenacious=[[@{Talent_TenaciousLvl}]]}} {{ironjaw=[[@{Talent_IronJawLvl}]]}}';
 	sitmods = '+@{Talent_Resistance1Lvl}+@{Talent_Resistance2Lvl}+@{Talent_Resistance3Lvl}+@{Talent_TenaciousLvl}+@{Talent_IronJawLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `(@{condgen}-@{DrunkMod})`).replaceAll('>sitmod<', sitmods);}   
-	else if (trigger === 'entertain') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{distracted=[[@{DistractedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{masterofdisguise=[[@{Talent_MasterOfDisguiseLvl}]]}}';
-	sitmods = '+@{Talent_MasterOfDisguiseLvl}';
-	rollPart = rollPart2.replaceAll('cond-', `(@{condgen}-@{DrunkMod})`);}  
+	else if (trigger === 'entertain') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{distracted=[[@{DistractedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{masterofdisguise=[[@{Talent_MasterOfDisguiseLvl}]]}} {{cantor=[[@{Talent_CantorLvl}]]}} {{chanty=[[@{Talent_ChantyLvl}]]}}';
+	sitmods = '+@{Talent_MasterOfDisguiseLvl}+@{Talent_CantorLvl}+@{Talent_ChantyLvl}';
+	rollPart = rollPart2.replaceAll('cond-', `(@{condgen}-@{DrunkMod})`).replaceAll('>sitmod<', sitmods);}  
 	else if (trigger === 'gamble') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{distracted=[[@{DistractedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{cardsharp=[[@{Talent_CardsharpLvl}]]}} {{cardsharp=[[@{Talent_CardsharpLvl}]]}} {{diceman=[[@{Talent_DicemanLvl}]]}} {{supernumerate=[[@{Talent_SuperNumerateLvl}]]}}';
 	sitmods = '+@{Talent_CardsharpLvl}+@{Talent_CardsharpLvl}+@{Talent_DicemanLvl}';
 	addsl = '+@{Talent_SuperNumerateLvl}';
@@ -51520,8 +51587,9 @@ on('clicked:repeating_divinemiracles:miracle clicked:repeating_divinemiracles:mi
 	sitfail= '+@{Talent_AlleyCatLvl}';
 	rollPart = rollPart2.replaceAll('cond-', `@{condgen_see_move_stealth}`).replaceAll('>sitmod<', sitmods).replaceAll('>sitfail<', sitfail);}
 	
-	else if (skill === 'entertain') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{distracted=[[@{DistractedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}}';
-	rollPart = rollPart2.replaceAll('cond-', `(@{condgen}-@{DrunkMod})`);}    
+	else if (skill === 'entertain') {cond = '{{cond=[[@{condgen}-@{DrunkMod}]]}} {{unconscious=[[@{UnconsciousMod}]]}} {{drunk=[[@{DrunkMod}]]}} {{fatigued=[[@{FatiguedMod}]]}} {{broken=[[@{BrokenMod}]]}} {{stuned=[[@{StunedMod}]]}} {{distracted=[[@{DistractedMod}]]}} {{poisoned=[[@{PoisonedMod}]]}} {{prone=[[0]]}} {{entangled=[[0]]}} {{blinded=[[0]]}} {{deafened=[[0]]}} {{masterofdisguise=[[@{Talent_MasterOfDisguiseLvl}]]}} {{cantor=[[@{Talent_CantorLvl}]]}} {{chanty=[[@{Talent_ChantyLvl}]]}}';
+	sitmods= '+@{Talent_MasterOfDisguiseLvl}+@{Talent_CantorLvl}+@{Talent_ChantyLvl}';
+	rollPart = rollPart2.replaceAll('cond-', `(@{condgen}-@{DrunkMod})`).replaceAll('>sitmod<', sitmods);}    
 	
 	else {cond = ''}
 

--- a/Warhammer 4e Character Sheet/translation.json
+++ b/Warhammer 4e Character Sheet/translation.json
@@ -1898,6 +1898,10 @@
 	"HOUSERULE-COMBAT-DEF": "Custom Melee Defensive Talent Rule",
 	"HOUSERULE2-COMBAT-DEF-RULES": "Houserule 2: Reversal test SL bonus changed to Parry weapons only, Riposte test SL bonus removed",
 
+	"CANTOR": "Cantor",
+	"CANTOR-SIT": "Entertain while singing",
+	"CHANTY": "Chanty",
+	"CHANTY-SIT": "Entertain while singing",
 	"CUSTOM": "Custom",
 	"TALENT-INTEGRATION": "Talents Integration options",
 


### PR DESCRIPTION

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

- Add Cantor Talent from Heart of Glass/Ubersreik Adventures 1, situational test bonus for entertain singing.
- Add Chanty Talent from Sea of Claws, situational test bonus for entertain singing.
- Fix Master of Disguise Talent, now shows situational test bonus for entertain acting.

