### PR TITLE
[PokemonTabletopAdventures_v3] New Feature: Adds Hybrid Advanced Class Level Field

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -310,9 +310,22 @@
                 <input class="sheet-top-information" name="attr_honor_count" title="Attribute: honor_count" type="number" />
               </span>
               <b>Advanced Class</b>
-              <input class="sheet-top-information" name="attr_pokemon_advanced_class" spellcheck="false" title="Attribute: pokemon_advanced_class" type="text" value="Advanced"/>
+              <span class="sheet-hide-on-mobile">
+                <input class="sheet-top-information sheet-half-text" name="attr_pokemon_advanced_class" spellcheck="false" title="Attribute: pokemon_advanced_class" type="text" value=" "/>
+                <b>Level</b>
+                <input name="attr_level2" title="Attribute: level2" type="number" class="sheet-top-information">
+              </span>
+              <span class="sheet-show-on-mobile">
+                <input class="sheet-top-information" name="attr_pokemon_advanced_class" spellcheck="false" title="Attribute: pokemon_advanced_class" type="text" value=" "/>
+              </span>
               <b>Credits</b>
               <input class="sheet-top-information sheet-long-number" name="attr_credits" title="Attribute: credits" type="number" />
+              <span class="sheet-show-on-mobile">
+                <b>Level</b>
+              </span>
+              <span class="sheet-show-on-mobile">
+                <input name="attr_level2" title="Attribute: level2" type="number" class="sheet-top-information">
+              </span>
             </div>
 
             <div class="sheet-character-name-grid">

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,6 +23,9 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Jan 28, 2025
+- Updated the Hybrid Character to allow entering the advanced class level
+
 ### Jan 18, 2025
 - Resolved an issue with the repeating sections not showing the edit controls when appropriate
 


### PR DESCRIPTION
# Submission Checklist
## Required

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

# Changes / Description

Adds a level field for the advanced class level for hybrid-style character sheets, intended for use with Pokémon-class characters
- Ensures mobile shows the level field beneath the advanced class field
- Ensures desktop shows the field in-line with advanced class
