### PR TITLE
Palladium Rifts by Grinning Gecko v1.6.1. Features/fixes.

### DIFF
--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -84,6 +84,7 @@
 - Move Modern Strike: Pulse to Strike: Single bonus.
 - Added Migrate button instead of auto-migrating on sheet load.
 - Output PPE/ISP/MDC to chat when an amount is deducted from the sheet using the action buttons.
+- Alternating colors on repeating rows, except in the Modifier Picker.
 
 ## [1.2.0] - 2021-10-15
 

--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Active Profile columns now fill the width.
 - Fix issue where damage that rolls into the next layer now outputs the correct layer name.
 - Alternating colors on repeating rows, except in the Modifier Picker.
+- Fix issue where using a `+` in a skill modifier dialog would cause the roll to be 0.
 
 ## [1.6.0] - 2022-04-18
 

--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [1.6.1] - 2025-01-27
 
+### Added
+
+- Add roll buttons to punch and kick damage.
+- Add kick damage to Supernatural Strength.
+
 ### Changed
 
 - Move Perception from Saving Throws to beside Initiative.

--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add roll buttons to punch and kick damage.
 - Add kick damage to Supernatural Strength.
+- Add Ammo tracker to Profile tab.
 
 ### Changed
 

--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.6.1] - 2025-01-27
+
+### Changed
+
+- Move Perception from Saving Throws to beside Initiative.
+- Active Profile columns now fill the width.
+
 ## [1.6.0] - 2020-04-18
 
 ### Added

--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Move Perception from Saving Throws to beside Initiative.
 - Active Profile columns now fill the width.
+- Fix issue where damage that rolls into the next layer now outputs the correct layer name.
 
 ## [1.6.0] - 2020-04-18
 

--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Move Perception from Saving Throws to beside Initiative.
 - Active Profile columns now fill the width.
 - Fix issue where damage that rolls into the next layer now outputs the correct layer name.
+- Alternating colors on repeating rows, except in the Modifier Picker.
 
 ## [1.6.0] - 2022-04-18
 
@@ -84,7 +85,6 @@
 - Move Modern Strike: Pulse to Strike: Single bonus.
 - Added Migrate button instead of auto-migrating on sheet load.
 - Output PPE/ISP/MDC to chat when an amount is deducted from the sheet using the action buttons.
-- Alternating colors on repeating rows, except in the Modifier Picker.
 
 ## [1.2.0] - 2021-10-15
 

--- a/Palladium Rifts by Grinning Gecko/CHANGELOG.md
+++ b/Palladium Rifts by Grinning Gecko/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Active Profile columns now fill the width.
 - Fix issue where damage that rolls into the next layer now outputs the correct layer name.
 
-## [1.6.0] - 2020-04-18
+## [1.6.0] - 2022-04-18
 
 ### Added
 

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.css
@@ -660,17 +660,20 @@ a {
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner, .charsheet main#megaverse .armor .repeating_ammo-inner {
+.charsheet main#megaverse .armor .repeating_armor-inner,
+.charsheet main#megaverse .armor .repeating_ammo-inner {
   display: grid;
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
   align-items: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label, .charsheet main#megaverse .armor .repeating_ammo-inner > label {
+.charsheet main#megaverse .armor .repeating_armor-inner > label,
+.charsheet main#megaverse .armor .repeating_ammo-inner > label {
   align-self: center;
   text-align: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active, .charsheet main#megaverse .armor .repeating_ammo-inner > label > input[type=checkbox].is-active {
+.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active,
+.charsheet main#megaverse .armor .repeating_ammo-inner > label > input[type=checkbox].is-active {
   align-self: center;
 }
 .charsheet main#megaverse .profile-management {
@@ -1077,6 +1080,15 @@ body.sheet-darkmode .charsheet main#megaverse label.abs {
 }
 body.sheet-darkmode .charsheet main#megaverse label.abs:hover {
   background-color: var(--dark-primary-highlight);
+}
+body.sheet-darkmode .charsheet main#megaverse .repitem:nth-child(odd):not(.picker *) {
+  opacity: 0.7;
+}
+body.sheet-darkmode .charsheet main#megaverse .repitem:nth-child(odd):not(.picker *):has(details.info[open]) {
+  opacity: 1;
+}
+body.sheet-darkmode .charsheet main#megaverse .repitem:nth-child(even):not(.picker *) {
+  background-color: #222;
 }
 body.sheet-darkmode .charsheet main#megaverse .ss-2c {
   border-color: #444;

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.css
@@ -660,17 +660,17 @@ a {
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner {
+.charsheet main#megaverse .armor .repeating_armor-inner, .charsheet main#megaverse .armor .repeating_ammo-inner {
   display: grid;
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
   align-items: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label {
+.charsheet main#megaverse .armor .repeating_armor-inner > label, .charsheet main#megaverse .armor .repeating_ammo-inner > label {
   align-self: center;
   text-align: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active {
+.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active, .charsheet main#megaverse .armor .repeating_ammo-inner > label > input[type=checkbox].is-active {
   align-self: center;
 }
 .charsheet main#megaverse .profile-management {

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.css
@@ -478,13 +478,13 @@ a {
 .charsheet main#megaverse .bonus-ps-container {
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .bonus-ps-container label {
   display: grid;
   align-items: center;
   gap: 0.5rem;
-  grid-template-columns: 6.5rem 6rem 1fr;
+  grid-template-columns: 6.5rem minmax(4rem, 1fr) 4rem 4rem;
 }
 .charsheet main#megaverse .bonus-ps-container label.select select {
   grid-column: 2/span 2;
@@ -492,12 +492,28 @@ a {
 .charsheet main#megaverse .bonus-ps-container label input {
   width: 6rem;
 }
-.charsheet main#megaverse .bonus-ps-container label span {
+.charsheet main#megaverse .bonus-ps-container label > span {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.charsheet main#megaverse .bonus-ps-container label span[name^=attr_] {
+.charsheet main#megaverse .bonus-ps-container label > span[name^=attr_] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #eee;
+  margin: 0.1rem 0.2rem;
+  border-radius: 0.1rem;
+  font-weight: normal;
+  padding-left: 0.5rem;
+  overflow-y: auto;
+}
+.charsheet main#megaverse .bonus-ps-container label > label span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.charsheet main#megaverse .bonus-ps-container label > label span[name^=attr_] {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -511,7 +527,7 @@ a {
 .charsheet main#megaverse .bonus-type-container {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .bonus-type-container.attributes > label {
   display: grid;
@@ -697,13 +713,13 @@ a {
   border: 0;
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-ps-container {
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container {
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container.attributes {
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container.attributes > label {
   display: grid;
@@ -1084,6 +1100,11 @@ body.sheet-darkmode .charsheet main#megaverse .bonus-type-container hr,
 body.sheet-darkmode .charsheet main#megaverse .bonus-ps-container hr {
   border-color: #444;
   background-color: #444;
+}
+body.sheet-darkmode .charsheet main#megaverse .bonus-type-container > div span[name^=attr_],
+body.sheet-darkmode .charsheet main#megaverse .bonus-ps-container > div span[name^=attr_] {
+  background-color: #444;
+  border-color: #555;
 }
 body.sheet-darkmode .charsheet main#megaverse .bonus-type-container label span[name^=attr_],
 body.sheet-darkmode .charsheet main#megaverse .bonus-ps-container label span[name^=attr_] {

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.css
@@ -453,7 +453,7 @@ a {
 .charsheet main#megaverse .modifiers-attributes {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
   align-items: start;
   margin-top: 0.5rem;
 }
@@ -700,7 +700,7 @@ a {
   grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container {
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container.attributes {
   grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.html
@@ -6074,6 +6074,11 @@
               name="attr_active_profile_mod_restrained_punch_unit"
             />
             <span name="attr_active_profile_mod_restrained_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{active_profile_mod_restrained_punch}]]}}"
+              name="roll_active_profile_damage_restrained_punch"
+            ></button>
           </label>
 
           <label
@@ -6086,6 +6091,11 @@
             <span name="attr_active_profile_mod_punch"></span>
             <input type="hidden" name="attr_active_profile_mod_punch_unit" />
             <span name="attr_active_profile_mod_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{active_profile_mod_punch}]]}}"
+              name="roll_active_profile_damage_punch"
+            ></button>
           </label>
 
           <label
@@ -6101,6 +6111,11 @@
               name="attr_active_profile_mod_power_punch_unit"
             />
             <span name="attr_active_profile_mod_power_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{active_profile_mod_power_punch}]]}}"
+              name="roll_active_profile_damage_power_punch"
+            ></button>
           </label>
 
           <label
@@ -6113,6 +6128,11 @@
             <span name="attr_active_profile_mod_kick"></span>
             <input type="hidden" name="attr_active_profile_mod_kick_unit" />
             <span name="attr_active_profile_mod_kick_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{active_profile_mod_kick}]]}}"
+              name="roll_active_profile_damage_kick"
+            ></button>
           </label>
 
           <label
@@ -6128,6 +6148,11 @@
               name="attr_active_profile_mod_leap_kick_unit"
             />
             <span name="attr_active_profile_mod_leap_kick_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{active_profile_mod_leap_kick}]]}}"
+              name="roll_active_profile_damage_leap_kick"
+            ></button>
           </label>
 
           <label
@@ -7485,6 +7510,11 @@
       <span name="attr_mod_restrained_punch"></span>
       <input type="hidden" name="attr_mod_restrained_punch_unit" />
       <span name="attr_mod_restrained_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{mod_restrained_punch}]]}}"
+        name="roll_damage_restrained_punch"
+      ></button>
     </label>
 
     <label
@@ -7493,6 +7523,11 @@
       <span name="attr_mod_punch"></span>
       <input type="hidden" name="attr_mod_punch_unit" />
       <span name="attr_mod_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{mod_punch}]]}}"
+        name="roll_damage_punch"
+      ></button>
     </label>
 
     <label
@@ -7501,6 +7536,11 @@
       <span name="attr_mod_power_punch"></span>
       <input type="hidden" name="attr_mod_power_punch_unit" />
       <span name="attr_mod_power_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{mod_power_punch}]]}}"
+        name="roll_damage_power_punch"
+      ></button>
     </label>
 
     <label
@@ -7509,6 +7549,11 @@
       <span name="attr_mod_kick"></span>
       <input type="hidden" name="attr_mod_kick_unit" />
       <span name="attr_mod_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{mod_kick}]]}}"
+        name="roll_damage_kick"
+      ></button>
     </label>
 
     <label
@@ -7517,6 +7562,11 @@
       <span name="attr_mod_leap_kick"></span>
       <input type="hidden" name="attr_mod_leap_kick_unit" />
       <span name="attr_mod_leap_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{mod_leap_kick}]]}}"
+        name="roll_damage_leap_kick"
+      ></button>
     </label>
 
     <label
@@ -8728,6 +8778,11 @@
       <span name="attr_mod_restrained_punch"></span>
       <input type="hidden" name="attr_mod_restrained_punch_unit" />
       <span name="attr_mod_restrained_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{mod_restrained_punch}]]}}"
+        name="roll_damage_restrained_punch"
+      ></button>
     </label>
 
     <label
@@ -8736,6 +8791,11 @@
       <span name="attr_mod_punch"></span>
       <input type="hidden" name="attr_mod_punch_unit" />
       <span name="attr_mod_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{mod_punch}]]}}"
+        name="roll_damage_punch"
+      ></button>
     </label>
 
     <label
@@ -8744,6 +8804,11 @@
       <span name="attr_mod_power_punch"></span>
       <input type="hidden" name="attr_mod_power_punch_unit" />
       <span name="attr_mod_power_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{mod_power_punch}]]}}"
+        name="roll_damage_power_punch"
+      ></button>
     </label>
 
     <label
@@ -8752,6 +8817,11 @@
       <span name="attr_mod_kick"></span>
       <input type="hidden" name="attr_mod_kick_unit" />
       <span name="attr_mod_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{mod_kick}]]}}"
+        name="roll_damage_kick"
+      ></button>
     </label>
 
     <label
@@ -8760,6 +8830,11 @@
       <span name="attr_mod_leap_kick"></span>
       <input type="hidden" name="attr_mod_leap_kick_unit" />
       <span name="attr_mod_leap_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{mod_leap_kick}]]}}"
+        name="roll_damage_leap_kick"
+      ></button>
     </label>
 
     <label
@@ -13226,51 +13301,51 @@ async function psBonusComplete(prefix = "") {
       }
       if (ps <= 15) {
         restrained_punch = "1D6";
-        punch = "4D6";
-        power_punch = "1D4";
-        power_punch_unit = "mdc";
+        punch = kick = "4D6";
+        power_punch = leap_kick = "1D4";
+        power_punch_unit = leap_kick_unit = "mdc";
       } else if (ps <= 20) {
         restrained_punch = "3D6";
-        punch = "1D6";
-        power_punch = "2D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "1D6";
+        power_punch = leap_kick = "2D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 25) {
         restrained_punch = "4D6";
-        punch = "2D6";
-        power_punch = "4D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "2D6";
+        power_punch = leap_kick = "4D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 30) {
         restrained_punch = "5D6";
-        punch = "3D6";
-        power_punch = "6D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "3D6";
+        power_punch = leap_kick = "6D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 35) {
         restrained_punch = "5D6";
-        punch = "4D6";
-        power_punch = "1D4*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "4D6";
+        power_punch = leap_kick = "1D4*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 40) {
         restrained_punch = "6D6";
-        punch = "5D6";
-        power_punch = "1D6*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "5D6";
+        power_punch = leap_kick = "1D6*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 50) {
         restrained_punch = "1D6*10";
-        punch = "6D6";
-        power_punch = "2D4*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "6D6";
+        power_punch = leap_kick = "2D4*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 60) {
         restrained_punch = "1D6";
-        punch = "1D6*10";
-        power_punch = "2D6*10";
-        restrained_punch_unit = punch_unit = power_punch_unit = "mdc";
+        punch = kick = "1D6*10";
+        power_punch = leap_kick = "2D6*10";
+        restrained_punch_unit = punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else {
         // > 60
         const extra = Math.ceil((ps - 60) / 10) * 10;
         restrained_punch = "1D6";
-        punch = `1D6*10+${extra}`;
-        power_punch = `2D6*10+${extra * 2}`;
-        restrained_punch_unit = punch_unit = power_punch_unit = "mdc";
+        punch = kick = `1D6*10+${extra}`;
+        power_punch = leap_kick = `2D6*10+${extra * 2}`;
+        restrained_punch_unit = punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       }
       break;
   }

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.html
@@ -11848,6 +11848,12 @@ async function migrateAttributes() {
       version: "1.5.0",
       function: migrateAddRowIds,
     },
+    {
+      version: "1.6.0",
+    },
+    {
+      version: "1.6.1",
+    },
   ];
 
   const { version, migrated } = await getAttrsAsync(["version", "migrated"]);

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.html
@@ -582,7 +582,7 @@
           <span class="readonly" name="attr_total"></span>
           <button
             type="roll"
-            value="@{opt_whisper}&{template:skill} [[ [[{@{total}+?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[0]]}} {{roll=$[[1]]}} {{total=$[[2]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+            value="@{opt_whisper}&{template:skill} [[ [[{@{total}+(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[0]]}} {{roll=$[[1]]}} {{total=$[[2]]}} {{add_skill=[[@{opt_add_skill}]]}}"
             name="roll_skill"
           ></button>
         </div>
@@ -1578,7 +1578,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_powerability_skill"
     ></button>
   </div>
@@ -2426,7 +2426,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_spell_skill"
     ></button>
     <input type="number" value="0" name="attr_ppecost" />
@@ -3264,7 +3264,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_psionic_skill"
     ></button>
     <input type="number" value="0" name="attr_ispcost" />
@@ -6003,7 +6003,7 @@
             <span name="attr_active_profile_mod_trust"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{active_profile_mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{active_profile_mod_trust}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_trust"
             ></button>
           </label>
@@ -6017,7 +6017,7 @@
             <span name="attr_active_profile_mod_intimidate"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{active_profile_mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{active_profile_mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_intimidate"
             ></button>
           </label>
@@ -6031,7 +6031,7 @@
             <span name="attr_active_profile_mod_charmimpress"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{active_profile_mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{active_profile_mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_charmimpress"
             ></button>
           </label>
@@ -7512,7 +7512,7 @@
       <span name="attr_mod_trust"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?({Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_trust"
       ></button>
     </label>
@@ -7522,7 +7522,7 @@
       <span name="attr_mod_intimidate"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_intimidate"
       ></button>
     </label>
@@ -7532,7 +7532,7 @@
       <span name="attr_mod_charmimpress"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_charmimpress"
       ></button>
     </label>
@@ -8780,7 +8780,7 @@
       <span name="attr_mod_trust"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?({Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_trust"
       ></button>
     </label>
@@ -8790,7 +8790,7 @@
       <span name="attr_mod_intimidate"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_intimidate"
       ></button>
     </label>
@@ -8800,7 +8800,7 @@
       <span name="attr_mod_charmimpress"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_charmimpress"
       ></button>
     </label>

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.html
@@ -1172,6 +1172,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -1412,10 +1416,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -2089,6 +2089,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -2329,10 +2333,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -2926,6 +2926,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -3166,10 +3170,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -3764,6 +3764,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -4004,10 +4008,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -4480,6 +4480,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -4722,10 +4726,6 @@
       <input type="number" value="0" name="attr_pain" />
     </label>
     <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
-    </label>
-    <label
       ><span>Poison: Lethal</span>
       <input type="number" value="0" name="attr_lethalpoison" />
     </label>
@@ -4838,6 +4838,21 @@
           >
             TT
           </button>
+        </label>
+        <label class="roller"
+          ><span>Perception</span>
+          <input
+            type="hidden"
+            value="0"
+            name="attr_active_profile_perceptioncheck"
+          />
+          <span>+</span>
+          <span name="attr_active_profile_perceptioncheck"></span>
+          <button
+            type="roll"
+            value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{active_profile_perceptioncheck}]]}}"
+            name="roll_active_profile_bonus_perceptioncheck"
+          ></button>
         </label>
       </div>
       <div class="modifiers-combat">
@@ -6498,1247 +6513,15 @@
       name="roll_bonus_initiative"
     ></button>
   </label>
-</div>
-<div class="modifiers-combat">
-  <div class="combat-offense-melee bonus-type-container">
-    <h3><span>&#x2694;</span> Ancient <span>&#x1F3F9;</span></h3>
-    <label
-      ><span>Strike</span>
-      <input type="hidden" value="0" name="attr_strike" />
-      <span>+</span>
-      <span name="attr_strike"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} strikes!}} {{Strike=[[d20cs>@{critical}+@{strike}]]}}"
-        name="roll_bonus_strike"
-      ></button>
-    </label>
-    <label
-      ><span>Disarm</span>
-      <input type="hidden" value="0" name="attr_disarm" />
-      <span>+</span>
-      <span name="attr_disarm"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm!}} {{Disarm=[[d20+@{disarm}]]}}"
-        name="roll_bonus_disarm"
-      ></button>
-    </label>
-    <label
-      ><span>Entangle</span>
-      <input type="hidden" value="0" name="attr_entangle" />
-      <span>+</span>
-      <span name="attr_entangle"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to entangle!}} {{Entangle=[[d20+@{entangle}]]}}"
-        name="roll_bonus_entangle"
-      ></button>
-    </label>
-    <label
-      ><span>Throw</span>
-      <input type="hidden" value="0" name="attr_throw" />
-      <span>+</span>
-      <span name="attr_throw"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws something!}} {{Throw=[[d20+@{throw}]]}}"
-        name="roll_bonus_throw"
-      ></button>
-    </label>
-    <label
-      ><span>Pull Punch vs. 11</span>
-      <input type="hidden" value="0" name="attr_pull" />
-      <span>+</span>
-      <span name="attr_pull"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to pull their punch!}} {{target=[[11]]}} {{roll=[[d20+@{pull}]]}}"
-        name="roll_bonus_pull"
-      ></button>
-    </label>
-    <label
-      ><span>Body Flip/Throw</span>
-      <input type="hidden" value="0" name="attr_flipthrow" />
-      <span>+</span>
-      <span name="attr_flipthrow"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body flip/throw!}} {{Body Flip/Throw=[[d20cs>@{critical}+@{flipthrow}]]}}"
-        name="roll_bonus_flipthrow"
-      ></button>
-    </label>
-    <label
-      ><span>Body Block/Tackle</span>
-      <input type="hidden" value="0" name="attr_tackle" />
-      <span>+</span>
-      <span name="attr_tackle"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body block/tackle!}} {{Body Block/Tackle=[[d20cs>@{critical}+@{tackle}]]}}"
-        name="roll_bonus_tackle"
-      ></button>
-    </label>
-    <label
-      ><span>Tripping/Leg Hook</span>
-      <input type="hidden" value="0" name="attr_leghook" />
-      <span>+</span>
-      <span name="attr_leghook"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a trip/leg hook!}} {{Tripping/Leg Hook=[[d20cs>@{critical}+@{leghook}]]}}"
-        name="roll_bonus_leghook"
-      ></button>
-    </label>
-    <label
-      ><span>Backward Sweep Kick</span>
-      <input type="hidden" value="0" name="attr_backwardsweepkick" />
-      <span>+</span>
-      <span name="attr_backwardsweepkick"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a backward sweep kick!}} {{Backward Sweep Kick=[[d20cs>@{critical}+@{backwardsweepkick}]]}}"
-        name="roll_bonus_backwardsweepkick"
-      ></button>
-    </label>
-    <hr />
-    <label
-      ><span>Critical</span>
-      <input type="hidden" value="" name="attr_critical" />
-      <span></span>
-      <span name="attr_critical"></span>
-    </label>
-    <label
-      ><span>Knockout</span>
-      <input type="hidden" value="" name="attr_knockout" />
-      <span></span>
-      <span name="attr_knockout"></span>
-    </label>
-    <label
-      ><span>Death Blow</span>
-      <input type="hidden" value="0" name="attr_deathblow" />
-      <span></span>
-      <span name="attr_deathblow"></span>
-    </label>
-    <hr />
-    <label
-      ><span>Damage</span>
-      <input type="hidden" value="0" name="attr_damage" />
-      <span></span>
-      <span name="attr_damage"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus}
-        }]]}}"
-        name="roll_bonus_damage"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Paired</span>
-      <input type="hidden" value="0" name="attr_damage_paired" />
-      <span></span>
-      <span name="attr_damage_paired"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_paired} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus} } * [[ {{ @{opt_paired_damage},0 }dl1 } * 1 + 1 ]]
-        ]]}}"
-        name="roll_bonus_damage_paired"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Main Hand</span>
-      <input type="hidden" value="0" name="attr_damage_mainhand" />
-      <span></span>
-      <span name="attr_damage_mainhand"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_mainhand} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
-        ]]}}"
-        name="roll_bonus_damage_mainhand"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Off Hand</span>
-      <input type="hidden" value="0" name="attr_damage_offhand" />
-      <span></span>
-      <span name="attr_damage_offhand"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_offhand} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
-        ]]}}"
-        name="roll_bonus_damage_offhand"
-      ></button>
-    </label>
-  </div>
-  <div class="combat-offense-range bonus-type-container">
-    <h3><span>&#x1F52B;</span> Modern/Range <span>&#x1F4A3;</span></h3>
-    <label
-      ><span>Strike</span>
-      <input type="hidden" value="0" name="attr_strike_range" />
-      <span>+</span>
-      <span name="attr_strike_range"></span>
-    </label>
-    <label title="1 Action"
-      ><span>Strike: Single/Pulse</span>
-      <input type="hidden" value="0" name="attr_strike_range_single" />
-      <span>+</span>
-      <span name="attr_strike_range_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a single shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_single} ]]}}"
-        name="roll_bonus_strike_range_single"
-      ></button>
-    </label>
-    <label title="1 Action"
-      ><span>Strike: Burst</span>
-      <input type="hidden" value="0" name="attr_strike_range_burst" />
-      <span>+</span>
-      <span name="attr_strike_range_burst"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a burst shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_burst} ]]}}"
-        name="roll_bonus_strike_range_burst"
-      ></button>
-    </label>
-    <label
-      ><span>Strike: Aimed</span>
-      <input type="hidden" value="0" name="attr_strike_range_aimed" />
-      <span>+</span>
-      <span name="attr_strike_range_aimed"></span>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Aimed Single</span>
-      <input type="hidden" value="0" name="attr_strike_range_aimed_single" />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed single shot!}} {{Range Aimed Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_single} ]]}}"
-        name="roll_bonus_strike_range_aimed_single"
-      ></button>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Aimed Pulse</span>
-      <input type="hidden" value="0" name="attr_strike_range_aimed_pulse" />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_pulse"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed pulse shot!}} {{Range Aimed Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_pulse} ]]}}"
-        name="roll_bonus_strike_range_aimed_pulse"
-      ></button>
-    </label>
-    <label
-      ><span>Strike: Called</span>
-      <input type="hidden" value="0" name="attr_strike_range_called" />
-      <span>+</span>
-      <span name="attr_strike_range_called"></span>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Called Single</span>
-      <input type="hidden" value="0" name="attr_strike_range_called_single" />
-      <span>+</span>
-      <span name="attr_strike_range_called_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called single shot!}} {{Range Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_single} ]]}}"
-        name="roll_bonus_strike_range_called_single"
-      ></button>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Called Pulse</span>
-      <input type="hidden" value="0" name="attr_strike_range_called_pulse" />
-      <span>+</span>
-      <span name="attr_strike_range_called_pulse"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called pulse shot!}} {{Range Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_pulse} ]]}}"
-        name="roll_bonus_strike_range_called_pulse"
-      ></button>
-    </label>
-    <label title="3 Actions"
-      ><span>Strike: Aimed Called Single</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_strike_range_aimed_called_single"
-      />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_called_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called single shot!}} {{Range Aimed Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_single} ]]}}"
-        name="roll_bonus_strike_range_aimed_called_single"
-      ></button>
-    </label>
-    <label title="3 Actions"
-      ><span>Strike: Aimed Called Pulse</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_strike_range_aimed_called_pulse"
-      />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_called_pulse"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called pulse shot!}} {{Range Aimed Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_pulse} ]]}}"
-        name="roll_bonus_strike_range_aimed_called_pulse"
-      ></button>
-    </label>
-    <hr />
-    <label
-      title="Using a gun to shoot a weapon out of an opponent's hand requires a called shot and careful aim (only the gunslinger can shoot to disarm on a quick draw)"
-      ><span>Disarm</span>
-      <input type="hidden" value="0" name="attr_disarm_range" />
-      <span>+</span>
-      <span name="attr_disarm_range"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm at range!}} {{Range Disarm=[[d20+@{disarm_range} + ?{Type of shot?|
-          No additional bonus,0|
-          Called Single (2 Actions),@{strike_range_called_single}|
-          Called Pulse (2 Actions),@{strike_range_called_pulse}|
-          Aimed Called Single (3 Actions),@{strike_range_aimed_called_single}|
-          Aimed Called Pulse (3 Actions),@{strike_range_aimed_called_pulse}|
-          Quick Draw Single (1 Action),@{strike_range_single}|
-          Quick Draw Pulse (1 Action),@{strike_range_burst}
-        }]]}}"
-        name="roll_bonus_disarm_range"
-      ></button>
-    </label>
-    <hr />
-    <label
-      ><span>Damage</span>
-      <input type="hidden" value="0" name="attr_damage_range" />
-      <span></span>
-      <span name="attr_damage_range"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage!}} {{Range Damage=[[@{damage_range}]]}}"
-        name="roll_bonus_damage_range"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Single</span>
-      <input type="hidden" value="0" name="attr_damage_range_single" />
-      <span></span>
-      <span name="attr_damage_range_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a single shot!}} {{Range Damage=[[@{damage_range_single}]]}}"
-        name="roll_bonus_damage_range_single"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Pulse/Burst</span>
-      <input type="hidden" value="0" name="attr_damage_range_burst" />
-      <span></span>
-      <span name="attr_damage_range_burst"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a burst!}} {{Range Damage=[[@{damage_range_burst}]]}}"
-        name="roll_bonus_damage_range_burst"
-      ></button>
-    </label>
-  </div>
-  <div class="combat-defense bonus-type-container">
-    <h3><span>&#x1F6E1;</span> Defense <span>&#x1F977;</span></h3>
-    <label
-      ><span>Parry</span>
-      <input type="hidden" value="0" name="attr_parry" />
-      <span>+</span>
-      <span name="attr_parry"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to parry!}} {{Parry=[[d20+@{parry}]]}}"
-        name="roll_bonus_parry"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge</span>
-      <input type="hidden" value="0" name="attr_dodge" />
-      <span>+</span>
-      <span name="attr_dodge"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge!}} {{ Dodge=[[ d20+@{dodge} - @{opt_dodge_penalty} ]] }}"
-        name="roll_bonus_dodge"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Flight</span>
-      <input type="hidden" value="0" name="attr_dodge_flight" />
-      <span>+</span>
-      <span name="attr_dodge_flight"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge in flight!}} {{Dodge in Flight=[[d20+@{dodge_flight} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_flight"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Auto</span>
-      <input type="hidden" value="0" name="attr_dodge_auto" />
-      <span>+</span>
-      <span name="attr_dodge_auto"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to auto dodge!}} {{Auto Dodge=[[d20+@{dodge_auto} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_auto"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Teleport</span>
-      <input type="hidden" value="0" name="attr_dodge_teleport" />
-      <span>+</span>
-      <span name="attr_dodge_teleport"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to teleport dodge!}} {{Teleport Dodge=[[d20+@{dodge_teleport} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_teleport"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Motion</span>
-      <input type="hidden" value="0" name="attr_dodge_motion" />
-      <span>+</span>
-      <span name="attr_dodge_motion"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge while in motion!}} {{Dodge in Motion=[[d20+@{dodge_motion} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_motion"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Underwater</span>
-      <input type="hidden" value="0" name="attr_dodge_underwater" />
-      <span>+</span>
-      <span name="attr_dodge_underwater"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge underwater!}} {{Dodge Underwater=[[d20+@{dodge_underwater} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_underwater"
-      ></button>
-    </label>
-    <label
-      ><span>Roll w/ Impact</span>
-      <input type="hidden" value="0" name="attr_roll" />
-      <span>+</span>
-      <span name="attr_roll"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to roll with impact!}} {{Roll w/ Impact=[[d20+@{roll}]]}}"
-        name="roll_bonus_roll"
-      ></button>
-    </label>
-    <label
-      ><span>Break Fall</span>
-      <input type="hidden" value="0" name="attr_breakfall" />
-      <span>+</span>
-      <span name="attr_breakfall"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to break fall!}} {{Break Fall=[[d20+@{breakfall}]]}}"
-        name="roll_bonus_breakfall"
-      ></button>
-    </label>
-  </div>
-  <div class="bonus-type-container">
-    <h3><span>&#x1F340;</span> Saving Throws <span>&#x1FAA6;</span></h3>
-    <label
-      ><span>Coma/Death</span>
-      <input type="hidden" value="0" name="attr_comadeath" />
-      <span>+</span>
-      <span name="attr_comadeath"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries not to die!}} {{target=[[50+@{comadeath}]]}} {{roll=[[d100]]}}"
-        name="roll_bonus_comadeath"
-      ></button>
-    </label>
-    <label
-      ><span>Curses vs. 15</span>
-      <input type="hidden" value="0" name="attr_curses" />
-      <span>+</span>
-      <span name="attr_curses"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against being cursed!}} {{target=[[15]]}} {{roll=[[d20+@{curses}+?{Add modifier?|
-            None,0|
-            Magic,@{magic}|
-            Psionics,@{psionics}
-          }]]}}"
-        name="roll_bonus_curses"
-      ></button>
-    </label>
-    <label
-      ><span>Despair</span>
-      <input type="hidden" value="0" name="attr_despair" />
-      <span>+</span>
-      <span name="attr_despair"></span>
-      <button
-        type="roll"
-        value="?{Type of Despair|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. magic despair!&amp;#125;&amp;#125; {{Save vs. Magic Despair=[[d20+@{despair}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to save vs. psionic despair!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{despair}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. despair!&amp;#125;&amp;#125; {{Save vs. Despair=[[d20+@{despair}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_despair"
-      ></button>
-    </label>
-    <label
-      ><span>Disease</span>
-      <input type="hidden" value="0" name="attr_disease" />
-      <span>+</span>
-      <span name="attr_disease"></span>
-      <button
-        type="roll"
-        value="?{Type of Disease|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Magic Disease=[[d20+@{disease}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{disease}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Disease=[[d20+@{disease}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_disease"
-      ></button>
-    </label>
-    <label
-      ><span>Drugs vs. 15</span>
-      <input type="hidden" value="0" name="attr_drugs" />
-      <span>+</span>
-      <span name="attr_drugs"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against harmful drugs!}} {{target=[[15]]}} {{roll=[[d20+@{drugs}]]}}"
-        name="roll_bonus_drugs"
-      ></button>
-    </label>
-    <label
-      ><span>Fatigue</span>
-      <input type="hidden" value="0" name="attr_fatigue" />
-      <span>+</span>
-      <span name="attr_fatigue"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to push through the fatigue!}} {{Fatigue=[[d20+@{fatigue}]]}}"
-        name="roll_bonus_fatigue"
-      ></button>
-    </label>
-    <label
-      ><span>Horror Factor</span>
-      <input type="hidden" value="0" name="attr_horrorfactor" />
-      <span>+</span>
-      <span name="attr_horrorfactor"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against horror factor!}} {{Save vs. Horror Factor=[[d20+@{horrorfactor}]]}}"
-        name="roll_bonus_horrorfactor"
-      ></button>
-    </label>
-    <label
-      ><span>Illusions</span>
-      <input type="hidden" value="0" name="attr_illusions" />
-      <span>+</span>
-      <span name="attr_illusions"></span>
-      <button
-        type="roll"
-        value="?{Type of Illusion|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the magic illusion!&amp;#125;&amp;#125; {{Save vs. Magic Illusions=[[d20+@{illusions}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to see through the psionic illusion!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{illusions}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the illusion!&amp;#125;&amp;#125; {{Save vs. Illusions=[[d20+@{illusions}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_illusions"
-      ></button>
-    </label>
-    <label
-      ><span>Insanity</span>
-      <input type="hidden" value="0" name="attr_insanity" />
-      <span>+</span>
-      <span name="attr_insanity"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against insanity!}} {{target=[[12]]}} {{roll=[[d20+@{insanity}]]}}"
-        name="roll_bonus_insanity"
-      ></button>
-    </label>
-    <label
-      ><span>Magic</span>
-      <input type="hidden" value="0" name="attr_magic" />
-      <span>+</span>
-      <span name="attr_magic"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against magic attack!}} {{Save vs. Magic=[[d20+@{magic}]]}}"
-        name="roll_bonus_magic"
-      ></button>
-    </label>
-    <label
-      ><span>Maintain Balance</span>
-      <input type="hidden" value="0" name="attr_maintainbalance" />
-      <span>+</span>
-      <span name="attr_maintainbalance"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to stay standing!}} {{Maintain Balance=[[d20+@{maintainbalance}]]}}"
-        name="roll_bonus_maintainbalance"
-      ></button>
-    </label>
-    <label
-      ><span>Mind Control</span>
-      <input type="hidden" value="0" name="attr_mindcontrol" />
-      <span>+</span>
-      <span name="attr_mindcontrol"></span>
-      <button
-        type="roll"
-        value="?{Type of Mind Control Attack|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off magic mind control!&amp;#125;&amp;#125; {{Save vs. Magic Mind Control=[[d20+@{mindcontrol}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to fight off psionic mind control!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{mindcontrol}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off mind control!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{mindcontrol}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_mindcontrol"
-      ></button>
-    </label>
-    <label
-      ><span>Pain</span>
-      <input type="hidden" value="0" name="attr_pain" />
-      <span>+</span>
-      <span name="attr_pain"></span>
-      <button
-        type="roll"
-        value="?{Type of Pain Attack|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the magic pain!&amp;#125;&amp;#125; {{Save vs. Magic Pain=[[d20+@{pain}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to push through the psionic pain!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{pain}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the pain!&amp;#125;&amp;#125; {{Save vs. Pain=[[d20+@{pain}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_pain"
-      ></button>
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="hidden" value="0" name="attr_perceptioncheck" />
-      <span>+</span>
-      <span name="attr_perceptioncheck"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
-        name="roll_bonus_perceptioncheck"
-      ></button>
-    </label>
-    <label
-      ><span>Poison: Lethal vs. 14</span>
-      <input type="hidden" value="0" name="attr_lethalpoison" />
-      <span>+</span>
-      <span name="attr_lethalpoison"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against lethal poison!}} {{target=[[14]]}} {{roll=[[d20+@{lethalpoison}]]}}"
-        name="roll_bonus_lethalpoison"
-      ></button>
-    </label>
-    <label
-      ><span>Poison: Non-Lethal vs. 16</span>
-      <input type="hidden" value="0" name="attr_nonlethalpoison" />
-      <span>+</span>
-      <span name="attr_nonlethalpoison"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against non-lethal poison!}} {{target=[[16]]}} {{roll=[[d20+@{nonlethalpoison}]]}}"
-        name="roll_bonus_nonlethalpoison"
-      ></button>
-    </label>
-    <label
-      ><span>Possession</span>
-      <input type="hidden" value="0" name="attr_possession" />
-      <span>+</span>
-      <span name="attr_possession"></span>
-      <button
-        type="roll"
-        value="?{Type of Possession|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being magically possessed!&amp;#125;&amp;#125; {{Save vs. Magic Possession=[[d20+@{possession}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to prevent being psionically possessed!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{possession}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being possessed!&amp;#125;&amp;#125; {{Save vs. Possession=[[d20+@{possession}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_possession"
-      ></button>
-    </label>
-    <label
-      ><span class="psi-vs"
-        >Psionics vs. <span name="attr_global_psionic_ability"></span
-      ></span>
-      <input type="hidden" value="0" name="attr_psionics" />
-      <span>+</span>
-      <span name="attr_psionics"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against psionic attack!}} {{target=[[@{psionic_ability}]]}} {{roll=[[d20+@{psionics}]]}}"
-        name="roll_save_psionics"
-      ></button>
-    </label>
-    <label
-      ><span>Telepathic Probes</span>
-      <input type="hidden" value="0" name="attr_telepathicprobes" />
-      <span>+</span>
-      <span name="attr_telepathicprobes"></span>
-      <button
-        type="roll"
-        value="?{Type of Telepathic Probe|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a magic telepathic probe!&amp;#125;&amp;#125; {{Save vs. Magic Telepathic Probe=[[d20+@{telepathicprobes}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to block a psionic telepathic probe!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{telepathicprobes}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a telepathic probe!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{telepathicprobes}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_telepathicprobes"
-      ></button>
-    </label>
-  </div>
-</div>
-<br />
-<h3>Attributes</h3>
-<div class="modifiers-attributes">
-  <div class="bonus-type-container attributes">
-    <label>
-      <span style="grid-column: 3 / -1">Bonuses</span>
-    </label>
-    <label
-      ><span>I.Q.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_iq"
-        title="Intelligence Quotient"
-      />
-      <span name="attr_mod_iq" title="Intelligence Quotient"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_iq_bonus"
-        title="+ Skills %"
-      />
-      <span name="attr_mod_iq_bonus" title="+ Skills %"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_perception_bonus"
-        title="+ Perception (Rifter #13, p.16)"
-      />
-      <span
-        name="attr_mod_perception_bonus"
-        title="+ Perception (Rifter #13, p.16)"
-      ></span>
-    </label>
-    <label
-      ><span>M.E.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_me"
-        title="Mental Endurance"
-      />
-      <span name="attr_mod_me" title="Mental Endurance"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_me_bonus"
-        title="+ Save vs. Psionics"
-      />
-      <span name="attr_mod_me_bonus" title="+ Save vs. Psionics"></span>
-    </label>
-    <label
-      ><span>M.A.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ma"
-        title="Mental Affinity"
-      />
-      <span name="attr_mod_ma" title="Mental Affinity"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ma_bonus"
-        title="% Trust/Intimidate"
-      />
-      <span name="attr_mod_ma_bonus" title="% Trust/Intimidate"></span>
-    </label>
-    <label
-      ><span>P.S.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ps"
-        title="Physical Strength"
-      />
-      <span name="attr_mod_ps" title="Physical Strength"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ps_bonus"
-        title="+ SDC Damage"
-      />
-      <span name="attr_mod_ps_bonus" title="+ SDC Damage"></span>
-    </label>
-    <label
-      ><span>P.P.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pp"
-        title="Physical Prowess"
-      />
-      <span name="attr_mod_pp" title="Physical Prowess"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pp_bonus"
-        title="+ Strike/Parry/Dodge/Entangle/Disarm"
-      />
-      <span
-        name="attr_mod_pp_bonus"
-        title="+ Strike/Parry/Dodge/Entangle/Disarm"
-      ></span>
-    </label>
-    <label
-      ><span>P.E.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pe"
-        title="Physical Endurance"
-      />
-      <span name="attr_mod_pe" title="Physical Endurance"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pe_bonus"
-        title="+ Magic/Poison/Toxins"
-      />
-      <span name="attr_mod_pe_bonus" title="+ Magic/Poison/Toxins"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pe_coma_bonus"
-        title="+ Coma/Death %"
-      />
-      <span name="attr_mod_pe_coma_bonus" title="+ Coma/Death %"></span>
-    </label>
-    <label
-      ><span>P.B.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pb"
-        title="Physical Beauty"
-      />
-      <span name="attr_mod_pb" title="Physical Beauty"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pb_bonus"
-        title="% Charm/Impress"
-      />
-      <span name="attr_mod_pb_bonus" title="% Charm/Impress"></span>
-    </label>
-    <label
-      ><span>Spd</span>
-      <input type="hidden" value="0" name="attr_mod_spd" title="Speed" />
-      <span name="attr_mod_spd" title="Speed"></span>
-    </label>
-    <label
-      ><span>Spd: Fly</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_spdfly"
-        title="Flying Speed"
-      />
-      <span name="attr_mod_spdfly" title="Flying Speed"></span>
-    </label>
-  </div>
-  <div class="bonus-type-container">
-    <label
-      ><span title="Hit Points">H.P.</span
-      ><input type="hidden" value="0" name="attr_hp" />
-      <span name="attr_hp"></span>
-    </label>
-    <label
-      ><span>S.D.C.</span><input type="hidden" value="0" name="attr_sdc" />
-      <span name="attr_sdc"></span>
-    </label>
-    <label
-      ><span>A.R.</span><input type="hidden" value="0" name="attr_ar" />
-      <span name="attr_ar"></span>
-    </label>
-    <label
-      ><span>M.D.C.</span><input type="hidden" value="0" name="attr_mdc" />
-      <span name="attr_mdc"></span>
-    </label>
-    <label
-      ><span>P.P.E.</span><input type="hidden" value="0" name="attr_ppe" />
-      <span name="attr_ppe"></span>
-    </label>
-    <label
-      ><span>I.S.P.</span><input type="hidden" value="0" name="attr_isp" />
-      <span name="attr_isp"></span>
-    </label>
-    <label
-      ><span>H.F.</span><input type="hidden" value="0" name="attr_mod_hf" />
-      <span name="attr_mod_hf"></span>
-    </label>
-    <label>
-      <span>Spell Strength</span>
-      <input type="hidden" value="0" name="attr_mod_spellstrength" />
-      <span name="attr_mod_spellstrength"></span>
-    </label>
-    <label>
-      <span>Trust</span>
-      <input type="hidden" value="0" name="attr_mod_trust" />
-      <span name="attr_mod_trust"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
-        name="roll_trust"
-      ></button>
-    </label>
-    <label>
-      <span>Intimidate</span>
-      <input type="hidden" value="0" name="attr_mod_intimidate" />
-      <span name="attr_mod_intimidate"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
-        name="roll_intimidate"
-      ></button>
-    </label>
-    <label>
-      <span>Charm/Impress</span>
-      <input type="hidden" value="0" name="attr_mod_charmimpress" />
-      <span name="attr_mod_charmimpress"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
-        name="roll_charmimpress"
-      ></button>
-    </label>
-    <label>
-      <span>Skill Bonus %</span>
-      <input type="hidden" value="0" name="attr_mod_skillbonus" />
-      <span name="attr_mod_skillbonus"></span>
-    </label>
-  </div>
-  <div class="bonus-ps-container">
-    <label class="select"
-      ><span>PS Type</span>
-      <input type="hidden" name="attr_mod_character_ps_type" />
-      <input type="hidden" name="attr_mod_character_ps_type_name" />
-      <span class="twospan2" name="attr_mod_character_ps_type_name"></span>
-    </label>
-    <label
-      ><span>Restrained Punch</span>
-      <input type="hidden" name="attr_mod_restrained_punch" value="0" />
-      <span name="attr_mod_restrained_punch"></span>
-      <input type="hidden" name="attr_mod_restrained_punch_unit" />
-      <span name="attr_mod_restrained_punch_unit"></span>
-    </label>
-
-    <label
-      ><span>Punch</span>
-      <input type="hidden" name="attr_mod_punch" value="0" />
-      <span name="attr_mod_punch"></span>
-      <input type="hidden" name="attr_mod_punch_unit" />
-      <span name="attr_mod_punch_unit"></span>
-    </label>
-
-    <label
-      ><span>Power Punch</span>
-      <input type="hidden" name="attr_mod_power_punch" value="0" />
-      <span name="attr_mod_power_punch"></span>
-      <input type="hidden" name="attr_mod_power_punch_unit" />
-      <span name="attr_mod_power_punch_unit"></span>
-    </label>
-
-    <label
-      ><span>Kick</span>
-      <input type="hidden" name="attr_mod_kick" value="0" />
-      <span name="attr_mod_kick"></span>
-      <input type="hidden" name="attr_mod_kick_unit" />
-      <span name="attr_mod_kick_unit"></span>
-    </label>
-
-    <label
-      ><span>Leap Kick</span>
-      <input type="hidden" name="attr_mod_leap_kick" value="0" />
-      <span name="attr_mod_leap_kick"></span>
-      <input type="hidden" name="attr_mod_leap_kick_unit" />
-      <span name="attr_mod_leap_kick_unit"></span>
-    </label>
-
-    <label
-      ><span>Lift/Carry Weight Multiplier</span>
-      <input
-        type="hidden"
-        value="1"
-        name="attr_mod_liftcarry_weight_multiplier"
-        value="1"
-      />
-      <span name="attr_mod_liftcarry_weight_multiplier"></span>
-      <span>&#x00D7;</span>
-    </label>
-
-    <label
-      ><span>Lift/Carry Duration Multiplier</span>
-      <input
-        type="hidden"
-        value="1"
-        name="attr_mod_liftcarry_duration_multiplier"
-        value="1"
-      />
-      <span name="attr_mod_liftcarry_duration_multiplier"></span>
-      <span>&#x00D7;</span>
-    </label>
-
-    <label
-      ><span>Lift</span>
-      <input type="hidden" value="0" name="attr_mod_lift" value="0" />
-      <span name="attr_mod_lift"></span>
-      <span>lbs</span>
-    </label>
-
-    <label
-      ><span>Carry</span>
-      <input type="hidden" value="0" name="attr_mod_carry" value="0" />
-      <span name="attr_mod_carry"></span>
-      <span>lbs</span>
-    </label>
-
-    <label
-      ><span>Throw (&frac12; Carry)</span>
-      <input type="hidden" value="0" name="attr_mod_throw_distance" value="0" />
-      <span name="attr_mod_throw_distance"></span>
-      <span>Feet</span></label
-    >
-
-    <label
-      ><span>Carry Max</span>
-      <input type="hidden" value="0" name="attr_mod_carry_max" />
-      <span name="attr_mod_carry_max"></span>
-      <span>Minutes</span>
-    </label>
-
-    <label
-      ><span>Carry (Running)</span>
-      <input type="hidden" value="0" name="attr_mod_carry_running" />
-      <span name="attr_mod_carry_running"></span>
-      <span>Minutes</span></label
-    >
-
-    <label
-      ><span>Hold Max.</span>
-      <input type="hidden" value="0" name="attr_mod_hold_max" />
-      <span name="attr_mod_hold_max"></span>
-      <span>Melees</span></label
-    >
-  </div>
-
-  <div class="bonus-type-container movement">
-    <h2>Movement</h2>
-    <label><span></span><span>Imperial</span><span>Metric</span></label>
-    <label
-      ><span>Run/hour</span
-      ><input type="hidden" value="0" name="attr_run_mph" />
-      <span class="readonly-light">
-        <span name="attr_run_mph"></span>
-        <span>mph</span>
-      </span>
-      <input type="hidden" value="0" name="attr_run_kmh" />
-      <span class="readonly-light">
-        <span name="attr_run_kmh"></span>
-        <span>km/h</span>
-      </span>
-    </label>
-    <label
-      ><span>Run/melee</span
-      ><input type="hidden" value="0" name="attr_run_ft_melee" />
-      <span class="readonly-light">
-        <span name="attr_run_ft_melee"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_run_m_melee" />
-      <span class="readonly-light">
-        <span name="attr_run_m_melee"></span>
-        <span>m</span>
-      </span>
-    </label>
-    <label
-      ><span>Run/action</span
-      ><input type="hidden" value="0" name="attr_run_ft_action" />
-      <span class="readonly-light">
-        <span name="attr_run_ft_action"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_run_m_action" />
-      <span class="readonly-light">
-        <span name="attr_run_m_action"></span>
-        <span>m</span>
-      </span>
-    </label>
-    <label
-      ><span>Fly/hour</span
-      ><input type="hidden" value="0" name="attr_fly_mph" />
-      <span class="readonly-light">
-        <span name="attr_fly_mph"></span>
-        <span>mph</span>
-      </span>
-      <input type="hidden" value="0" name="attr_fly_kmh" />
-      <span class="readonly-light">
-        <span name="attr_fly_kmh"></span>
-        <span>km/h</span>
-      </span>
-    </label>
-    <label
-      ><span>Fly/melee</span
-      ><input type="hidden" value="0" name="attr_fly_ft_melee" />
-      <span class="readonly-light">
-        <span name="attr_fly_ft_melee"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_fly_m_melee" />
-      <span class="readonly-light">
-        <span name="attr_fly_m_melee"></span>
-        <span>m</span>
-      </span>
-    </label>
-    <label
-      ><span>Fly/action</span
-      ><input type="hidden" value="0" name="attr_fly_ft_action" />
-      <span class="readonly-light">
-        <span name="attr_fly_ft_action"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_fly_m_action" />
-      <span class="readonly-light">
-        <span name="attr_fly_m_action"></span>
-        <span>m</span>
-      </span>
-    </label>
-  </div>
-</div>
-<br />
-<label class="description"
-  ><b>Description</b>
-  <textarea class="full" name="attr_description" value=""></textarea>
-</label>
-<div class="macro-help">
-  <label
-    ><span><b>Row ID:</b></span>
-    <input type="text" readonly name="attr_rowid" value=""
-  /></label>
-</div>
-
-                            <!-- endinject -->
-                          </div>
-                        </details>
-                      </div>
-                    </fieldset>
-                  </div>
-                </div>
-                <div class="picker">
-                  <div class="picker-inner">
-                    <h3 class="picker-title">Modifier Picker</h3>
-                    <fieldset class="repeating_bonusselections">
-                      <label>
-                        <input type="checkbox" name="attr_enabled" value="1" />
-                        <span name="attr_name"></span
-                      ></label>
-                      <input type="hidden" name="attr_name" value="" />
-                      <input type="hidden" name="attr_bonus_id" value="" />
-                    </fieldset>
-                    <div class="selected-ids">
-                      <b>Selected IDs</b>
-                      <input
-                        class="full"
-                        type="text"
-                        name="attr_bonus_ids_output"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <hr />
-          </div>
-          <div class="bonus-sources repeating-bonuses-outer">
-            <h3>Bonus Sources</h3>
-            <fieldset class="repeating_bonuses">
-              <input type="hidden" name="attr_selection_id" value="" />
-              <details class="info">
-                <summary>
-                  <div class="bonus-thing-heading">
-                    <b class="click-expand"
-                      ><span title="Click for more info">&nbsp;&#9432;</span></b
-                    >
-                    <label
-                      ><span>Name</span>
-                      <input type="text" list="modifiers" name="attr_name" />
-                    </label>
-                    <label
-                      ><span>Level</span>
-                      <input type="number" value="1" name="attr_level" />
-                    </label>
-                  </div>
-                </summary>
-                <div class="details-body">
-                  <!-- inject:partials/repeating_modifiers_readonly.html -->
-                  <input type="hidden" name="attr_bonus_id" value="" />
-<input type="hidden" name="global_psionic_ability" />
-<h3>Combat</h3>
-<div class="bonus-type-container">
-  <label
-    ><span>Attacks</span>
-    <input type="hidden" value="0" name="attr_attacks" />
-    <span name="attr_attacks"></span>
-  </label>
   <label class="roller"
-    ><span>Initiative</span>
-    <input type="hidden" value="0" name="attr_initiative" />
+    ><span>Perception</span>
+    <input type="hidden" value="0" name="attr_perceptioncheck" />
     <span>+</span>
-    <span name="attr_initiative"></span>
+    <span name="attr_perceptioncheck"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:custom} {{title=@{character_name} rolls Initiative}} {{Initiative=[[d20+@{initiative} &{tracker}]]}}"
-      name="roll_bonus_initiative"
+      value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
+      name="roll_bonus_perceptioncheck"
     ></button>
   </label>
 </div>
@@ -8384,14 +7167,1246 @@
       ></button>
     </label>
     <label
-      ><span>Perception</span>
-      <input type="hidden" value="0" name="attr_perceptioncheck" />
+      ><span>Poison: Lethal vs. 14</span>
+      <input type="hidden" value="0" name="attr_lethalpoison" />
       <span>+</span>
-      <span name="attr_perceptioncheck"></span>
+      <span name="attr_lethalpoison"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
-        name="roll_bonus_perceptioncheck"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against lethal poison!}} {{target=[[14]]}} {{roll=[[d20+@{lethalpoison}]]}}"
+        name="roll_bonus_lethalpoison"
+      ></button>
+    </label>
+    <label
+      ><span>Poison: Non-Lethal vs. 16</span>
+      <input type="hidden" value="0" name="attr_nonlethalpoison" />
+      <span>+</span>
+      <span name="attr_nonlethalpoison"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against non-lethal poison!}} {{target=[[16]]}} {{roll=[[d20+@{nonlethalpoison}]]}}"
+        name="roll_bonus_nonlethalpoison"
+      ></button>
+    </label>
+    <label
+      ><span>Possession</span>
+      <input type="hidden" value="0" name="attr_possession" />
+      <span>+</span>
+      <span name="attr_possession"></span>
+      <button
+        type="roll"
+        value="?{Type of Possession|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being magically possessed!&amp;#125;&amp;#125; {{Save vs. Magic Possession=[[d20+@{possession}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to prevent being psionically possessed!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{possession}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being possessed!&amp;#125;&amp;#125; {{Save vs. Possession=[[d20+@{possession}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_possession"
+      ></button>
+    </label>
+    <label
+      ><span class="psi-vs"
+        >Psionics vs. <span name="attr_global_psionic_ability"></span
+      ></span>
+      <input type="hidden" value="0" name="attr_psionics" />
+      <span>+</span>
+      <span name="attr_psionics"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against psionic attack!}} {{target=[[@{psionic_ability}]]}} {{roll=[[d20+@{psionics}]]}}"
+        name="roll_save_psionics"
+      ></button>
+    </label>
+    <label
+      ><span>Telepathic Probes</span>
+      <input type="hidden" value="0" name="attr_telepathicprobes" />
+      <span>+</span>
+      <span name="attr_telepathicprobes"></span>
+      <button
+        type="roll"
+        value="?{Type of Telepathic Probe|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a magic telepathic probe!&amp;#125;&amp;#125; {{Save vs. Magic Telepathic Probe=[[d20+@{telepathicprobes}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to block a psionic telepathic probe!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{telepathicprobes}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a telepathic probe!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{telepathicprobes}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_telepathicprobes"
+      ></button>
+    </label>
+  </div>
+</div>
+<br />
+<h3>Attributes</h3>
+<div class="modifiers-attributes">
+  <div class="bonus-type-container attributes">
+    <label>
+      <span style="grid-column: 3 / -1">Bonuses</span>
+    </label>
+    <label
+      ><span>I.Q.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_iq"
+        title="Intelligence Quotient"
+      />
+      <span name="attr_mod_iq" title="Intelligence Quotient"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_iq_bonus"
+        title="+ Skills %"
+      />
+      <span name="attr_mod_iq_bonus" title="+ Skills %"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_perception_bonus"
+        title="+ Perception (Rifter #13, p.16)"
+      />
+      <span
+        name="attr_mod_perception_bonus"
+        title="+ Perception (Rifter #13, p.16)"
+      ></span>
+    </label>
+    <label
+      ><span>M.E.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_me"
+        title="Mental Endurance"
+      />
+      <span name="attr_mod_me" title="Mental Endurance"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_me_bonus"
+        title="+ Save vs. Psionics"
+      />
+      <span name="attr_mod_me_bonus" title="+ Save vs. Psionics"></span>
+    </label>
+    <label
+      ><span>M.A.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ma"
+        title="Mental Affinity"
+      />
+      <span name="attr_mod_ma" title="Mental Affinity"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ma_bonus"
+        title="% Trust/Intimidate"
+      />
+      <span name="attr_mod_ma_bonus" title="% Trust/Intimidate"></span>
+    </label>
+    <label
+      ><span>P.S.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ps"
+        title="Physical Strength"
+      />
+      <span name="attr_mod_ps" title="Physical Strength"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ps_bonus"
+        title="+ SDC Damage"
+      />
+      <span name="attr_mod_ps_bonus" title="+ SDC Damage"></span>
+    </label>
+    <label
+      ><span>P.P.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pp"
+        title="Physical Prowess"
+      />
+      <span name="attr_mod_pp" title="Physical Prowess"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pp_bonus"
+        title="+ Strike/Parry/Dodge/Entangle/Disarm"
+      />
+      <span
+        name="attr_mod_pp_bonus"
+        title="+ Strike/Parry/Dodge/Entangle/Disarm"
+      ></span>
+    </label>
+    <label
+      ><span>P.E.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pe"
+        title="Physical Endurance"
+      />
+      <span name="attr_mod_pe" title="Physical Endurance"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pe_bonus"
+        title="+ Magic/Poison/Toxins"
+      />
+      <span name="attr_mod_pe_bonus" title="+ Magic/Poison/Toxins"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pe_coma_bonus"
+        title="+ Coma/Death %"
+      />
+      <span name="attr_mod_pe_coma_bonus" title="+ Coma/Death %"></span>
+    </label>
+    <label
+      ><span>P.B.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pb"
+        title="Physical Beauty"
+      />
+      <span name="attr_mod_pb" title="Physical Beauty"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pb_bonus"
+        title="% Charm/Impress"
+      />
+      <span name="attr_mod_pb_bonus" title="% Charm/Impress"></span>
+    </label>
+    <label
+      ><span>Spd</span>
+      <input type="hidden" value="0" name="attr_mod_spd" title="Speed" />
+      <span name="attr_mod_spd" title="Speed"></span>
+    </label>
+    <label
+      ><span>Spd: Fly</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_spdfly"
+        title="Flying Speed"
+      />
+      <span name="attr_mod_spdfly" title="Flying Speed"></span>
+    </label>
+  </div>
+  <div class="bonus-type-container">
+    <label
+      ><span title="Hit Points">H.P.</span
+      ><input type="hidden" value="0" name="attr_hp" />
+      <span name="attr_hp"></span>
+    </label>
+    <label
+      ><span>S.D.C.</span><input type="hidden" value="0" name="attr_sdc" />
+      <span name="attr_sdc"></span>
+    </label>
+    <label
+      ><span>A.R.</span><input type="hidden" value="0" name="attr_ar" />
+      <span name="attr_ar"></span>
+    </label>
+    <label
+      ><span>M.D.C.</span><input type="hidden" value="0" name="attr_mdc" />
+      <span name="attr_mdc"></span>
+    </label>
+    <label
+      ><span>P.P.E.</span><input type="hidden" value="0" name="attr_ppe" />
+      <span name="attr_ppe"></span>
+    </label>
+    <label
+      ><span>I.S.P.</span><input type="hidden" value="0" name="attr_isp" />
+      <span name="attr_isp"></span>
+    </label>
+    <label
+      ><span>H.F.</span><input type="hidden" value="0" name="attr_mod_hf" />
+      <span name="attr_mod_hf"></span>
+    </label>
+    <label>
+      <span>Spell Strength</span>
+      <input type="hidden" value="0" name="attr_mod_spellstrength" />
+      <span name="attr_mod_spellstrength"></span>
+    </label>
+    <label>
+      <span>Trust</span>
+      <input type="hidden" value="0" name="attr_mod_trust" />
+      <span name="attr_mod_trust"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        name="roll_trust"
+      ></button>
+    </label>
+    <label>
+      <span>Intimidate</span>
+      <input type="hidden" value="0" name="attr_mod_intimidate" />
+      <span name="attr_mod_intimidate"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        name="roll_intimidate"
+      ></button>
+    </label>
+    <label>
+      <span>Charm/Impress</span>
+      <input type="hidden" value="0" name="attr_mod_charmimpress" />
+      <span name="attr_mod_charmimpress"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        name="roll_charmimpress"
+      ></button>
+    </label>
+    <label>
+      <span>Skill Bonus %</span>
+      <input type="hidden" value="0" name="attr_mod_skillbonus" />
+      <span name="attr_mod_skillbonus"></span>
+    </label>
+  </div>
+  <div class="bonus-ps-container">
+    <label class="select"
+      ><span>PS Type</span>
+      <input type="hidden" name="attr_mod_character_ps_type" />
+      <input type="hidden" name="attr_mod_character_ps_type_name" />
+      <span class="twospan2" name="attr_mod_character_ps_type_name"></span>
+    </label>
+    <label
+      ><span>Restrained Punch</span>
+      <input type="hidden" name="attr_mod_restrained_punch" value="0" />
+      <span name="attr_mod_restrained_punch"></span>
+      <input type="hidden" name="attr_mod_restrained_punch_unit" />
+      <span name="attr_mod_restrained_punch_unit"></span>
+    </label>
+
+    <label
+      ><span>Punch</span>
+      <input type="hidden" name="attr_mod_punch" value="0" />
+      <span name="attr_mod_punch"></span>
+      <input type="hidden" name="attr_mod_punch_unit" />
+      <span name="attr_mod_punch_unit"></span>
+    </label>
+
+    <label
+      ><span>Power Punch</span>
+      <input type="hidden" name="attr_mod_power_punch" value="0" />
+      <span name="attr_mod_power_punch"></span>
+      <input type="hidden" name="attr_mod_power_punch_unit" />
+      <span name="attr_mod_power_punch_unit"></span>
+    </label>
+
+    <label
+      ><span>Kick</span>
+      <input type="hidden" name="attr_mod_kick" value="0" />
+      <span name="attr_mod_kick"></span>
+      <input type="hidden" name="attr_mod_kick_unit" />
+      <span name="attr_mod_kick_unit"></span>
+    </label>
+
+    <label
+      ><span>Leap Kick</span>
+      <input type="hidden" name="attr_mod_leap_kick" value="0" />
+      <span name="attr_mod_leap_kick"></span>
+      <input type="hidden" name="attr_mod_leap_kick_unit" />
+      <span name="attr_mod_leap_kick_unit"></span>
+    </label>
+
+    <label
+      ><span>Lift/Carry Weight Multiplier</span>
+      <input
+        type="hidden"
+        value="1"
+        name="attr_mod_liftcarry_weight_multiplier"
+        value="1"
+      />
+      <span name="attr_mod_liftcarry_weight_multiplier"></span>
+      <span>&#x00D7;</span>
+    </label>
+
+    <label
+      ><span>Lift/Carry Duration Multiplier</span>
+      <input
+        type="hidden"
+        value="1"
+        name="attr_mod_liftcarry_duration_multiplier"
+        value="1"
+      />
+      <span name="attr_mod_liftcarry_duration_multiplier"></span>
+      <span>&#x00D7;</span>
+    </label>
+
+    <label
+      ><span>Lift</span>
+      <input type="hidden" value="0" name="attr_mod_lift" value="0" />
+      <span name="attr_mod_lift"></span>
+      <span>lbs</span>
+    </label>
+
+    <label
+      ><span>Carry</span>
+      <input type="hidden" value="0" name="attr_mod_carry" value="0" />
+      <span name="attr_mod_carry"></span>
+      <span>lbs</span>
+    </label>
+
+    <label
+      ><span>Throw (&frac12; Carry)</span>
+      <input type="hidden" value="0" name="attr_mod_throw_distance" value="0" />
+      <span name="attr_mod_throw_distance"></span>
+      <span>Feet</span></label
+    >
+
+    <label
+      ><span>Carry Max</span>
+      <input type="hidden" value="0" name="attr_mod_carry_max" />
+      <span name="attr_mod_carry_max"></span>
+      <span>Minutes</span>
+    </label>
+
+    <label
+      ><span>Carry (Running)</span>
+      <input type="hidden" value="0" name="attr_mod_carry_running" />
+      <span name="attr_mod_carry_running"></span>
+      <span>Minutes</span></label
+    >
+
+    <label
+      ><span>Hold Max.</span>
+      <input type="hidden" value="0" name="attr_mod_hold_max" />
+      <span name="attr_mod_hold_max"></span>
+      <span>Melees</span></label
+    >
+  </div>
+
+  <div class="bonus-type-container movement">
+    <h2>Movement</h2>
+    <label><span></span><span>Imperial</span><span>Metric</span></label>
+    <label
+      ><span>Run/hour</span
+      ><input type="hidden" value="0" name="attr_run_mph" />
+      <span class="readonly-light">
+        <span name="attr_run_mph"></span>
+        <span>mph</span>
+      </span>
+      <input type="hidden" value="0" name="attr_run_kmh" />
+      <span class="readonly-light">
+        <span name="attr_run_kmh"></span>
+        <span>km/h</span>
+      </span>
+    </label>
+    <label
+      ><span>Run/melee</span
+      ><input type="hidden" value="0" name="attr_run_ft_melee" />
+      <span class="readonly-light">
+        <span name="attr_run_ft_melee"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_run_m_melee" />
+      <span class="readonly-light">
+        <span name="attr_run_m_melee"></span>
+        <span>m</span>
+      </span>
+    </label>
+    <label
+      ><span>Run/action</span
+      ><input type="hidden" value="0" name="attr_run_ft_action" />
+      <span class="readonly-light">
+        <span name="attr_run_ft_action"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_run_m_action" />
+      <span class="readonly-light">
+        <span name="attr_run_m_action"></span>
+        <span>m</span>
+      </span>
+    </label>
+    <label
+      ><span>Fly/hour</span
+      ><input type="hidden" value="0" name="attr_fly_mph" />
+      <span class="readonly-light">
+        <span name="attr_fly_mph"></span>
+        <span>mph</span>
+      </span>
+      <input type="hidden" value="0" name="attr_fly_kmh" />
+      <span class="readonly-light">
+        <span name="attr_fly_kmh"></span>
+        <span>km/h</span>
+      </span>
+    </label>
+    <label
+      ><span>Fly/melee</span
+      ><input type="hidden" value="0" name="attr_fly_ft_melee" />
+      <span class="readonly-light">
+        <span name="attr_fly_ft_melee"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_fly_m_melee" />
+      <span class="readonly-light">
+        <span name="attr_fly_m_melee"></span>
+        <span>m</span>
+      </span>
+    </label>
+    <label
+      ><span>Fly/action</span
+      ><input type="hidden" value="0" name="attr_fly_ft_action" />
+      <span class="readonly-light">
+        <span name="attr_fly_ft_action"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_fly_m_action" />
+      <span class="readonly-light">
+        <span name="attr_fly_m_action"></span>
+        <span>m</span>
+      </span>
+    </label>
+  </div>
+</div>
+<br />
+<label class="description"
+  ><b>Description</b>
+  <textarea class="full" name="attr_description" value=""></textarea>
+</label>
+<div class="macro-help">
+  <label
+    ><span><b>Row ID:</b></span>
+    <input type="text" readonly name="attr_rowid" value=""
+  /></label>
+</div>
+
+                            <!-- endinject -->
+                          </div>
+                        </details>
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+                <div class="picker">
+                  <div class="picker-inner">
+                    <h3 class="picker-title">Modifier Picker</h3>
+                    <fieldset class="repeating_bonusselections">
+                      <label>
+                        <input type="checkbox" name="attr_enabled" value="1" />
+                        <span name="attr_name"></span
+                      ></label>
+                      <input type="hidden" name="attr_name" value="" />
+                      <input type="hidden" name="attr_bonus_id" value="" />
+                    </fieldset>
+                    <div class="selected-ids">
+                      <b>Selected IDs</b>
+                      <input
+                        class="full"
+                        type="text"
+                        name="attr_bonus_ids_output"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <hr />
+          </div>
+          <div class="bonus-sources repeating-bonuses-outer">
+            <h3>Bonus Sources</h3>
+            <fieldset class="repeating_bonuses">
+              <input type="hidden" name="attr_selection_id" value="" />
+              <details class="info">
+                <summary>
+                  <div class="bonus-thing-heading">
+                    <b class="click-expand"
+                      ><span title="Click for more info">&nbsp;&#9432;</span></b
+                    >
+                    <label
+                      ><span>Name</span>
+                      <input type="text" list="modifiers" name="attr_name" />
+                    </label>
+                    <label
+                      ><span>Level</span>
+                      <input type="number" value="1" name="attr_level" />
+                    </label>
+                  </div>
+                </summary>
+                <div class="details-body">
+                  <!-- inject:partials/repeating_modifiers_readonly.html -->
+                  <input type="hidden" name="attr_bonus_id" value="" />
+<input type="hidden" name="global_psionic_ability" />
+<h3>Combat</h3>
+<div class="bonus-type-container">
+  <label
+    ><span>Attacks</span>
+    <input type="hidden" value="0" name="attr_attacks" />
+    <span name="attr_attacks"></span>
+  </label>
+  <label class="roller"
+    ><span>Initiative</span>
+    <input type="hidden" value="0" name="attr_initiative" />
+    <span>+</span>
+    <span name="attr_initiative"></span>
+    <button
+      type="roll"
+      value="@{opt_whisper}&{template:custom} {{title=@{character_name} rolls Initiative}} {{Initiative=[[d20+@{initiative} &{tracker}]]}}"
+      name="roll_bonus_initiative"
+    ></button>
+  </label>
+  <label class="roller"
+    ><span>Perception</span>
+    <input type="hidden" value="0" name="attr_perceptioncheck" />
+    <span>+</span>
+    <span name="attr_perceptioncheck"></span>
+    <button
+      type="roll"
+      value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
+      name="roll_bonus_perceptioncheck"
+    ></button>
+  </label>
+</div>
+<div class="modifiers-combat">
+  <div class="combat-offense-melee bonus-type-container">
+    <h3><span>&#x2694;</span> Ancient <span>&#x1F3F9;</span></h3>
+    <label
+      ><span>Strike</span>
+      <input type="hidden" value="0" name="attr_strike" />
+      <span>+</span>
+      <span name="attr_strike"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} strikes!}} {{Strike=[[d20cs>@{critical}+@{strike}]]}}"
+        name="roll_bonus_strike"
+      ></button>
+    </label>
+    <label
+      ><span>Disarm</span>
+      <input type="hidden" value="0" name="attr_disarm" />
+      <span>+</span>
+      <span name="attr_disarm"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm!}} {{Disarm=[[d20+@{disarm}]]}}"
+        name="roll_bonus_disarm"
+      ></button>
+    </label>
+    <label
+      ><span>Entangle</span>
+      <input type="hidden" value="0" name="attr_entangle" />
+      <span>+</span>
+      <span name="attr_entangle"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to entangle!}} {{Entangle=[[d20+@{entangle}]]}}"
+        name="roll_bonus_entangle"
+      ></button>
+    </label>
+    <label
+      ><span>Throw</span>
+      <input type="hidden" value="0" name="attr_throw" />
+      <span>+</span>
+      <span name="attr_throw"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws something!}} {{Throw=[[d20+@{throw}]]}}"
+        name="roll_bonus_throw"
+      ></button>
+    </label>
+    <label
+      ><span>Pull Punch vs. 11</span>
+      <input type="hidden" value="0" name="attr_pull" />
+      <span>+</span>
+      <span name="attr_pull"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to pull their punch!}} {{target=[[11]]}} {{roll=[[d20+@{pull}]]}}"
+        name="roll_bonus_pull"
+      ></button>
+    </label>
+    <label
+      ><span>Body Flip/Throw</span>
+      <input type="hidden" value="0" name="attr_flipthrow" />
+      <span>+</span>
+      <span name="attr_flipthrow"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body flip/throw!}} {{Body Flip/Throw=[[d20cs>@{critical}+@{flipthrow}]]}}"
+        name="roll_bonus_flipthrow"
+      ></button>
+    </label>
+    <label
+      ><span>Body Block/Tackle</span>
+      <input type="hidden" value="0" name="attr_tackle" />
+      <span>+</span>
+      <span name="attr_tackle"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body block/tackle!}} {{Body Block/Tackle=[[d20cs>@{critical}+@{tackle}]]}}"
+        name="roll_bonus_tackle"
+      ></button>
+    </label>
+    <label
+      ><span>Tripping/Leg Hook</span>
+      <input type="hidden" value="0" name="attr_leghook" />
+      <span>+</span>
+      <span name="attr_leghook"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a trip/leg hook!}} {{Tripping/Leg Hook=[[d20cs>@{critical}+@{leghook}]]}}"
+        name="roll_bonus_leghook"
+      ></button>
+    </label>
+    <label
+      ><span>Backward Sweep Kick</span>
+      <input type="hidden" value="0" name="attr_backwardsweepkick" />
+      <span>+</span>
+      <span name="attr_backwardsweepkick"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a backward sweep kick!}} {{Backward Sweep Kick=[[d20cs>@{critical}+@{backwardsweepkick}]]}}"
+        name="roll_bonus_backwardsweepkick"
+      ></button>
+    </label>
+    <hr />
+    <label
+      ><span>Critical</span>
+      <input type="hidden" value="" name="attr_critical" />
+      <span></span>
+      <span name="attr_critical"></span>
+    </label>
+    <label
+      ><span>Knockout</span>
+      <input type="hidden" value="" name="attr_knockout" />
+      <span></span>
+      <span name="attr_knockout"></span>
+    </label>
+    <label
+      ><span>Death Blow</span>
+      <input type="hidden" value="0" name="attr_deathblow" />
+      <span></span>
+      <span name="attr_deathblow"></span>
+    </label>
+    <hr />
+    <label
+      ><span>Damage</span>
+      <input type="hidden" value="0" name="attr_damage" />
+      <span></span>
+      <span name="attr_damage"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus}
+        }]]}}"
+        name="roll_bonus_damage"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Paired</span>
+      <input type="hidden" value="0" name="attr_damage_paired" />
+      <span></span>
+      <span name="attr_damage_paired"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_paired} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus} } * [[ {{ @{opt_paired_damage},0 }dl1 } * 1 + 1 ]]
+        ]]}}"
+        name="roll_bonus_damage_paired"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Main Hand</span>
+      <input type="hidden" value="0" name="attr_damage_mainhand" />
+      <span></span>
+      <span name="attr_damage_mainhand"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_mainhand} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
+        ]]}}"
+        name="roll_bonus_damage_mainhand"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Off Hand</span>
+      <input type="hidden" value="0" name="attr_damage_offhand" />
+      <span></span>
+      <span name="attr_damage_offhand"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_offhand} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
+        ]]}}"
+        name="roll_bonus_damage_offhand"
+      ></button>
+    </label>
+  </div>
+  <div class="combat-offense-range bonus-type-container">
+    <h3><span>&#x1F52B;</span> Modern/Range <span>&#x1F4A3;</span></h3>
+    <label
+      ><span>Strike</span>
+      <input type="hidden" value="0" name="attr_strike_range" />
+      <span>+</span>
+      <span name="attr_strike_range"></span>
+    </label>
+    <label title="1 Action"
+      ><span>Strike: Single/Pulse</span>
+      <input type="hidden" value="0" name="attr_strike_range_single" />
+      <span>+</span>
+      <span name="attr_strike_range_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a single shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_single} ]]}}"
+        name="roll_bonus_strike_range_single"
+      ></button>
+    </label>
+    <label title="1 Action"
+      ><span>Strike: Burst</span>
+      <input type="hidden" value="0" name="attr_strike_range_burst" />
+      <span>+</span>
+      <span name="attr_strike_range_burst"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a burst shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_burst} ]]}}"
+        name="roll_bonus_strike_range_burst"
+      ></button>
+    </label>
+    <label
+      ><span>Strike: Aimed</span>
+      <input type="hidden" value="0" name="attr_strike_range_aimed" />
+      <span>+</span>
+      <span name="attr_strike_range_aimed"></span>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Aimed Single</span>
+      <input type="hidden" value="0" name="attr_strike_range_aimed_single" />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed single shot!}} {{Range Aimed Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_single} ]]}}"
+        name="roll_bonus_strike_range_aimed_single"
+      ></button>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Aimed Pulse</span>
+      <input type="hidden" value="0" name="attr_strike_range_aimed_pulse" />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_pulse"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed pulse shot!}} {{Range Aimed Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_pulse} ]]}}"
+        name="roll_bonus_strike_range_aimed_pulse"
+      ></button>
+    </label>
+    <label
+      ><span>Strike: Called</span>
+      <input type="hidden" value="0" name="attr_strike_range_called" />
+      <span>+</span>
+      <span name="attr_strike_range_called"></span>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Called Single</span>
+      <input type="hidden" value="0" name="attr_strike_range_called_single" />
+      <span>+</span>
+      <span name="attr_strike_range_called_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called single shot!}} {{Range Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_single} ]]}}"
+        name="roll_bonus_strike_range_called_single"
+      ></button>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Called Pulse</span>
+      <input type="hidden" value="0" name="attr_strike_range_called_pulse" />
+      <span>+</span>
+      <span name="attr_strike_range_called_pulse"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called pulse shot!}} {{Range Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_pulse} ]]}}"
+        name="roll_bonus_strike_range_called_pulse"
+      ></button>
+    </label>
+    <label title="3 Actions"
+      ><span>Strike: Aimed Called Single</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_strike_range_aimed_called_single"
+      />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_called_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called single shot!}} {{Range Aimed Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_single} ]]}}"
+        name="roll_bonus_strike_range_aimed_called_single"
+      ></button>
+    </label>
+    <label title="3 Actions"
+      ><span>Strike: Aimed Called Pulse</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_strike_range_aimed_called_pulse"
+      />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_called_pulse"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called pulse shot!}} {{Range Aimed Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_pulse} ]]}}"
+        name="roll_bonus_strike_range_aimed_called_pulse"
+      ></button>
+    </label>
+    <hr />
+    <label
+      title="Using a gun to shoot a weapon out of an opponent's hand requires a called shot and careful aim (only the gunslinger can shoot to disarm on a quick draw)"
+      ><span>Disarm</span>
+      <input type="hidden" value="0" name="attr_disarm_range" />
+      <span>+</span>
+      <span name="attr_disarm_range"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm at range!}} {{Range Disarm=[[d20+@{disarm_range} + ?{Type of shot?|
+          No additional bonus,0|
+          Called Single (2 Actions),@{strike_range_called_single}|
+          Called Pulse (2 Actions),@{strike_range_called_pulse}|
+          Aimed Called Single (3 Actions),@{strike_range_aimed_called_single}|
+          Aimed Called Pulse (3 Actions),@{strike_range_aimed_called_pulse}|
+          Quick Draw Single (1 Action),@{strike_range_single}|
+          Quick Draw Pulse (1 Action),@{strike_range_burst}
+        }]]}}"
+        name="roll_bonus_disarm_range"
+      ></button>
+    </label>
+    <hr />
+    <label
+      ><span>Damage</span>
+      <input type="hidden" value="0" name="attr_damage_range" />
+      <span></span>
+      <span name="attr_damage_range"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage!}} {{Range Damage=[[@{damage_range}]]}}"
+        name="roll_bonus_damage_range"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Single</span>
+      <input type="hidden" value="0" name="attr_damage_range_single" />
+      <span></span>
+      <span name="attr_damage_range_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a single shot!}} {{Range Damage=[[@{damage_range_single}]]}}"
+        name="roll_bonus_damage_range_single"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Pulse/Burst</span>
+      <input type="hidden" value="0" name="attr_damage_range_burst" />
+      <span></span>
+      <span name="attr_damage_range_burst"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a burst!}} {{Range Damage=[[@{damage_range_burst}]]}}"
+        name="roll_bonus_damage_range_burst"
+      ></button>
+    </label>
+  </div>
+  <div class="combat-defense bonus-type-container">
+    <h3><span>&#x1F6E1;</span> Defense <span>&#x1F977;</span></h3>
+    <label
+      ><span>Parry</span>
+      <input type="hidden" value="0" name="attr_parry" />
+      <span>+</span>
+      <span name="attr_parry"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to parry!}} {{Parry=[[d20+@{parry}]]}}"
+        name="roll_bonus_parry"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge</span>
+      <input type="hidden" value="0" name="attr_dodge" />
+      <span>+</span>
+      <span name="attr_dodge"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge!}} {{ Dodge=[[ d20+@{dodge} - @{opt_dodge_penalty} ]] }}"
+        name="roll_bonus_dodge"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Flight</span>
+      <input type="hidden" value="0" name="attr_dodge_flight" />
+      <span>+</span>
+      <span name="attr_dodge_flight"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge in flight!}} {{Dodge in Flight=[[d20+@{dodge_flight} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_flight"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Auto</span>
+      <input type="hidden" value="0" name="attr_dodge_auto" />
+      <span>+</span>
+      <span name="attr_dodge_auto"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to auto dodge!}} {{Auto Dodge=[[d20+@{dodge_auto} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_auto"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Teleport</span>
+      <input type="hidden" value="0" name="attr_dodge_teleport" />
+      <span>+</span>
+      <span name="attr_dodge_teleport"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to teleport dodge!}} {{Teleport Dodge=[[d20+@{dodge_teleport} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_teleport"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Motion</span>
+      <input type="hidden" value="0" name="attr_dodge_motion" />
+      <span>+</span>
+      <span name="attr_dodge_motion"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge while in motion!}} {{Dodge in Motion=[[d20+@{dodge_motion} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_motion"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Underwater</span>
+      <input type="hidden" value="0" name="attr_dodge_underwater" />
+      <span>+</span>
+      <span name="attr_dodge_underwater"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge underwater!}} {{Dodge Underwater=[[d20+@{dodge_underwater} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_underwater"
+      ></button>
+    </label>
+    <label
+      ><span>Roll w/ Impact</span>
+      <input type="hidden" value="0" name="attr_roll" />
+      <span>+</span>
+      <span name="attr_roll"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to roll with impact!}} {{Roll w/ Impact=[[d20+@{roll}]]}}"
+        name="roll_bonus_roll"
+      ></button>
+    </label>
+    <label
+      ><span>Break Fall</span>
+      <input type="hidden" value="0" name="attr_breakfall" />
+      <span>+</span>
+      <span name="attr_breakfall"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to break fall!}} {{Break Fall=[[d20+@{breakfall}]]}}"
+        name="roll_bonus_breakfall"
+      ></button>
+    </label>
+  </div>
+  <div class="bonus-type-container">
+    <h3><span>&#x1F340;</span> Saving Throws <span>&#x1FAA6;</span></h3>
+    <label
+      ><span>Coma/Death</span>
+      <input type="hidden" value="0" name="attr_comadeath" />
+      <span>+</span>
+      <span name="attr_comadeath"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries not to die!}} {{target=[[50+@{comadeath}]]}} {{roll=[[d100]]}}"
+        name="roll_bonus_comadeath"
+      ></button>
+    </label>
+    <label
+      ><span>Curses vs. 15</span>
+      <input type="hidden" value="0" name="attr_curses" />
+      <span>+</span>
+      <span name="attr_curses"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against being cursed!}} {{target=[[15]]}} {{roll=[[d20+@{curses}+?{Add modifier?|
+            None,0|
+            Magic,@{magic}|
+            Psionics,@{psionics}
+          }]]}}"
+        name="roll_bonus_curses"
+      ></button>
+    </label>
+    <label
+      ><span>Despair</span>
+      <input type="hidden" value="0" name="attr_despair" />
+      <span>+</span>
+      <span name="attr_despair"></span>
+      <button
+        type="roll"
+        value="?{Type of Despair|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. magic despair!&amp;#125;&amp;#125; {{Save vs. Magic Despair=[[d20+@{despair}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to save vs. psionic despair!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{despair}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. despair!&amp;#125;&amp;#125; {{Save vs. Despair=[[d20+@{despair}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_despair"
+      ></button>
+    </label>
+    <label
+      ><span>Disease</span>
+      <input type="hidden" value="0" name="attr_disease" />
+      <span>+</span>
+      <span name="attr_disease"></span>
+      <button
+        type="roll"
+        value="?{Type of Disease|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Magic Disease=[[d20+@{disease}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{disease}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Disease=[[d20+@{disease}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_disease"
+      ></button>
+    </label>
+    <label
+      ><span>Drugs vs. 15</span>
+      <input type="hidden" value="0" name="attr_drugs" />
+      <span>+</span>
+      <span name="attr_drugs"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against harmful drugs!}} {{target=[[15]]}} {{roll=[[d20+@{drugs}]]}}"
+        name="roll_bonus_drugs"
+      ></button>
+    </label>
+    <label
+      ><span>Fatigue</span>
+      <input type="hidden" value="0" name="attr_fatigue" />
+      <span>+</span>
+      <span name="attr_fatigue"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to push through the fatigue!}} {{Fatigue=[[d20+@{fatigue}]]}}"
+        name="roll_bonus_fatigue"
+      ></button>
+    </label>
+    <label
+      ><span>Horror Factor</span>
+      <input type="hidden" value="0" name="attr_horrorfactor" />
+      <span>+</span>
+      <span name="attr_horrorfactor"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against horror factor!}} {{Save vs. Horror Factor=[[d20+@{horrorfactor}]]}}"
+        name="roll_bonus_horrorfactor"
+      ></button>
+    </label>
+    <label
+      ><span>Illusions</span>
+      <input type="hidden" value="0" name="attr_illusions" />
+      <span>+</span>
+      <span name="attr_illusions"></span>
+      <button
+        type="roll"
+        value="?{Type of Illusion|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the magic illusion!&amp;#125;&amp;#125; {{Save vs. Magic Illusions=[[d20+@{illusions}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to see through the psionic illusion!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{illusions}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the illusion!&amp;#125;&amp;#125; {{Save vs. Illusions=[[d20+@{illusions}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_illusions"
+      ></button>
+    </label>
+    <label
+      ><span>Insanity</span>
+      <input type="hidden" value="0" name="attr_insanity" />
+      <span>+</span>
+      <span name="attr_insanity"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against insanity!}} {{target=[[12]]}} {{roll=[[d20+@{insanity}]]}}"
+        name="roll_bonus_insanity"
+      ></button>
+    </label>
+    <label
+      ><span>Magic</span>
+      <input type="hidden" value="0" name="attr_magic" />
+      <span>+</span>
+      <span name="attr_magic"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against magic attack!}} {{Save vs. Magic=[[d20+@{magic}]]}}"
+        name="roll_bonus_magic"
+      ></button>
+    </label>
+    <label
+      ><span>Maintain Balance</span>
+      <input type="hidden" value="0" name="attr_maintainbalance" />
+      <span>+</span>
+      <span name="attr_maintainbalance"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to stay standing!}} {{Maintain Balance=[[d20+@{maintainbalance}]]}}"
+        name="roll_bonus_maintainbalance"
+      ></button>
+    </label>
+    <label
+      ><span>Mind Control</span>
+      <input type="hidden" value="0" name="attr_mindcontrol" />
+      <span>+</span>
+      <span name="attr_mindcontrol"></span>
+      <button
+        type="roll"
+        value="?{Type of Mind Control Attack|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off magic mind control!&amp;#125;&amp;#125; {{Save vs. Magic Mind Control=[[d20+@{mindcontrol}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to fight off psionic mind control!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{mindcontrol}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off mind control!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{mindcontrol}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_mindcontrol"
+      ></button>
+    </label>
+    <label
+      ><span>Pain</span>
+      <input type="hidden" value="0" name="attr_pain" />
+      <span>+</span>
+      <span name="attr_pain"></span>
+      <button
+        type="roll"
+        value="?{Type of Pain Attack|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the magic pain!&amp;#125;&amp;#125; {{Save vs. Magic Pain=[[d20+@{pain}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to push through the psionic pain!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{pain}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the pain!&amp;#125;&amp;#125; {{Save vs. Pain=[[d20+@{pain}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_pain"
       ></button>
     </label>
     <label

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.html
@@ -12842,6 +12842,89 @@ on("change:repeating_armor:is_active", async (e) => {
 
   /* endinject */
 
+  /* inject:js/ammo.js */
+  async function deductRoundsFromNextActiveAmmo(section, rounds) {
+  console.log("deductRoundsFromNextActiveAmmo", section, rounds);
+  const ids = await getSectionIDsOrderedAsync(section);
+  const attrKeys = ids
+    .flatMap((id) => [
+      `repeating_${section}_${id}_is_active`,
+      `repeating_${section}_${id}_clip`,
+      `repeating_${section}_${id}_name`,
+    ]);
+  const attrs = {};
+  const a = await getAttrsAsync(attrKeys);
+  
+  let ammoCarry = rounds;
+  let currentRounds = false;
+
+  const activeIds = ids.reduce((acc, cur) => {
+    if (Boolean(Number(a[`repeating_${section}_${cur}_is_active`]))) {
+      acc.push(cur);
+    }
+    return acc;
+  }, []);
+
+  console.log("deductRoundsFromNextActiveAmmo", a, activeIds);
+
+  let i = 0;
+  let activeRowId;
+  for (activeRowId of activeIds) {
+    currentRounds = Number(a[`repeating_${section}_${activeRowId}_clip`]) - ammoCarry;
+    console.log("deductRoundsFromNextActiveAmmo currentRounds", currentRounds, ammoCarry);
+    if (currentRounds < 0 && ++i < activeIds.length) {
+      console.log(
+        "deductRoundsFromNextActiveAmmo",
+        "BELOW ZERO on " + activeRowId
+      );
+      attrs[`repeating_${section}_${activeRowId}_clip`] = 0;
+      ammoCarry = Math.abs(currentRounds);
+    } else {
+      attrs[`repeating_${section}_${activeRowId}_clip`] = currentRounds;
+      break;
+    }
+  }
+  await setAttrsAsync(attrs);
+  // await updateActiveArmor(activeRowId);
+  return {
+    currentRounds,
+    ammo_name: a[`repeating_${section}_${activeRowId}_name`],
+  };
+}
+
+on("clicked:ammodeductrounds", async (e) => {
+  console.log("clicked:ammodeductrounds", e);
+  const a = await getAttrsAsync([
+    `ammorounds`,
+    `character_name`,
+    `outputusage`,
+  ]);
+  const { currentRounds, ammo_name } = await deductRoundsFromNextActiveAmmo(
+    "ammo",
+    +a[`ammorounds`]
+  );
+  const outputUsage = Boolean(Number(a.outputusage));
+  if (outputUsage) {
+    // const b = await getAttrsAsync([`active_armor_mdc`, `active_armor_name`]);
+    const chat = await startRoll(
+      `@{opt_whisper}&{template:ammo} {{character_name=${a["character_name"]}}} {{spent=${a["ammorounds"]}}} {{name=${ammo_name}}} {{remaining=${currentRounds}}}`
+    );
+    finishRoll(chat.rollId);
+  }
+});
+
+on("clicked:repeating_ammo:resetclip", async (e) => {
+  console.log("clicked:repeating_ammo:resetclip", e);
+  const [r, section, rowId] = e.sourceAttribute.split("_");
+  const a = await getAttrsAsync([`repeating_ammo_${rowId}_roundsperclip`]);
+  await setAttrsAsync({
+    [`repeating_ammo_${rowId}_clip`]: a[`repeating_ammo_${rowId}_roundsperclip`],
+  });
+  // await updateActiveArmor(rowId);
+});
+
+  /* endinject */
+
   /* inject:js/profiles.js */
   async function getDefaultProfileID() {
   const { default_profile } = await getAttrsAsync(["default_profile"]);
@@ -14436,6 +14519,15 @@ on("clicked:migrate", async (e) => {
     <span class="spent">{{spent}}</span> points of damage, reducing their
     <span class="name">{{name}}</span> to
     <span class="remaining">{{remaining}}</span>!
+  </div>
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-ammo">
+  <div class="sheet-container sheet-color-{{color}}">
+    <span class="character_name">{{character_name}}</span> fired
+    <span class="spent">{{spent}}</span> rounds, leaving their
+    <span class="name">{{name}}</span> with
+    <span class="remaining">{{remaining}}</span> remaining rounds!
   </div>
 </rolltemplate>
 

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.html
@@ -6439,6 +6439,51 @@
                 </fieldset>
               </div>
               <hr />
+              <div class="armor">
+                <h3>Ammo</h3>
+                <div class="armor-damage">
+                  <label
+                    >Rounds
+                    <input
+                      type="number"
+                      placeholder="Rounds"
+                      name="attr_ammorounds"
+                    />
+                  </label>
+                  <button type="action" name="act_ammodeductrounds">
+                    Deduct Rounds
+                  </button>
+                </div>
+                <div class="armor-labels heading">
+                  <label>Active</label>
+                  <label>Weapon</label>
+                  <label>Full Clips</label>
+                  <label>Rounds per Clip</label>
+                  <label>Current Clip</label>
+                </div>
+                <fieldset class="repeating_ammo">
+                  <div class="repeating_ammo-inner">
+                    <!-- inject:partials/ammo.html -->
+                    <label
+  ><input type="checkbox" class="is-active" name="attr_is_active" value="1"
+/></label>
+<input type="text" placeholder="Weapon Name" name="attr_name" />
+<input type="number" placeholder="Clips" name="attr_fullclips" />
+<input type="number" placeholder="Rounds per Clip" name="attr_roundsperclip" value="0" />
+<input
+  type="number"
+  class="danger"
+  placeholder="Current Clip"
+  name="attr_clip"
+  value="0"
+/>
+<button type="action" name="act_resetclip">Reset Clip</button>
+
+                    <!-- endinject -->
+                  </div>
+                </fieldset>
+              </div>
+              <hr />
               <div class="profile-builder">
                 <div class="profiles repeating-bonuses-outer">
                   <div class="profiles-inner">

--- a/Palladium Rifts by Grinning Gecko/dist/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/dist/rifts.html
@@ -12723,6 +12723,7 @@ on(
     .flatMap((id) => [
       `repeating_${section}_${id}_is_active`,
       `repeating_${section}_${id}_mdc`,
+      `repeating_${section}_${id}_name`,
     ])
     .concat(["outputarmorwarnings"]);
   const attrs = {};
@@ -12765,7 +12766,10 @@ on(
   }
   await setAttrsAsync(attrs);
   await updateActiveArmor(activeRowId);
-  return currentMdc;
+  return {
+    currentMdc,
+    armor_name: a[`repeating_${section}_${activeRowId}_name`],
+  };
 }
 
 /**
@@ -12807,7 +12811,7 @@ on("clicked:armorapplydamage", async (e) => {
     `active_armor_name`,
     `outputusage`,
   ]);
-  const currentMdc = await applyDamageToNextActiveArmor(
+  const { currentMdc, armor_name } = await applyDamageToNextActiveArmor(
     "armor",
     +a[`armordamage`]
   );
@@ -12815,11 +12819,7 @@ on("clicked:armorapplydamage", async (e) => {
   if (outputUsage) {
     // const b = await getAttrsAsync([`active_armor_mdc`, `active_armor_name`]);
     const chat = await startRoll(
-      `@{opt_whisper}&{template:damage} {{character_name=${
-        a["character_name"]
-      }}} {{spent=${a["armordamage"]}}} {{name=${
-        a[`active_armor_name`]
-      }}} {{remaining=${currentMdc}}}`
+      `@{opt_whisper}&{template:damage} {{character_name=${a["character_name"]}}} {{spent=${a["armordamage"]}}} {{name=${armor_name}}} {{remaining=${currentMdc}}}`
     );
     finishRoll(chat.rollId);
   }

--- a/Palladium Rifts by Grinning Gecko/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/rifts.css
@@ -660,17 +660,20 @@ a {
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner, .charsheet main#megaverse .armor .repeating_ammo-inner {
+.charsheet main#megaverse .armor .repeating_armor-inner,
+.charsheet main#megaverse .armor .repeating_ammo-inner {
   display: grid;
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
   align-items: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label, .charsheet main#megaverse .armor .repeating_ammo-inner > label {
+.charsheet main#megaverse .armor .repeating_armor-inner > label,
+.charsheet main#megaverse .armor .repeating_ammo-inner > label {
   align-self: center;
   text-align: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active, .charsheet main#megaverse .armor .repeating_ammo-inner > label > input[type=checkbox].is-active {
+.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active,
+.charsheet main#megaverse .armor .repeating_ammo-inner > label > input[type=checkbox].is-active {
   align-self: center;
 }
 .charsheet main#megaverse .profile-management {
@@ -1077,6 +1080,15 @@ body.sheet-darkmode .charsheet main#megaverse label.abs {
 }
 body.sheet-darkmode .charsheet main#megaverse label.abs:hover {
   background-color: var(--dark-primary-highlight);
+}
+body.sheet-darkmode .charsheet main#megaverse .repitem:nth-child(odd):not(.picker *) {
+  opacity: 0.7;
+}
+body.sheet-darkmode .charsheet main#megaverse .repitem:nth-child(odd):not(.picker *):has(details.info[open]) {
+  opacity: 1;
+}
+body.sheet-darkmode .charsheet main#megaverse .repitem:nth-child(even):not(.picker *) {
+  background-color: #222;
 }
 body.sheet-darkmode .charsheet main#megaverse .ss-2c {
   border-color: #444;

--- a/Palladium Rifts by Grinning Gecko/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/rifts.css
@@ -660,17 +660,17 @@ a {
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner {
+.charsheet main#megaverse .armor .repeating_armor-inner, .charsheet main#megaverse .armor .repeating_ammo-inner {
   display: grid;
   gap: 0.5rem;
   grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
   align-items: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label {
+.charsheet main#megaverse .armor .repeating_armor-inner > label, .charsheet main#megaverse .armor .repeating_ammo-inner > label {
   align-self: center;
   text-align: center;
 }
-.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active {
+.charsheet main#megaverse .armor .repeating_armor-inner > label > input[type=checkbox].is-active, .charsheet main#megaverse .armor .repeating_ammo-inner > label > input[type=checkbox].is-active {
   align-self: center;
 }
 .charsheet main#megaverse .profile-management {

--- a/Palladium Rifts by Grinning Gecko/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/rifts.css
@@ -478,13 +478,13 @@ a {
 .charsheet main#megaverse .bonus-ps-container {
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .bonus-ps-container label {
   display: grid;
   align-items: center;
   gap: 0.5rem;
-  grid-template-columns: 6.5rem 6rem 1fr;
+  grid-template-columns: 6.5rem minmax(4rem, 1fr) 4rem 4rem;
 }
 .charsheet main#megaverse .bonus-ps-container label.select select {
   grid-column: 2/span 2;
@@ -492,12 +492,28 @@ a {
 .charsheet main#megaverse .bonus-ps-container label input {
   width: 6rem;
 }
-.charsheet main#megaverse .bonus-ps-container label span {
+.charsheet main#megaverse .bonus-ps-container label > span {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
-.charsheet main#megaverse .bonus-ps-container label span[name^=attr_] {
+.charsheet main#megaverse .bonus-ps-container label > span[name^=attr_] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #eee;
+  margin: 0.1rem 0.2rem;
+  border-radius: 0.1rem;
+  font-weight: normal;
+  padding-left: 0.5rem;
+  overflow-y: auto;
+}
+.charsheet main#megaverse .bonus-ps-container label > label span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.charsheet main#megaverse .bonus-ps-container label > label span[name^=attr_] {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -511,7 +527,7 @@ a {
 .charsheet main#megaverse .bonus-type-container {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .bonus-type-container.attributes > label {
   display: grid;
@@ -697,13 +713,13 @@ a {
   border: 0;
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-ps-container {
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container {
   grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container.attributes {
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container.attributes > label {
   display: grid;
@@ -1084,6 +1100,11 @@ body.sheet-darkmode .charsheet main#megaverse .bonus-type-container hr,
 body.sheet-darkmode .charsheet main#megaverse .bonus-ps-container hr {
   border-color: #444;
   background-color: #444;
+}
+body.sheet-darkmode .charsheet main#megaverse .bonus-type-container > div span[name^=attr_],
+body.sheet-darkmode .charsheet main#megaverse .bonus-ps-container > div span[name^=attr_] {
+  background-color: #444;
+  border-color: #555;
 }
 body.sheet-darkmode .charsheet main#megaverse .bonus-type-container label span[name^=attr_],
 body.sheet-darkmode .charsheet main#megaverse .bonus-ps-container label span[name^=attr_] {

--- a/Palladium Rifts by Grinning Gecko/rifts.css
+++ b/Palladium Rifts by Grinning Gecko/rifts.css
@@ -453,7 +453,7 @@ a {
 .charsheet main#megaverse .modifiers-attributes {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
   align-items: start;
   margin-top: 0.5rem;
 }
@@ -700,7 +700,7 @@ a {
   grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container {
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 .charsheet main#megaverse .profile-builder .profiles .bonus-type-container.attributes {
   grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));

--- a/Palladium Rifts by Grinning Gecko/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/rifts.html
@@ -6074,6 +6074,11 @@
               name="attr_active_profile_mod_restrained_punch_unit"
             />
             <span name="attr_active_profile_mod_restrained_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{active_profile_mod_restrained_punch}]]}}"
+              name="roll_active_profile_damage_restrained_punch"
+            ></button>
           </label>
 
           <label
@@ -6086,6 +6091,11 @@
             <span name="attr_active_profile_mod_punch"></span>
             <input type="hidden" name="attr_active_profile_mod_punch_unit" />
             <span name="attr_active_profile_mod_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{active_profile_mod_punch}]]}}"
+              name="roll_active_profile_damage_punch"
+            ></button>
           </label>
 
           <label
@@ -6101,6 +6111,11 @@
               name="attr_active_profile_mod_power_punch_unit"
             />
             <span name="attr_active_profile_mod_power_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{active_profile_mod_power_punch}]]}}"
+              name="roll_active_profile_damage_power_punch"
+            ></button>
           </label>
 
           <label
@@ -6113,6 +6128,11 @@
             <span name="attr_active_profile_mod_kick"></span>
             <input type="hidden" name="attr_active_profile_mod_kick_unit" />
             <span name="attr_active_profile_mod_kick_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{active_profile_mod_kick}]]}}"
+              name="roll_active_profile_damage_kick"
+            ></button>
           </label>
 
           <label
@@ -6128,6 +6148,11 @@
               name="attr_active_profile_mod_leap_kick_unit"
             />
             <span name="attr_active_profile_mod_leap_kick_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{active_profile_mod_leap_kick}]]}}"
+              name="roll_active_profile_damage_leap_kick"
+            ></button>
           </label>
 
           <label
@@ -7485,6 +7510,11 @@
       <span name="attr_mod_restrained_punch"></span>
       <input type="hidden" name="attr_mod_restrained_punch_unit" />
       <span name="attr_mod_restrained_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{mod_restrained_punch}]]}}"
+        name="roll_damage_restrained_punch"
+      ></button>
     </label>
 
     <label
@@ -7493,6 +7523,11 @@
       <span name="attr_mod_punch"></span>
       <input type="hidden" name="attr_mod_punch_unit" />
       <span name="attr_mod_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{mod_punch}]]}}"
+        name="roll_damage_punch"
+      ></button>
     </label>
 
     <label
@@ -7501,6 +7536,11 @@
       <span name="attr_mod_power_punch"></span>
       <input type="hidden" name="attr_mod_power_punch_unit" />
       <span name="attr_mod_power_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{mod_power_punch}]]}}"
+        name="roll_damage_power_punch"
+      ></button>
     </label>
 
     <label
@@ -7509,6 +7549,11 @@
       <span name="attr_mod_kick"></span>
       <input type="hidden" name="attr_mod_kick_unit" />
       <span name="attr_mod_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{mod_kick}]]}}"
+        name="roll_damage_kick"
+      ></button>
     </label>
 
     <label
@@ -7517,6 +7562,11 @@
       <span name="attr_mod_leap_kick"></span>
       <input type="hidden" name="attr_mod_leap_kick_unit" />
       <span name="attr_mod_leap_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{mod_leap_kick}]]}}"
+        name="roll_damage_leap_kick"
+      ></button>
     </label>
 
     <label
@@ -8728,6 +8778,11 @@
       <span name="attr_mod_restrained_punch"></span>
       <input type="hidden" name="attr_mod_restrained_punch_unit" />
       <span name="attr_mod_restrained_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{mod_restrained_punch}]]}}"
+        name="roll_damage_restrained_punch"
+      ></button>
     </label>
 
     <label
@@ -8736,6 +8791,11 @@
       <span name="attr_mod_punch"></span>
       <input type="hidden" name="attr_mod_punch_unit" />
       <span name="attr_mod_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{mod_punch}]]}}"
+        name="roll_damage_punch"
+      ></button>
     </label>
 
     <label
@@ -8744,6 +8804,11 @@
       <span name="attr_mod_power_punch"></span>
       <input type="hidden" name="attr_mod_power_punch_unit" />
       <span name="attr_mod_power_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{mod_power_punch}]]}}"
+        name="roll_damage_power_punch"
+      ></button>
     </label>
 
     <label
@@ -8752,6 +8817,11 @@
       <span name="attr_mod_kick"></span>
       <input type="hidden" name="attr_mod_kick_unit" />
       <span name="attr_mod_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{mod_kick}]]}}"
+        name="roll_damage_kick"
+      ></button>
     </label>
 
     <label
@@ -8760,6 +8830,11 @@
       <span name="attr_mod_leap_kick"></span>
       <input type="hidden" name="attr_mod_leap_kick_unit" />
       <span name="attr_mod_leap_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{mod_leap_kick}]]}}"
+        name="roll_damage_leap_kick"
+      ></button>
     </label>
 
     <label
@@ -13226,51 +13301,51 @@ async function psBonusComplete(prefix = "") {
       }
       if (ps <= 15) {
         restrained_punch = "1D6";
-        punch = "4D6";
-        power_punch = "1D4";
-        power_punch_unit = "mdc";
+        punch = kick = "4D6";
+        power_punch = leap_kick = "1D4";
+        power_punch_unit = leap_kick_unit = "mdc";
       } else if (ps <= 20) {
         restrained_punch = "3D6";
-        punch = "1D6";
-        power_punch = "2D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "1D6";
+        power_punch = leap_kick = "2D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 25) {
         restrained_punch = "4D6";
-        punch = "2D6";
-        power_punch = "4D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "2D6";
+        power_punch = leap_kick = "4D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 30) {
         restrained_punch = "5D6";
-        punch = "3D6";
-        power_punch = "6D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "3D6";
+        power_punch = leap_kick = "6D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 35) {
         restrained_punch = "5D6";
-        punch = "4D6";
-        power_punch = "1D4*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "4D6";
+        power_punch = leap_kick = "1D4*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 40) {
         restrained_punch = "6D6";
-        punch = "5D6";
-        power_punch = "1D6*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "5D6";
+        power_punch = leap_kick = "1D6*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 50) {
         restrained_punch = "1D6*10";
-        punch = "6D6";
-        power_punch = "2D4*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "6D6";
+        power_punch = leap_kick = "2D4*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 60) {
         restrained_punch = "1D6";
-        punch = "1D6*10";
-        power_punch = "2D6*10";
-        restrained_punch_unit = punch_unit = power_punch_unit = "mdc";
+        punch = kick = "1D6*10";
+        power_punch = leap_kick = "2D6*10";
+        restrained_punch_unit = punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else {
         // > 60
         const extra = Math.ceil((ps - 60) / 10) * 10;
         restrained_punch = "1D6";
-        punch = `1D6*10+${extra}`;
-        power_punch = `2D6*10+${extra * 2}`;
-        restrained_punch_unit = punch_unit = power_punch_unit = "mdc";
+        punch = kick = `1D6*10+${extra}`;
+        power_punch = leap_kick = `2D6*10+${extra * 2}`;
+        restrained_punch_unit = punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       }
       break;
   }

--- a/Palladium Rifts by Grinning Gecko/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/rifts.html
@@ -11848,6 +11848,12 @@ async function migrateAttributes() {
       version: "1.5.0",
       function: migrateAddRowIds,
     },
+    {
+      version: "1.6.0",
+    },
+    {
+      version: "1.6.1",
+    },
   ];
 
   const { version, migrated } = await getAttrsAsync(["version", "migrated"]);

--- a/Palladium Rifts by Grinning Gecko/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/rifts.html
@@ -582,7 +582,7 @@
           <span class="readonly" name="attr_total"></span>
           <button
             type="roll"
-            value="@{opt_whisper}&{template:skill} [[ [[{@{total}+?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[0]]}} {{roll=$[[1]]}} {{total=$[[2]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+            value="@{opt_whisper}&{template:skill} [[ [[{@{total}+(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[0]]}} {{roll=$[[1]]}} {{total=$[[2]]}} {{add_skill=[[@{opt_add_skill}]]}}"
             name="roll_skill"
           ></button>
         </div>
@@ -1578,7 +1578,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_powerability_skill"
     ></button>
   </div>
@@ -2426,7 +2426,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_spell_skill"
     ></button>
     <input type="number" value="0" name="attr_ppecost" />
@@ -3264,7 +3264,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_psionic_skill"
     ></button>
     <input type="number" value="0" name="attr_ispcost" />
@@ -6003,7 +6003,7 @@
             <span name="attr_active_profile_mod_trust"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{active_profile_mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{active_profile_mod_trust}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_trust"
             ></button>
           </label>
@@ -6017,7 +6017,7 @@
             <span name="attr_active_profile_mod_intimidate"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{active_profile_mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{active_profile_mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_intimidate"
             ></button>
           </label>
@@ -6031,7 +6031,7 @@
             <span name="attr_active_profile_mod_charmimpress"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{active_profile_mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{active_profile_mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_charmimpress"
             ></button>
           </label>
@@ -7512,7 +7512,7 @@
       <span name="attr_mod_trust"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?({Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_trust"
       ></button>
     </label>
@@ -7522,7 +7522,7 @@
       <span name="attr_mod_intimidate"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_intimidate"
       ></button>
     </label>
@@ -7532,7 +7532,7 @@
       <span name="attr_mod_charmimpress"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_charmimpress"
       ></button>
     </label>
@@ -8780,7 +8780,7 @@
       <span name="attr_mod_trust"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?({Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_trust"
       ></button>
     </label>
@@ -8790,7 +8790,7 @@
       <span name="attr_mod_intimidate"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_intimidate"
       ></button>
     </label>
@@ -8800,7 +8800,7 @@
       <span name="attr_mod_charmimpress"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_charmimpress"
       ></button>
     </label>

--- a/Palladium Rifts by Grinning Gecko/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/rifts.html
@@ -12842,6 +12842,89 @@ on("change:repeating_armor:is_active", async (e) => {
 
   /* endinject */
 
+  /* inject:js/ammo.js */
+  async function deductRoundsFromNextActiveAmmo(section, rounds) {
+  console.log("deductRoundsFromNextActiveAmmo", section, rounds);
+  const ids = await getSectionIDsOrderedAsync(section);
+  const attrKeys = ids
+    .flatMap((id) => [
+      `repeating_${section}_${id}_is_active`,
+      `repeating_${section}_${id}_clip`,
+      `repeating_${section}_${id}_name`,
+    ]);
+  const attrs = {};
+  const a = await getAttrsAsync(attrKeys);
+  
+  let ammoCarry = rounds;
+  let currentRounds = false;
+
+  const activeIds = ids.reduce((acc, cur) => {
+    if (Boolean(Number(a[`repeating_${section}_${cur}_is_active`]))) {
+      acc.push(cur);
+    }
+    return acc;
+  }, []);
+
+  console.log("deductRoundsFromNextActiveAmmo", a, activeIds);
+
+  let i = 0;
+  let activeRowId;
+  for (activeRowId of activeIds) {
+    currentRounds = Number(a[`repeating_${section}_${activeRowId}_clip`]) - ammoCarry;
+    console.log("deductRoundsFromNextActiveAmmo currentRounds", currentRounds, ammoCarry);
+    if (currentRounds < 0 && ++i < activeIds.length) {
+      console.log(
+        "deductRoundsFromNextActiveAmmo",
+        "BELOW ZERO on " + activeRowId
+      );
+      attrs[`repeating_${section}_${activeRowId}_clip`] = 0;
+      ammoCarry = Math.abs(currentRounds);
+    } else {
+      attrs[`repeating_${section}_${activeRowId}_clip`] = currentRounds;
+      break;
+    }
+  }
+  await setAttrsAsync(attrs);
+  // await updateActiveArmor(activeRowId);
+  return {
+    currentRounds,
+    ammo_name: a[`repeating_${section}_${activeRowId}_name`],
+  };
+}
+
+on("clicked:ammodeductrounds", async (e) => {
+  console.log("clicked:ammodeductrounds", e);
+  const a = await getAttrsAsync([
+    `ammorounds`,
+    `character_name`,
+    `outputusage`,
+  ]);
+  const { currentRounds, ammo_name } = await deductRoundsFromNextActiveAmmo(
+    "ammo",
+    +a[`ammorounds`]
+  );
+  const outputUsage = Boolean(Number(a.outputusage));
+  if (outputUsage) {
+    // const b = await getAttrsAsync([`active_armor_mdc`, `active_armor_name`]);
+    const chat = await startRoll(
+      `@{opt_whisper}&{template:ammo} {{character_name=${a["character_name"]}}} {{spent=${a["ammorounds"]}}} {{name=${ammo_name}}} {{remaining=${currentRounds}}}`
+    );
+    finishRoll(chat.rollId);
+  }
+});
+
+on("clicked:repeating_ammo:resetclip", async (e) => {
+  console.log("clicked:repeating_ammo:resetclip", e);
+  const [r, section, rowId] = e.sourceAttribute.split("_");
+  const a = await getAttrsAsync([`repeating_ammo_${rowId}_roundsperclip`]);
+  await setAttrsAsync({
+    [`repeating_ammo_${rowId}_clip`]: a[`repeating_ammo_${rowId}_roundsperclip`],
+  });
+  // await updateActiveArmor(rowId);
+});
+
+  /* endinject */
+
   /* inject:js/profiles.js */
   async function getDefaultProfileID() {
   const { default_profile } = await getAttrsAsync(["default_profile"]);
@@ -14436,6 +14519,15 @@ on("clicked:migrate", async (e) => {
     <span class="spent">{{spent}}</span> points of damage, reducing their
     <span class="name">{{name}}</span> to
     <span class="remaining">{{remaining}}</span>!
+  </div>
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-ammo">
+  <div class="sheet-container sheet-color-{{color}}">
+    <span class="character_name">{{character_name}}</span> fired
+    <span class="spent">{{spent}}</span> rounds, leaving their
+    <span class="name">{{name}}</span> with
+    <span class="remaining">{{remaining}}</span> remaining rounds!
   </div>
 </rolltemplate>
 

--- a/Palladium Rifts by Grinning Gecko/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/rifts.html
@@ -6439,6 +6439,51 @@
                 </fieldset>
               </div>
               <hr />
+              <div class="armor">
+                <h3>Ammo</h3>
+                <div class="armor-damage">
+                  <label
+                    >Rounds
+                    <input
+                      type="number"
+                      placeholder="Rounds"
+                      name="attr_ammorounds"
+                    />
+                  </label>
+                  <button type="action" name="act_ammodeductrounds">
+                    Deduct Rounds
+                  </button>
+                </div>
+                <div class="armor-labels heading">
+                  <label>Active</label>
+                  <label>Weapon</label>
+                  <label>Full Clips</label>
+                  <label>Rounds per Clip</label>
+                  <label>Current Clip</label>
+                </div>
+                <fieldset class="repeating_ammo">
+                  <div class="repeating_ammo-inner">
+                    <!-- inject:partials/ammo.html -->
+                    <label
+  ><input type="checkbox" class="is-active" name="attr_is_active" value="1"
+/></label>
+<input type="text" placeholder="Weapon Name" name="attr_name" />
+<input type="number" placeholder="Clips" name="attr_fullclips" />
+<input type="number" placeholder="Rounds per Clip" name="attr_roundsperclip" value="0" />
+<input
+  type="number"
+  class="danger"
+  placeholder="Current Clip"
+  name="attr_clip"
+  value="0"
+/>
+<button type="action" name="act_resetclip">Reset Clip</button>
+
+                    <!-- endinject -->
+                  </div>
+                </fieldset>
+              </div>
+              <hr />
               <div class="profile-builder">
                 <div class="profiles repeating-bonuses-outer">
                   <div class="profiles-inner">

--- a/Palladium Rifts by Grinning Gecko/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/rifts.html
@@ -12723,6 +12723,7 @@ on(
     .flatMap((id) => [
       `repeating_${section}_${id}_is_active`,
       `repeating_${section}_${id}_mdc`,
+      `repeating_${section}_${id}_name`,
     ])
     .concat(["outputarmorwarnings"]);
   const attrs = {};
@@ -12765,7 +12766,10 @@ on(
   }
   await setAttrsAsync(attrs);
   await updateActiveArmor(activeRowId);
-  return currentMdc;
+  return {
+    currentMdc,
+    armor_name: a[`repeating_${section}_${activeRowId}_name`],
+  };
 }
 
 /**
@@ -12807,7 +12811,7 @@ on("clicked:armorapplydamage", async (e) => {
     `active_armor_name`,
     `outputusage`,
   ]);
-  const currentMdc = await applyDamageToNextActiveArmor(
+  const { currentMdc, armor_name } = await applyDamageToNextActiveArmor(
     "armor",
     +a[`armordamage`]
   );
@@ -12815,11 +12819,7 @@ on("clicked:armorapplydamage", async (e) => {
   if (outputUsage) {
     // const b = await getAttrsAsync([`active_armor_mdc`, `active_armor_name`]);
     const chat = await startRoll(
-      `@{opt_whisper}&{template:damage} {{character_name=${
-        a["character_name"]
-      }}} {{spent=${a["armordamage"]}}} {{name=${
-        a[`active_armor_name`]
-      }}} {{remaining=${currentMdc}}}`
+      `@{opt_whisper}&{template:damage} {{character_name=${a["character_name"]}}} {{spent=${a["armordamage"]}}} {{name=${armor_name}}} {{remaining=${currentMdc}}}`
     );
     finishRoll(chat.rollId);
   }

--- a/Palladium Rifts by Grinning Gecko/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/rifts.html
@@ -1172,6 +1172,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -1412,10 +1416,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -2089,6 +2089,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -2329,10 +2333,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -2926,6 +2926,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -3166,10 +3170,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -3764,6 +3764,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -4004,10 +4008,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>
@@ -4480,6 +4480,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -4722,10 +4726,6 @@
       <input type="number" value="0" name="attr_pain" />
     </label>
     <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
-    </label>
-    <label
       ><span>Poison: Lethal</span>
       <input type="number" value="0" name="attr_lethalpoison" />
     </label>
@@ -4838,6 +4838,21 @@
           >
             TT
           </button>
+        </label>
+        <label class="roller"
+          ><span>Perception</span>
+          <input
+            type="hidden"
+            value="0"
+            name="attr_active_profile_perceptioncheck"
+          />
+          <span>+</span>
+          <span name="attr_active_profile_perceptioncheck"></span>
+          <button
+            type="roll"
+            value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{active_profile_perceptioncheck}]]}}"
+            name="roll_active_profile_bonus_perceptioncheck"
+          ></button>
         </label>
       </div>
       <div class="modifiers-combat">
@@ -6498,1247 +6513,15 @@
       name="roll_bonus_initiative"
     ></button>
   </label>
-</div>
-<div class="modifiers-combat">
-  <div class="combat-offense-melee bonus-type-container">
-    <h3><span>&#x2694;</span> Ancient <span>&#x1F3F9;</span></h3>
-    <label
-      ><span>Strike</span>
-      <input type="hidden" value="0" name="attr_strike" />
-      <span>+</span>
-      <span name="attr_strike"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} strikes!}} {{Strike=[[d20cs>@{critical}+@{strike}]]}}"
-        name="roll_bonus_strike"
-      ></button>
-    </label>
-    <label
-      ><span>Disarm</span>
-      <input type="hidden" value="0" name="attr_disarm" />
-      <span>+</span>
-      <span name="attr_disarm"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm!}} {{Disarm=[[d20+@{disarm}]]}}"
-        name="roll_bonus_disarm"
-      ></button>
-    </label>
-    <label
-      ><span>Entangle</span>
-      <input type="hidden" value="0" name="attr_entangle" />
-      <span>+</span>
-      <span name="attr_entangle"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to entangle!}} {{Entangle=[[d20+@{entangle}]]}}"
-        name="roll_bonus_entangle"
-      ></button>
-    </label>
-    <label
-      ><span>Throw</span>
-      <input type="hidden" value="0" name="attr_throw" />
-      <span>+</span>
-      <span name="attr_throw"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws something!}} {{Throw=[[d20+@{throw}]]}}"
-        name="roll_bonus_throw"
-      ></button>
-    </label>
-    <label
-      ><span>Pull Punch vs. 11</span>
-      <input type="hidden" value="0" name="attr_pull" />
-      <span>+</span>
-      <span name="attr_pull"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to pull their punch!}} {{target=[[11]]}} {{roll=[[d20+@{pull}]]}}"
-        name="roll_bonus_pull"
-      ></button>
-    </label>
-    <label
-      ><span>Body Flip/Throw</span>
-      <input type="hidden" value="0" name="attr_flipthrow" />
-      <span>+</span>
-      <span name="attr_flipthrow"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body flip/throw!}} {{Body Flip/Throw=[[d20cs>@{critical}+@{flipthrow}]]}}"
-        name="roll_bonus_flipthrow"
-      ></button>
-    </label>
-    <label
-      ><span>Body Block/Tackle</span>
-      <input type="hidden" value="0" name="attr_tackle" />
-      <span>+</span>
-      <span name="attr_tackle"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body block/tackle!}} {{Body Block/Tackle=[[d20cs>@{critical}+@{tackle}]]}}"
-        name="roll_bonus_tackle"
-      ></button>
-    </label>
-    <label
-      ><span>Tripping/Leg Hook</span>
-      <input type="hidden" value="0" name="attr_leghook" />
-      <span>+</span>
-      <span name="attr_leghook"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a trip/leg hook!}} {{Tripping/Leg Hook=[[d20cs>@{critical}+@{leghook}]]}}"
-        name="roll_bonus_leghook"
-      ></button>
-    </label>
-    <label
-      ><span>Backward Sweep Kick</span>
-      <input type="hidden" value="0" name="attr_backwardsweepkick" />
-      <span>+</span>
-      <span name="attr_backwardsweepkick"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a backward sweep kick!}} {{Backward Sweep Kick=[[d20cs>@{critical}+@{backwardsweepkick}]]}}"
-        name="roll_bonus_backwardsweepkick"
-      ></button>
-    </label>
-    <hr />
-    <label
-      ><span>Critical</span>
-      <input type="hidden" value="" name="attr_critical" />
-      <span></span>
-      <span name="attr_critical"></span>
-    </label>
-    <label
-      ><span>Knockout</span>
-      <input type="hidden" value="" name="attr_knockout" />
-      <span></span>
-      <span name="attr_knockout"></span>
-    </label>
-    <label
-      ><span>Death Blow</span>
-      <input type="hidden" value="0" name="attr_deathblow" />
-      <span></span>
-      <span name="attr_deathblow"></span>
-    </label>
-    <hr />
-    <label
-      ><span>Damage</span>
-      <input type="hidden" value="0" name="attr_damage" />
-      <span></span>
-      <span name="attr_damage"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus}
-        }]]}}"
-        name="roll_bonus_damage"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Paired</span>
-      <input type="hidden" value="0" name="attr_damage_paired" />
-      <span></span>
-      <span name="attr_damage_paired"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_paired} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus} } * [[ {{ @{opt_paired_damage},0 }dl1 } * 1 + 1 ]]
-        ]]}}"
-        name="roll_bonus_damage_paired"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Main Hand</span>
-      <input type="hidden" value="0" name="attr_damage_mainhand" />
-      <span></span>
-      <span name="attr_damage_mainhand"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_mainhand} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
-        ]]}}"
-        name="roll_bonus_damage_mainhand"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Off Hand</span>
-      <input type="hidden" value="0" name="attr_damage_offhand" />
-      <span></span>
-      <span name="attr_damage_offhand"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_offhand} + ?{Add damage modifier?|
-          None,0|
-          Punch,@{mod_punch}|
-          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
-        ]]}}"
-        name="roll_bonus_damage_offhand"
-      ></button>
-    </label>
-  </div>
-  <div class="combat-offense-range bonus-type-container">
-    <h3><span>&#x1F52B;</span> Modern/Range <span>&#x1F4A3;</span></h3>
-    <label
-      ><span>Strike</span>
-      <input type="hidden" value="0" name="attr_strike_range" />
-      <span>+</span>
-      <span name="attr_strike_range"></span>
-    </label>
-    <label title="1 Action"
-      ><span>Strike: Single/Pulse</span>
-      <input type="hidden" value="0" name="attr_strike_range_single" />
-      <span>+</span>
-      <span name="attr_strike_range_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a single shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_single} ]]}}"
-        name="roll_bonus_strike_range_single"
-      ></button>
-    </label>
-    <label title="1 Action"
-      ><span>Strike: Burst</span>
-      <input type="hidden" value="0" name="attr_strike_range_burst" />
-      <span>+</span>
-      <span name="attr_strike_range_burst"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a burst shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_burst} ]]}}"
-        name="roll_bonus_strike_range_burst"
-      ></button>
-    </label>
-    <label
-      ><span>Strike: Aimed</span>
-      <input type="hidden" value="0" name="attr_strike_range_aimed" />
-      <span>+</span>
-      <span name="attr_strike_range_aimed"></span>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Aimed Single</span>
-      <input type="hidden" value="0" name="attr_strike_range_aimed_single" />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed single shot!}} {{Range Aimed Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_single} ]]}}"
-        name="roll_bonus_strike_range_aimed_single"
-      ></button>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Aimed Pulse</span>
-      <input type="hidden" value="0" name="attr_strike_range_aimed_pulse" />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_pulse"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed pulse shot!}} {{Range Aimed Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_pulse} ]]}}"
-        name="roll_bonus_strike_range_aimed_pulse"
-      ></button>
-    </label>
-    <label
-      ><span>Strike: Called</span>
-      <input type="hidden" value="0" name="attr_strike_range_called" />
-      <span>+</span>
-      <span name="attr_strike_range_called"></span>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Called Single</span>
-      <input type="hidden" value="0" name="attr_strike_range_called_single" />
-      <span>+</span>
-      <span name="attr_strike_range_called_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called single shot!}} {{Range Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_single} ]]}}"
-        name="roll_bonus_strike_range_called_single"
-      ></button>
-    </label>
-    <label title="2 Actions"
-      ><span>Strike: Called Pulse</span>
-      <input type="hidden" value="0" name="attr_strike_range_called_pulse" />
-      <span>+</span>
-      <span name="attr_strike_range_called_pulse"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called pulse shot!}} {{Range Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_pulse} ]]}}"
-        name="roll_bonus_strike_range_called_pulse"
-      ></button>
-    </label>
-    <label title="3 Actions"
-      ><span>Strike: Aimed Called Single</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_strike_range_aimed_called_single"
-      />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_called_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called single shot!}} {{Range Aimed Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_single} ]]}}"
-        name="roll_bonus_strike_range_aimed_called_single"
-      ></button>
-    </label>
-    <label title="3 Actions"
-      ><span>Strike: Aimed Called Pulse</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_strike_range_aimed_called_pulse"
-      />
-      <span>+</span>
-      <span name="attr_strike_range_aimed_called_pulse"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called pulse shot!}} {{Range Aimed Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_pulse} ]]}}"
-        name="roll_bonus_strike_range_aimed_called_pulse"
-      ></button>
-    </label>
-    <hr />
-    <label
-      title="Using a gun to shoot a weapon out of an opponent's hand requires a called shot and careful aim (only the gunslinger can shoot to disarm on a quick draw)"
-      ><span>Disarm</span>
-      <input type="hidden" value="0" name="attr_disarm_range" />
-      <span>+</span>
-      <span name="attr_disarm_range"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm at range!}} {{Range Disarm=[[d20+@{disarm_range} + ?{Type of shot?|
-          No additional bonus,0|
-          Called Single (2 Actions),@{strike_range_called_single}|
-          Called Pulse (2 Actions),@{strike_range_called_pulse}|
-          Aimed Called Single (3 Actions),@{strike_range_aimed_called_single}|
-          Aimed Called Pulse (3 Actions),@{strike_range_aimed_called_pulse}|
-          Quick Draw Single (1 Action),@{strike_range_single}|
-          Quick Draw Pulse (1 Action),@{strike_range_burst}
-        }]]}}"
-        name="roll_bonus_disarm_range"
-      ></button>
-    </label>
-    <hr />
-    <label
-      ><span>Damage</span>
-      <input type="hidden" value="0" name="attr_damage_range" />
-      <span></span>
-      <span name="attr_damage_range"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage!}} {{Range Damage=[[@{damage_range}]]}}"
-        name="roll_bonus_damage_range"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Single</span>
-      <input type="hidden" value="0" name="attr_damage_range_single" />
-      <span></span>
-      <span name="attr_damage_range_single"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a single shot!}} {{Range Damage=[[@{damage_range_single}]]}}"
-        name="roll_bonus_damage_range_single"
-      ></button>
-    </label>
-    <label
-      ><span>Damage: Pulse/Burst</span>
-      <input type="hidden" value="0" name="attr_damage_range_burst" />
-      <span></span>
-      <span name="attr_damage_range_burst"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a burst!}} {{Range Damage=[[@{damage_range_burst}]]}}"
-        name="roll_bonus_damage_range_burst"
-      ></button>
-    </label>
-  </div>
-  <div class="combat-defense bonus-type-container">
-    <h3><span>&#x1F6E1;</span> Defense <span>&#x1F977;</span></h3>
-    <label
-      ><span>Parry</span>
-      <input type="hidden" value="0" name="attr_parry" />
-      <span>+</span>
-      <span name="attr_parry"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to parry!}} {{Parry=[[d20+@{parry}]]}}"
-        name="roll_bonus_parry"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge</span>
-      <input type="hidden" value="0" name="attr_dodge" />
-      <span>+</span>
-      <span name="attr_dodge"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge!}} {{ Dodge=[[ d20+@{dodge} - @{opt_dodge_penalty} ]] }}"
-        name="roll_bonus_dodge"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Flight</span>
-      <input type="hidden" value="0" name="attr_dodge_flight" />
-      <span>+</span>
-      <span name="attr_dodge_flight"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge in flight!}} {{Dodge in Flight=[[d20+@{dodge_flight} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_flight"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Auto</span>
-      <input type="hidden" value="0" name="attr_dodge_auto" />
-      <span>+</span>
-      <span name="attr_dodge_auto"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to auto dodge!}} {{Auto Dodge=[[d20+@{dodge_auto} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_auto"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Teleport</span>
-      <input type="hidden" value="0" name="attr_dodge_teleport" />
-      <span>+</span>
-      <span name="attr_dodge_teleport"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to teleport dodge!}} {{Teleport Dodge=[[d20+@{dodge_teleport} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_teleport"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Motion</span>
-      <input type="hidden" value="0" name="attr_dodge_motion" />
-      <span>+</span>
-      <span name="attr_dodge_motion"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge while in motion!}} {{Dodge in Motion=[[d20+@{dodge_motion} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_motion"
-      ></button>
-    </label>
-    <label
-      ><span>Dodge: Underwater</span>
-      <input type="hidden" value="0" name="attr_dodge_underwater" />
-      <span>+</span>
-      <span name="attr_dodge_underwater"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge underwater!}} {{Dodge Underwater=[[d20+@{dodge_underwater} - @{opt_dodge_penalty} ]]}}"
-        name="roll_bonus_dodge_underwater"
-      ></button>
-    </label>
-    <label
-      ><span>Roll w/ Impact</span>
-      <input type="hidden" value="0" name="attr_roll" />
-      <span>+</span>
-      <span name="attr_roll"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to roll with impact!}} {{Roll w/ Impact=[[d20+@{roll}]]}}"
-        name="roll_bonus_roll"
-      ></button>
-    </label>
-    <label
-      ><span>Break Fall</span>
-      <input type="hidden" value="0" name="attr_breakfall" />
-      <span>+</span>
-      <span name="attr_breakfall"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to break fall!}} {{Break Fall=[[d20+@{breakfall}]]}}"
-        name="roll_bonus_breakfall"
-      ></button>
-    </label>
-  </div>
-  <div class="bonus-type-container">
-    <h3><span>&#x1F340;</span> Saving Throws <span>&#x1FAA6;</span></h3>
-    <label
-      ><span>Coma/Death</span>
-      <input type="hidden" value="0" name="attr_comadeath" />
-      <span>+</span>
-      <span name="attr_comadeath"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries not to die!}} {{target=[[50+@{comadeath}]]}} {{roll=[[d100]]}}"
-        name="roll_bonus_comadeath"
-      ></button>
-    </label>
-    <label
-      ><span>Curses vs. 15</span>
-      <input type="hidden" value="0" name="attr_curses" />
-      <span>+</span>
-      <span name="attr_curses"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against being cursed!}} {{target=[[15]]}} {{roll=[[d20+@{curses}+?{Add modifier?|
-            None,0|
-            Magic,@{magic}|
-            Psionics,@{psionics}
-          }]]}}"
-        name="roll_bonus_curses"
-      ></button>
-    </label>
-    <label
-      ><span>Despair</span>
-      <input type="hidden" value="0" name="attr_despair" />
-      <span>+</span>
-      <span name="attr_despair"></span>
-      <button
-        type="roll"
-        value="?{Type of Despair|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. magic despair!&amp;#125;&amp;#125; {{Save vs. Magic Despair=[[d20+@{despair}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to save vs. psionic despair!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{despair}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. despair!&amp;#125;&amp;#125; {{Save vs. Despair=[[d20+@{despair}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_despair"
-      ></button>
-    </label>
-    <label
-      ><span>Disease</span>
-      <input type="hidden" value="0" name="attr_disease" />
-      <span>+</span>
-      <span name="attr_disease"></span>
-      <button
-        type="roll"
-        value="?{Type of Disease|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Magic Disease=[[d20+@{disease}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{disease}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Disease=[[d20+@{disease}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_disease"
-      ></button>
-    </label>
-    <label
-      ><span>Drugs vs. 15</span>
-      <input type="hidden" value="0" name="attr_drugs" />
-      <span>+</span>
-      <span name="attr_drugs"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against harmful drugs!}} {{target=[[15]]}} {{roll=[[d20+@{drugs}]]}}"
-        name="roll_bonus_drugs"
-      ></button>
-    </label>
-    <label
-      ><span>Fatigue</span>
-      <input type="hidden" value="0" name="attr_fatigue" />
-      <span>+</span>
-      <span name="attr_fatigue"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to push through the fatigue!}} {{Fatigue=[[d20+@{fatigue}]]}}"
-        name="roll_bonus_fatigue"
-      ></button>
-    </label>
-    <label
-      ><span>Horror Factor</span>
-      <input type="hidden" value="0" name="attr_horrorfactor" />
-      <span>+</span>
-      <span name="attr_horrorfactor"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against horror factor!}} {{Save vs. Horror Factor=[[d20+@{horrorfactor}]]}}"
-        name="roll_bonus_horrorfactor"
-      ></button>
-    </label>
-    <label
-      ><span>Illusions</span>
-      <input type="hidden" value="0" name="attr_illusions" />
-      <span>+</span>
-      <span name="attr_illusions"></span>
-      <button
-        type="roll"
-        value="?{Type of Illusion|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the magic illusion!&amp;#125;&amp;#125; {{Save vs. Magic Illusions=[[d20+@{illusions}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to see through the psionic illusion!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{illusions}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the illusion!&amp;#125;&amp;#125; {{Save vs. Illusions=[[d20+@{illusions}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_illusions"
-      ></button>
-    </label>
-    <label
-      ><span>Insanity</span>
-      <input type="hidden" value="0" name="attr_insanity" />
-      <span>+</span>
-      <span name="attr_insanity"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against insanity!}} {{target=[[12]]}} {{roll=[[d20+@{insanity}]]}}"
-        name="roll_bonus_insanity"
-      ></button>
-    </label>
-    <label
-      ><span>Magic</span>
-      <input type="hidden" value="0" name="attr_magic" />
-      <span>+</span>
-      <span name="attr_magic"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against magic attack!}} {{Save vs. Magic=[[d20+@{magic}]]}}"
-        name="roll_bonus_magic"
-      ></button>
-    </label>
-    <label
-      ><span>Maintain Balance</span>
-      <input type="hidden" value="0" name="attr_maintainbalance" />
-      <span>+</span>
-      <span name="attr_maintainbalance"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to stay standing!}} {{Maintain Balance=[[d20+@{maintainbalance}]]}}"
-        name="roll_bonus_maintainbalance"
-      ></button>
-    </label>
-    <label
-      ><span>Mind Control</span>
-      <input type="hidden" value="0" name="attr_mindcontrol" />
-      <span>+</span>
-      <span name="attr_mindcontrol"></span>
-      <button
-        type="roll"
-        value="?{Type of Mind Control Attack|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off magic mind control!&amp;#125;&amp;#125; {{Save vs. Magic Mind Control=[[d20+@{mindcontrol}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to fight off psionic mind control!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{mindcontrol}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off mind control!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{mindcontrol}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_mindcontrol"
-      ></button>
-    </label>
-    <label
-      ><span>Pain</span>
-      <input type="hidden" value="0" name="attr_pain" />
-      <span>+</span>
-      <span name="attr_pain"></span>
-      <button
-        type="roll"
-        value="?{Type of Pain Attack|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the magic pain!&amp;#125;&amp;#125; {{Save vs. Magic Pain=[[d20+@{pain}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to push through the psionic pain!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{pain}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the pain!&amp;#125;&amp;#125; {{Save vs. Pain=[[d20+@{pain}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_pain"
-      ></button>
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="hidden" value="0" name="attr_perceptioncheck" />
-      <span>+</span>
-      <span name="attr_perceptioncheck"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
-        name="roll_bonus_perceptioncheck"
-      ></button>
-    </label>
-    <label
-      ><span>Poison: Lethal vs. 14</span>
-      <input type="hidden" value="0" name="attr_lethalpoison" />
-      <span>+</span>
-      <span name="attr_lethalpoison"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against lethal poison!}} {{target=[[14]]}} {{roll=[[d20+@{lethalpoison}]]}}"
-        name="roll_bonus_lethalpoison"
-      ></button>
-    </label>
-    <label
-      ><span>Poison: Non-Lethal vs. 16</span>
-      <input type="hidden" value="0" name="attr_nonlethalpoison" />
-      <span>+</span>
-      <span name="attr_nonlethalpoison"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against non-lethal poison!}} {{target=[[16]]}} {{roll=[[d20+@{nonlethalpoison}]]}}"
-        name="roll_bonus_nonlethalpoison"
-      ></button>
-    </label>
-    <label
-      ><span>Possession</span>
-      <input type="hidden" value="0" name="attr_possession" />
-      <span>+</span>
-      <span name="attr_possession"></span>
-      <button
-        type="roll"
-        value="?{Type of Possession|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being magically possessed!&amp;#125;&amp;#125; {{Save vs. Magic Possession=[[d20+@{possession}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to prevent being psionically possessed!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{possession}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being possessed!&amp;#125;&amp;#125; {{Save vs. Possession=[[d20+@{possession}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_possession"
-      ></button>
-    </label>
-    <label
-      ><span class="psi-vs"
-        >Psionics vs. <span name="attr_global_psionic_ability"></span
-      ></span>
-      <input type="hidden" value="0" name="attr_psionics" />
-      <span>+</span>
-      <span name="attr_psionics"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against psionic attack!}} {{target=[[@{psionic_ability}]]}} {{roll=[[d20+@{psionics}]]}}"
-        name="roll_save_psionics"
-      ></button>
-    </label>
-    <label
-      ><span>Telepathic Probes</span>
-      <input type="hidden" value="0" name="attr_telepathicprobes" />
-      <span>+</span>
-      <span name="attr_telepathicprobes"></span>
-      <button
-        type="roll"
-        value="?{Type of Telepathic Probe|
-          Magic,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a magic telepathic probe!&amp;#125;&amp;#125; {{Save vs. Magic Telepathic Probe=[[d20+@{telepathicprobes}+@{magic}]]&amp;#125;&amp;#125;|
-          Psionic,
-            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to block a psionic telepathic probe!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{telepathicprobes}+@{psionics}]]&amp;#125;&amp;#125;|
-          Other,
-            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a telepathic probe!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{telepathicprobes}]]&amp;#125;&amp;#125;
-        }"
-        name="roll_bonus_telepathicprobes"
-      ></button>
-    </label>
-  </div>
-</div>
-<br />
-<h3>Attributes</h3>
-<div class="modifiers-attributes">
-  <div class="bonus-type-container attributes">
-    <label>
-      <span style="grid-column: 3 / -1">Bonuses</span>
-    </label>
-    <label
-      ><span>I.Q.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_iq"
-        title="Intelligence Quotient"
-      />
-      <span name="attr_mod_iq" title="Intelligence Quotient"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_iq_bonus"
-        title="+ Skills %"
-      />
-      <span name="attr_mod_iq_bonus" title="+ Skills %"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_perception_bonus"
-        title="+ Perception (Rifter #13, p.16)"
-      />
-      <span
-        name="attr_mod_perception_bonus"
-        title="+ Perception (Rifter #13, p.16)"
-      ></span>
-    </label>
-    <label
-      ><span>M.E.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_me"
-        title="Mental Endurance"
-      />
-      <span name="attr_mod_me" title="Mental Endurance"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_me_bonus"
-        title="+ Save vs. Psionics"
-      />
-      <span name="attr_mod_me_bonus" title="+ Save vs. Psionics"></span>
-    </label>
-    <label
-      ><span>M.A.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ma"
-        title="Mental Affinity"
-      />
-      <span name="attr_mod_ma" title="Mental Affinity"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ma_bonus"
-        title="% Trust/Intimidate"
-      />
-      <span name="attr_mod_ma_bonus" title="% Trust/Intimidate"></span>
-    </label>
-    <label
-      ><span>P.S.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ps"
-        title="Physical Strength"
-      />
-      <span name="attr_mod_ps" title="Physical Strength"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_ps_bonus"
-        title="+ SDC Damage"
-      />
-      <span name="attr_mod_ps_bonus" title="+ SDC Damage"></span>
-    </label>
-    <label
-      ><span>P.P.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pp"
-        title="Physical Prowess"
-      />
-      <span name="attr_mod_pp" title="Physical Prowess"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pp_bonus"
-        title="+ Strike/Parry/Dodge/Entangle/Disarm"
-      />
-      <span
-        name="attr_mod_pp_bonus"
-        title="+ Strike/Parry/Dodge/Entangle/Disarm"
-      ></span>
-    </label>
-    <label
-      ><span>P.E.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pe"
-        title="Physical Endurance"
-      />
-      <span name="attr_mod_pe" title="Physical Endurance"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pe_bonus"
-        title="+ Magic/Poison/Toxins"
-      />
-      <span name="attr_mod_pe_bonus" title="+ Magic/Poison/Toxins"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pe_coma_bonus"
-        title="+ Coma/Death %"
-      />
-      <span name="attr_mod_pe_coma_bonus" title="+ Coma/Death %"></span>
-    </label>
-    <label
-      ><span>P.B.</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pb"
-        title="Physical Beauty"
-      />
-      <span name="attr_mod_pb" title="Physical Beauty"></span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_pb_bonus"
-        title="% Charm/Impress"
-      />
-      <span name="attr_mod_pb_bonus" title="% Charm/Impress"></span>
-    </label>
-    <label
-      ><span>Spd</span>
-      <input type="hidden" value="0" name="attr_mod_spd" title="Speed" />
-      <span name="attr_mod_spd" title="Speed"></span>
-    </label>
-    <label
-      ><span>Spd: Fly</span>
-      <input
-        type="hidden"
-        value="0"
-        name="attr_mod_spdfly"
-        title="Flying Speed"
-      />
-      <span name="attr_mod_spdfly" title="Flying Speed"></span>
-    </label>
-  </div>
-  <div class="bonus-type-container">
-    <label
-      ><span title="Hit Points">H.P.</span
-      ><input type="hidden" value="0" name="attr_hp" />
-      <span name="attr_hp"></span>
-    </label>
-    <label
-      ><span>S.D.C.</span><input type="hidden" value="0" name="attr_sdc" />
-      <span name="attr_sdc"></span>
-    </label>
-    <label
-      ><span>A.R.</span><input type="hidden" value="0" name="attr_ar" />
-      <span name="attr_ar"></span>
-    </label>
-    <label
-      ><span>M.D.C.</span><input type="hidden" value="0" name="attr_mdc" />
-      <span name="attr_mdc"></span>
-    </label>
-    <label
-      ><span>P.P.E.</span><input type="hidden" value="0" name="attr_ppe" />
-      <span name="attr_ppe"></span>
-    </label>
-    <label
-      ><span>I.S.P.</span><input type="hidden" value="0" name="attr_isp" />
-      <span name="attr_isp"></span>
-    </label>
-    <label
-      ><span>H.F.</span><input type="hidden" value="0" name="attr_mod_hf" />
-      <span name="attr_mod_hf"></span>
-    </label>
-    <label>
-      <span>Spell Strength</span>
-      <input type="hidden" value="0" name="attr_mod_spellstrength" />
-      <span name="attr_mod_spellstrength"></span>
-    </label>
-    <label>
-      <span>Trust</span>
-      <input type="hidden" value="0" name="attr_mod_trust" />
-      <span name="attr_mod_trust"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
-        name="roll_trust"
-      ></button>
-    </label>
-    <label>
-      <span>Intimidate</span>
-      <input type="hidden" value="0" name="attr_mod_intimidate" />
-      <span name="attr_mod_intimidate"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
-        name="roll_intimidate"
-      ></button>
-    </label>
-    <label>
-      <span>Charm/Impress</span>
-      <input type="hidden" value="0" name="attr_mod_charmimpress" />
-      <span name="attr_mod_charmimpress"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
-        name="roll_charmimpress"
-      ></button>
-    </label>
-    <label>
-      <span>Skill Bonus %</span>
-      <input type="hidden" value="0" name="attr_mod_skillbonus" />
-      <span name="attr_mod_skillbonus"></span>
-    </label>
-  </div>
-  <div class="bonus-ps-container">
-    <label class="select"
-      ><span>PS Type</span>
-      <input type="hidden" name="attr_mod_character_ps_type" />
-      <input type="hidden" name="attr_mod_character_ps_type_name" />
-      <span class="twospan2" name="attr_mod_character_ps_type_name"></span>
-    </label>
-    <label
-      ><span>Restrained Punch</span>
-      <input type="hidden" name="attr_mod_restrained_punch" value="0" />
-      <span name="attr_mod_restrained_punch"></span>
-      <input type="hidden" name="attr_mod_restrained_punch_unit" />
-      <span name="attr_mod_restrained_punch_unit"></span>
-    </label>
-
-    <label
-      ><span>Punch</span>
-      <input type="hidden" name="attr_mod_punch" value="0" />
-      <span name="attr_mod_punch"></span>
-      <input type="hidden" name="attr_mod_punch_unit" />
-      <span name="attr_mod_punch_unit"></span>
-    </label>
-
-    <label
-      ><span>Power Punch</span>
-      <input type="hidden" name="attr_mod_power_punch" value="0" />
-      <span name="attr_mod_power_punch"></span>
-      <input type="hidden" name="attr_mod_power_punch_unit" />
-      <span name="attr_mod_power_punch_unit"></span>
-    </label>
-
-    <label
-      ><span>Kick</span>
-      <input type="hidden" name="attr_mod_kick" value="0" />
-      <span name="attr_mod_kick"></span>
-      <input type="hidden" name="attr_mod_kick_unit" />
-      <span name="attr_mod_kick_unit"></span>
-    </label>
-
-    <label
-      ><span>Leap Kick</span>
-      <input type="hidden" name="attr_mod_leap_kick" value="0" />
-      <span name="attr_mod_leap_kick"></span>
-      <input type="hidden" name="attr_mod_leap_kick_unit" />
-      <span name="attr_mod_leap_kick_unit"></span>
-    </label>
-
-    <label
-      ><span>Lift/Carry Weight Multiplier</span>
-      <input
-        type="hidden"
-        value="1"
-        name="attr_mod_liftcarry_weight_multiplier"
-        value="1"
-      />
-      <span name="attr_mod_liftcarry_weight_multiplier"></span>
-      <span>&#x00D7;</span>
-    </label>
-
-    <label
-      ><span>Lift/Carry Duration Multiplier</span>
-      <input
-        type="hidden"
-        value="1"
-        name="attr_mod_liftcarry_duration_multiplier"
-        value="1"
-      />
-      <span name="attr_mod_liftcarry_duration_multiplier"></span>
-      <span>&#x00D7;</span>
-    </label>
-
-    <label
-      ><span>Lift</span>
-      <input type="hidden" value="0" name="attr_mod_lift" value="0" />
-      <span name="attr_mod_lift"></span>
-      <span>lbs</span>
-    </label>
-
-    <label
-      ><span>Carry</span>
-      <input type="hidden" value="0" name="attr_mod_carry" value="0" />
-      <span name="attr_mod_carry"></span>
-      <span>lbs</span>
-    </label>
-
-    <label
-      ><span>Throw (&frac12; Carry)</span>
-      <input type="hidden" value="0" name="attr_mod_throw_distance" value="0" />
-      <span name="attr_mod_throw_distance"></span>
-      <span>Feet</span></label
-    >
-
-    <label
-      ><span>Carry Max</span>
-      <input type="hidden" value="0" name="attr_mod_carry_max" />
-      <span name="attr_mod_carry_max"></span>
-      <span>Minutes</span>
-    </label>
-
-    <label
-      ><span>Carry (Running)</span>
-      <input type="hidden" value="0" name="attr_mod_carry_running" />
-      <span name="attr_mod_carry_running"></span>
-      <span>Minutes</span></label
-    >
-
-    <label
-      ><span>Hold Max.</span>
-      <input type="hidden" value="0" name="attr_mod_hold_max" />
-      <span name="attr_mod_hold_max"></span>
-      <span>Melees</span></label
-    >
-  </div>
-
-  <div class="bonus-type-container movement">
-    <h2>Movement</h2>
-    <label><span></span><span>Imperial</span><span>Metric</span></label>
-    <label
-      ><span>Run/hour</span
-      ><input type="hidden" value="0" name="attr_run_mph" />
-      <span class="readonly-light">
-        <span name="attr_run_mph"></span>
-        <span>mph</span>
-      </span>
-      <input type="hidden" value="0" name="attr_run_kmh" />
-      <span class="readonly-light">
-        <span name="attr_run_kmh"></span>
-        <span>km/h</span>
-      </span>
-    </label>
-    <label
-      ><span>Run/melee</span
-      ><input type="hidden" value="0" name="attr_run_ft_melee" />
-      <span class="readonly-light">
-        <span name="attr_run_ft_melee"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_run_m_melee" />
-      <span class="readonly-light">
-        <span name="attr_run_m_melee"></span>
-        <span>m</span>
-      </span>
-    </label>
-    <label
-      ><span>Run/action</span
-      ><input type="hidden" value="0" name="attr_run_ft_action" />
-      <span class="readonly-light">
-        <span name="attr_run_ft_action"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_run_m_action" />
-      <span class="readonly-light">
-        <span name="attr_run_m_action"></span>
-        <span>m</span>
-      </span>
-    </label>
-    <label
-      ><span>Fly/hour</span
-      ><input type="hidden" value="0" name="attr_fly_mph" />
-      <span class="readonly-light">
-        <span name="attr_fly_mph"></span>
-        <span>mph</span>
-      </span>
-      <input type="hidden" value="0" name="attr_fly_kmh" />
-      <span class="readonly-light">
-        <span name="attr_fly_kmh"></span>
-        <span>km/h</span>
-      </span>
-    </label>
-    <label
-      ><span>Fly/melee</span
-      ><input type="hidden" value="0" name="attr_fly_ft_melee" />
-      <span class="readonly-light">
-        <span name="attr_fly_ft_melee"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_fly_m_melee" />
-      <span class="readonly-light">
-        <span name="attr_fly_m_melee"></span>
-        <span>m</span>
-      </span>
-    </label>
-    <label
-      ><span>Fly/action</span
-      ><input type="hidden" value="0" name="attr_fly_ft_action" />
-      <span class="readonly-light">
-        <span name="attr_fly_ft_action"></span>
-        <span>ft</span>
-      </span>
-      <input type="hidden" value="0" name="attr_fly_m_action" />
-      <span class="readonly-light">
-        <span name="attr_fly_m_action"></span>
-        <span>m</span>
-      </span>
-    </label>
-  </div>
-</div>
-<br />
-<label class="description"
-  ><b>Description</b>
-  <textarea class="full" name="attr_description" value=""></textarea>
-</label>
-<div class="macro-help">
-  <label
-    ><span><b>Row ID:</b></span>
-    <input type="text" readonly name="attr_rowid" value=""
-  /></label>
-</div>
-
-                            <!-- endinject -->
-                          </div>
-                        </details>
-                      </div>
-                    </fieldset>
-                  </div>
-                </div>
-                <div class="picker">
-                  <div class="picker-inner">
-                    <h3 class="picker-title">Modifier Picker</h3>
-                    <fieldset class="repeating_bonusselections">
-                      <label>
-                        <input type="checkbox" name="attr_enabled" value="1" />
-                        <span name="attr_name"></span
-                      ></label>
-                      <input type="hidden" name="attr_name" value="" />
-                      <input type="hidden" name="attr_bonus_id" value="" />
-                    </fieldset>
-                    <div class="selected-ids">
-                      <b>Selected IDs</b>
-                      <input
-                        class="full"
-                        type="text"
-                        name="attr_bonus_ids_output"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <hr />
-          </div>
-          <div class="bonus-sources repeating-bonuses-outer">
-            <h3>Bonus Sources</h3>
-            <fieldset class="repeating_bonuses">
-              <input type="hidden" name="attr_selection_id" value="" />
-              <details class="info">
-                <summary>
-                  <div class="bonus-thing-heading">
-                    <b class="click-expand"
-                      ><span title="Click for more info">&nbsp;&#9432;</span></b
-                    >
-                    <label
-                      ><span>Name</span>
-                      <input type="text" list="modifiers" name="attr_name" />
-                    </label>
-                    <label
-                      ><span>Level</span>
-                      <input type="number" value="1" name="attr_level" />
-                    </label>
-                  </div>
-                </summary>
-                <div class="details-body">
-                  <!-- inject:partials/repeating_modifiers_readonly.html -->
-                  <input type="hidden" name="attr_bonus_id" value="" />
-<input type="hidden" name="global_psionic_ability" />
-<h3>Combat</h3>
-<div class="bonus-type-container">
-  <label
-    ><span>Attacks</span>
-    <input type="hidden" value="0" name="attr_attacks" />
-    <span name="attr_attacks"></span>
-  </label>
   <label class="roller"
-    ><span>Initiative</span>
-    <input type="hidden" value="0" name="attr_initiative" />
+    ><span>Perception</span>
+    <input type="hidden" value="0" name="attr_perceptioncheck" />
     <span>+</span>
-    <span name="attr_initiative"></span>
+    <span name="attr_perceptioncheck"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:custom} {{title=@{character_name} rolls Initiative}} {{Initiative=[[d20+@{initiative} &{tracker}]]}}"
-      name="roll_bonus_initiative"
+      value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
+      name="roll_bonus_perceptioncheck"
     ></button>
   </label>
 </div>
@@ -8384,14 +7167,1246 @@
       ></button>
     </label>
     <label
-      ><span>Perception</span>
-      <input type="hidden" value="0" name="attr_perceptioncheck" />
+      ><span>Poison: Lethal vs. 14</span>
+      <input type="hidden" value="0" name="attr_lethalpoison" />
       <span>+</span>
-      <span name="attr_perceptioncheck"></span>
+      <span name="attr_lethalpoison"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
-        name="roll_bonus_perceptioncheck"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against lethal poison!}} {{target=[[14]]}} {{roll=[[d20+@{lethalpoison}]]}}"
+        name="roll_bonus_lethalpoison"
+      ></button>
+    </label>
+    <label
+      ><span>Poison: Non-Lethal vs. 16</span>
+      <input type="hidden" value="0" name="attr_nonlethalpoison" />
+      <span>+</span>
+      <span name="attr_nonlethalpoison"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against non-lethal poison!}} {{target=[[16]]}} {{roll=[[d20+@{nonlethalpoison}]]}}"
+        name="roll_bonus_nonlethalpoison"
+      ></button>
+    </label>
+    <label
+      ><span>Possession</span>
+      <input type="hidden" value="0" name="attr_possession" />
+      <span>+</span>
+      <span name="attr_possession"></span>
+      <button
+        type="roll"
+        value="?{Type of Possession|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being magically possessed!&amp;#125;&amp;#125; {{Save vs. Magic Possession=[[d20+@{possession}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to prevent being psionically possessed!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{possession}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to prevent being possessed!&amp;#125;&amp;#125; {{Save vs. Possession=[[d20+@{possession}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_possession"
+      ></button>
+    </label>
+    <label
+      ><span class="psi-vs"
+        >Psionics vs. <span name="attr_global_psionic_ability"></span
+      ></span>
+      <input type="hidden" value="0" name="attr_psionics" />
+      <span>+</span>
+      <span name="attr_psionics"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against psionic attack!}} {{target=[[@{psionic_ability}]]}} {{roll=[[d20+@{psionics}]]}}"
+        name="roll_save_psionics"
+      ></button>
+    </label>
+    <label
+      ><span>Telepathic Probes</span>
+      <input type="hidden" value="0" name="attr_telepathicprobes" />
+      <span>+</span>
+      <span name="attr_telepathicprobes"></span>
+      <button
+        type="roll"
+        value="?{Type of Telepathic Probe|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a magic telepathic probe!&amp;#125;&amp;#125; {{Save vs. Magic Telepathic Probe=[[d20+@{telepathicprobes}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to block a psionic telepathic probe!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{telepathicprobes}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to block a telepathic probe!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{telepathicprobes}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_telepathicprobes"
+      ></button>
+    </label>
+  </div>
+</div>
+<br />
+<h3>Attributes</h3>
+<div class="modifiers-attributes">
+  <div class="bonus-type-container attributes">
+    <label>
+      <span style="grid-column: 3 / -1">Bonuses</span>
+    </label>
+    <label
+      ><span>I.Q.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_iq"
+        title="Intelligence Quotient"
+      />
+      <span name="attr_mod_iq" title="Intelligence Quotient"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_iq_bonus"
+        title="+ Skills %"
+      />
+      <span name="attr_mod_iq_bonus" title="+ Skills %"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_perception_bonus"
+        title="+ Perception (Rifter #13, p.16)"
+      />
+      <span
+        name="attr_mod_perception_bonus"
+        title="+ Perception (Rifter #13, p.16)"
+      ></span>
+    </label>
+    <label
+      ><span>M.E.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_me"
+        title="Mental Endurance"
+      />
+      <span name="attr_mod_me" title="Mental Endurance"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_me_bonus"
+        title="+ Save vs. Psionics"
+      />
+      <span name="attr_mod_me_bonus" title="+ Save vs. Psionics"></span>
+    </label>
+    <label
+      ><span>M.A.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ma"
+        title="Mental Affinity"
+      />
+      <span name="attr_mod_ma" title="Mental Affinity"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ma_bonus"
+        title="% Trust/Intimidate"
+      />
+      <span name="attr_mod_ma_bonus" title="% Trust/Intimidate"></span>
+    </label>
+    <label
+      ><span>P.S.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ps"
+        title="Physical Strength"
+      />
+      <span name="attr_mod_ps" title="Physical Strength"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_ps_bonus"
+        title="+ SDC Damage"
+      />
+      <span name="attr_mod_ps_bonus" title="+ SDC Damage"></span>
+    </label>
+    <label
+      ><span>P.P.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pp"
+        title="Physical Prowess"
+      />
+      <span name="attr_mod_pp" title="Physical Prowess"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pp_bonus"
+        title="+ Strike/Parry/Dodge/Entangle/Disarm"
+      />
+      <span
+        name="attr_mod_pp_bonus"
+        title="+ Strike/Parry/Dodge/Entangle/Disarm"
+      ></span>
+    </label>
+    <label
+      ><span>P.E.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pe"
+        title="Physical Endurance"
+      />
+      <span name="attr_mod_pe" title="Physical Endurance"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pe_bonus"
+        title="+ Magic/Poison/Toxins"
+      />
+      <span name="attr_mod_pe_bonus" title="+ Magic/Poison/Toxins"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pe_coma_bonus"
+        title="+ Coma/Death %"
+      />
+      <span name="attr_mod_pe_coma_bonus" title="+ Coma/Death %"></span>
+    </label>
+    <label
+      ><span>P.B.</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pb"
+        title="Physical Beauty"
+      />
+      <span name="attr_mod_pb" title="Physical Beauty"></span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_pb_bonus"
+        title="% Charm/Impress"
+      />
+      <span name="attr_mod_pb_bonus" title="% Charm/Impress"></span>
+    </label>
+    <label
+      ><span>Spd</span>
+      <input type="hidden" value="0" name="attr_mod_spd" title="Speed" />
+      <span name="attr_mod_spd" title="Speed"></span>
+    </label>
+    <label
+      ><span>Spd: Fly</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_mod_spdfly"
+        title="Flying Speed"
+      />
+      <span name="attr_mod_spdfly" title="Flying Speed"></span>
+    </label>
+  </div>
+  <div class="bonus-type-container">
+    <label
+      ><span title="Hit Points">H.P.</span
+      ><input type="hidden" value="0" name="attr_hp" />
+      <span name="attr_hp"></span>
+    </label>
+    <label
+      ><span>S.D.C.</span><input type="hidden" value="0" name="attr_sdc" />
+      <span name="attr_sdc"></span>
+    </label>
+    <label
+      ><span>A.R.</span><input type="hidden" value="0" name="attr_ar" />
+      <span name="attr_ar"></span>
+    </label>
+    <label
+      ><span>M.D.C.</span><input type="hidden" value="0" name="attr_mdc" />
+      <span name="attr_mdc"></span>
+    </label>
+    <label
+      ><span>P.P.E.</span><input type="hidden" value="0" name="attr_ppe" />
+      <span name="attr_ppe"></span>
+    </label>
+    <label
+      ><span>I.S.P.</span><input type="hidden" value="0" name="attr_isp" />
+      <span name="attr_isp"></span>
+    </label>
+    <label
+      ><span>H.F.</span><input type="hidden" value="0" name="attr_mod_hf" />
+      <span name="attr_mod_hf"></span>
+    </label>
+    <label>
+      <span>Spell Strength</span>
+      <input type="hidden" value="0" name="attr_mod_spellstrength" />
+      <span name="attr_mod_spellstrength"></span>
+    </label>
+    <label>
+      <span>Trust</span>
+      <input type="hidden" value="0" name="attr_mod_trust" />
+      <span name="attr_mod_trust"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        name="roll_trust"
+      ></button>
+    </label>
+    <label>
+      <span>Intimidate</span>
+      <input type="hidden" value="0" name="attr_mod_intimidate" />
+      <span name="attr_mod_intimidate"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        name="roll_intimidate"
+      ></button>
+    </label>
+    <label>
+      <span>Charm/Impress</span>
+      <input type="hidden" value="0" name="attr_mod_charmimpress" />
+      <span name="attr_mod_charmimpress"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        name="roll_charmimpress"
+      ></button>
+    </label>
+    <label>
+      <span>Skill Bonus %</span>
+      <input type="hidden" value="0" name="attr_mod_skillbonus" />
+      <span name="attr_mod_skillbonus"></span>
+    </label>
+  </div>
+  <div class="bonus-ps-container">
+    <label class="select"
+      ><span>PS Type</span>
+      <input type="hidden" name="attr_mod_character_ps_type" />
+      <input type="hidden" name="attr_mod_character_ps_type_name" />
+      <span class="twospan2" name="attr_mod_character_ps_type_name"></span>
+    </label>
+    <label
+      ><span>Restrained Punch</span>
+      <input type="hidden" name="attr_mod_restrained_punch" value="0" />
+      <span name="attr_mod_restrained_punch"></span>
+      <input type="hidden" name="attr_mod_restrained_punch_unit" />
+      <span name="attr_mod_restrained_punch_unit"></span>
+    </label>
+
+    <label
+      ><span>Punch</span>
+      <input type="hidden" name="attr_mod_punch" value="0" />
+      <span name="attr_mod_punch"></span>
+      <input type="hidden" name="attr_mod_punch_unit" />
+      <span name="attr_mod_punch_unit"></span>
+    </label>
+
+    <label
+      ><span>Power Punch</span>
+      <input type="hidden" name="attr_mod_power_punch" value="0" />
+      <span name="attr_mod_power_punch"></span>
+      <input type="hidden" name="attr_mod_power_punch_unit" />
+      <span name="attr_mod_power_punch_unit"></span>
+    </label>
+
+    <label
+      ><span>Kick</span>
+      <input type="hidden" name="attr_mod_kick" value="0" />
+      <span name="attr_mod_kick"></span>
+      <input type="hidden" name="attr_mod_kick_unit" />
+      <span name="attr_mod_kick_unit"></span>
+    </label>
+
+    <label
+      ><span>Leap Kick</span>
+      <input type="hidden" name="attr_mod_leap_kick" value="0" />
+      <span name="attr_mod_leap_kick"></span>
+      <input type="hidden" name="attr_mod_leap_kick_unit" />
+      <span name="attr_mod_leap_kick_unit"></span>
+    </label>
+
+    <label
+      ><span>Lift/Carry Weight Multiplier</span>
+      <input
+        type="hidden"
+        value="1"
+        name="attr_mod_liftcarry_weight_multiplier"
+        value="1"
+      />
+      <span name="attr_mod_liftcarry_weight_multiplier"></span>
+      <span>&#x00D7;</span>
+    </label>
+
+    <label
+      ><span>Lift/Carry Duration Multiplier</span>
+      <input
+        type="hidden"
+        value="1"
+        name="attr_mod_liftcarry_duration_multiplier"
+        value="1"
+      />
+      <span name="attr_mod_liftcarry_duration_multiplier"></span>
+      <span>&#x00D7;</span>
+    </label>
+
+    <label
+      ><span>Lift</span>
+      <input type="hidden" value="0" name="attr_mod_lift" value="0" />
+      <span name="attr_mod_lift"></span>
+      <span>lbs</span>
+    </label>
+
+    <label
+      ><span>Carry</span>
+      <input type="hidden" value="0" name="attr_mod_carry" value="0" />
+      <span name="attr_mod_carry"></span>
+      <span>lbs</span>
+    </label>
+
+    <label
+      ><span>Throw (&frac12; Carry)</span>
+      <input type="hidden" value="0" name="attr_mod_throw_distance" value="0" />
+      <span name="attr_mod_throw_distance"></span>
+      <span>Feet</span></label
+    >
+
+    <label
+      ><span>Carry Max</span>
+      <input type="hidden" value="0" name="attr_mod_carry_max" />
+      <span name="attr_mod_carry_max"></span>
+      <span>Minutes</span>
+    </label>
+
+    <label
+      ><span>Carry (Running)</span>
+      <input type="hidden" value="0" name="attr_mod_carry_running" />
+      <span name="attr_mod_carry_running"></span>
+      <span>Minutes</span></label
+    >
+
+    <label
+      ><span>Hold Max.</span>
+      <input type="hidden" value="0" name="attr_mod_hold_max" />
+      <span name="attr_mod_hold_max"></span>
+      <span>Melees</span></label
+    >
+  </div>
+
+  <div class="bonus-type-container movement">
+    <h2>Movement</h2>
+    <label><span></span><span>Imperial</span><span>Metric</span></label>
+    <label
+      ><span>Run/hour</span
+      ><input type="hidden" value="0" name="attr_run_mph" />
+      <span class="readonly-light">
+        <span name="attr_run_mph"></span>
+        <span>mph</span>
+      </span>
+      <input type="hidden" value="0" name="attr_run_kmh" />
+      <span class="readonly-light">
+        <span name="attr_run_kmh"></span>
+        <span>km/h</span>
+      </span>
+    </label>
+    <label
+      ><span>Run/melee</span
+      ><input type="hidden" value="0" name="attr_run_ft_melee" />
+      <span class="readonly-light">
+        <span name="attr_run_ft_melee"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_run_m_melee" />
+      <span class="readonly-light">
+        <span name="attr_run_m_melee"></span>
+        <span>m</span>
+      </span>
+    </label>
+    <label
+      ><span>Run/action</span
+      ><input type="hidden" value="0" name="attr_run_ft_action" />
+      <span class="readonly-light">
+        <span name="attr_run_ft_action"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_run_m_action" />
+      <span class="readonly-light">
+        <span name="attr_run_m_action"></span>
+        <span>m</span>
+      </span>
+    </label>
+    <label
+      ><span>Fly/hour</span
+      ><input type="hidden" value="0" name="attr_fly_mph" />
+      <span class="readonly-light">
+        <span name="attr_fly_mph"></span>
+        <span>mph</span>
+      </span>
+      <input type="hidden" value="0" name="attr_fly_kmh" />
+      <span class="readonly-light">
+        <span name="attr_fly_kmh"></span>
+        <span>km/h</span>
+      </span>
+    </label>
+    <label
+      ><span>Fly/melee</span
+      ><input type="hidden" value="0" name="attr_fly_ft_melee" />
+      <span class="readonly-light">
+        <span name="attr_fly_ft_melee"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_fly_m_melee" />
+      <span class="readonly-light">
+        <span name="attr_fly_m_melee"></span>
+        <span>m</span>
+      </span>
+    </label>
+    <label
+      ><span>Fly/action</span
+      ><input type="hidden" value="0" name="attr_fly_ft_action" />
+      <span class="readonly-light">
+        <span name="attr_fly_ft_action"></span>
+        <span>ft</span>
+      </span>
+      <input type="hidden" value="0" name="attr_fly_m_action" />
+      <span class="readonly-light">
+        <span name="attr_fly_m_action"></span>
+        <span>m</span>
+      </span>
+    </label>
+  </div>
+</div>
+<br />
+<label class="description"
+  ><b>Description</b>
+  <textarea class="full" name="attr_description" value=""></textarea>
+</label>
+<div class="macro-help">
+  <label
+    ><span><b>Row ID:</b></span>
+    <input type="text" readonly name="attr_rowid" value=""
+  /></label>
+</div>
+
+                            <!-- endinject -->
+                          </div>
+                        </details>
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+                <div class="picker">
+                  <div class="picker-inner">
+                    <h3 class="picker-title">Modifier Picker</h3>
+                    <fieldset class="repeating_bonusselections">
+                      <label>
+                        <input type="checkbox" name="attr_enabled" value="1" />
+                        <span name="attr_name"></span
+                      ></label>
+                      <input type="hidden" name="attr_name" value="" />
+                      <input type="hidden" name="attr_bonus_id" value="" />
+                    </fieldset>
+                    <div class="selected-ids">
+                      <b>Selected IDs</b>
+                      <input
+                        class="full"
+                        type="text"
+                        name="attr_bonus_ids_output"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <hr />
+          </div>
+          <div class="bonus-sources repeating-bonuses-outer">
+            <h3>Bonus Sources</h3>
+            <fieldset class="repeating_bonuses">
+              <input type="hidden" name="attr_selection_id" value="" />
+              <details class="info">
+                <summary>
+                  <div class="bonus-thing-heading">
+                    <b class="click-expand"
+                      ><span title="Click for more info">&nbsp;&#9432;</span></b
+                    >
+                    <label
+                      ><span>Name</span>
+                      <input type="text" list="modifiers" name="attr_name" />
+                    </label>
+                    <label
+                      ><span>Level</span>
+                      <input type="number" value="1" name="attr_level" />
+                    </label>
+                  </div>
+                </summary>
+                <div class="details-body">
+                  <!-- inject:partials/repeating_modifiers_readonly.html -->
+                  <input type="hidden" name="attr_bonus_id" value="" />
+<input type="hidden" name="global_psionic_ability" />
+<h3>Combat</h3>
+<div class="bonus-type-container">
+  <label
+    ><span>Attacks</span>
+    <input type="hidden" value="0" name="attr_attacks" />
+    <span name="attr_attacks"></span>
+  </label>
+  <label class="roller"
+    ><span>Initiative</span>
+    <input type="hidden" value="0" name="attr_initiative" />
+    <span>+</span>
+    <span name="attr_initiative"></span>
+    <button
+      type="roll"
+      value="@{opt_whisper}&{template:custom} {{title=@{character_name} rolls Initiative}} {{Initiative=[[d20+@{initiative} &{tracker}]]}}"
+      name="roll_bonus_initiative"
+    ></button>
+  </label>
+  <label class="roller"
+    ><span>Perception</span>
+    <input type="hidden" value="0" name="attr_perceptioncheck" />
+    <span>+</span>
+    <span name="attr_perceptioncheck"></span>
+    <button
+      type="roll"
+      value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
+      name="roll_bonus_perceptioncheck"
+    ></button>
+  </label>
+</div>
+<div class="modifiers-combat">
+  <div class="combat-offense-melee bonus-type-container">
+    <h3><span>&#x2694;</span> Ancient <span>&#x1F3F9;</span></h3>
+    <label
+      ><span>Strike</span>
+      <input type="hidden" value="0" name="attr_strike" />
+      <span>+</span>
+      <span name="attr_strike"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} strikes!}} {{Strike=[[d20cs>@{critical}+@{strike}]]}}"
+        name="roll_bonus_strike"
+      ></button>
+    </label>
+    <label
+      ><span>Disarm</span>
+      <input type="hidden" value="0" name="attr_disarm" />
+      <span>+</span>
+      <span name="attr_disarm"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm!}} {{Disarm=[[d20+@{disarm}]]}}"
+        name="roll_bonus_disarm"
+      ></button>
+    </label>
+    <label
+      ><span>Entangle</span>
+      <input type="hidden" value="0" name="attr_entangle" />
+      <span>+</span>
+      <span name="attr_entangle"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to entangle!}} {{Entangle=[[d20+@{entangle}]]}}"
+        name="roll_bonus_entangle"
+      ></button>
+    </label>
+    <label
+      ><span>Throw</span>
+      <input type="hidden" value="0" name="attr_throw" />
+      <span>+</span>
+      <span name="attr_throw"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws something!}} {{Throw=[[d20+@{throw}]]}}"
+        name="roll_bonus_throw"
+      ></button>
+    </label>
+    <label
+      ><span>Pull Punch vs. 11</span>
+      <input type="hidden" value="0" name="attr_pull" />
+      <span>+</span>
+      <span name="attr_pull"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to pull their punch!}} {{target=[[11]]}} {{roll=[[d20+@{pull}]]}}"
+        name="roll_bonus_pull"
+      ></button>
+    </label>
+    <label
+      ><span>Body Flip/Throw</span>
+      <input type="hidden" value="0" name="attr_flipthrow" />
+      <span>+</span>
+      <span name="attr_flipthrow"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body flip/throw!}} {{Body Flip/Throw=[[d20cs>@{critical}+@{flipthrow}]]}}"
+        name="roll_bonus_flipthrow"
+      ></button>
+    </label>
+    <label
+      ><span>Body Block/Tackle</span>
+      <input type="hidden" value="0" name="attr_tackle" />
+      <span>+</span>
+      <span name="attr_tackle"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a body block/tackle!}} {{Body Block/Tackle=[[d20cs>@{critical}+@{tackle}]]}}"
+        name="roll_bonus_tackle"
+      ></button>
+    </label>
+    <label
+      ><span>Tripping/Leg Hook</span>
+      <input type="hidden" value="0" name="attr_leghook" />
+      <span>+</span>
+      <span name="attr_leghook"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a trip/leg hook!}} {{Tripping/Leg Hook=[[d20cs>@{critical}+@{leghook}]]}}"
+        name="roll_bonus_leghook"
+      ></button>
+    </label>
+    <label
+      ><span>Backward Sweep Kick</span>
+      <input type="hidden" value="0" name="attr_backwardsweepkick" />
+      <span>+</span>
+      <span name="attr_backwardsweepkick"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts a backward sweep kick!}} {{Backward Sweep Kick=[[d20cs>@{critical}+@{backwardsweepkick}]]}}"
+        name="roll_bonus_backwardsweepkick"
+      ></button>
+    </label>
+    <hr />
+    <label
+      ><span>Critical</span>
+      <input type="hidden" value="" name="attr_critical" />
+      <span></span>
+      <span name="attr_critical"></span>
+    </label>
+    <label
+      ><span>Knockout</span>
+      <input type="hidden" value="" name="attr_knockout" />
+      <span></span>
+      <span name="attr_knockout"></span>
+    </label>
+    <label
+      ><span>Death Blow</span>
+      <input type="hidden" value="0" name="attr_deathblow" />
+      <span></span>
+      <span name="attr_deathblow"></span>
+    </label>
+    <hr />
+    <label
+      ><span>Damage</span>
+      <input type="hidden" value="0" name="attr_damage" />
+      <span></span>
+      <span name="attr_damage"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus}
+        }]]}}"
+        name="roll_bonus_damage"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Paired</span>
+      <input type="hidden" value="0" name="attr_damage_paired" />
+      <span></span>
+      <span name="attr_damage_paired"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_paired} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus} } * [[ {{ @{opt_paired_damage},0 }dl1 } * 1 + 1 ]]
+        ]]}}"
+        name="roll_bonus_damage_paired"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Main Hand</span>
+      <input type="hidden" value="0" name="attr_damage_mainhand" />
+      <span></span>
+      <span name="attr_damage_mainhand"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_mainhand} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
+        ]]}}"
+        name="roll_bonus_damage_mainhand"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Off Hand</span>
+      <input type="hidden" value="0" name="attr_damage_offhand" />
+      <span></span>
+      <span name="attr_damage_offhand"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts damage!}} {{Damage=[[@{damage_offhand} + ?{Add damage modifier?|
+          None,0|
+          Punch,@{mod_punch}|
+          P.S. Bonus,@{mod_ps_bonus} } / [[ {{ @{opt_paired_damage},0 }dl1 } * -1 + 2 ]]
+        ]]}}"
+        name="roll_bonus_damage_offhand"
+      ></button>
+    </label>
+  </div>
+  <div class="combat-offense-range bonus-type-container">
+    <h3><span>&#x1F52B;</span> Modern/Range <span>&#x1F4A3;</span></h3>
+    <label
+      ><span>Strike</span>
+      <input type="hidden" value="0" name="attr_strike_range" />
+      <span>+</span>
+      <span name="attr_strike_range"></span>
+    </label>
+    <label title="1 Action"
+      ><span>Strike: Single/Pulse</span>
+      <input type="hidden" value="0" name="attr_strike_range_single" />
+      <span>+</span>
+      <span name="attr_strike_range_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a single shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_single} ]]}}"
+        name="roll_bonus_strike_range_single"
+      ></button>
+    </label>
+    <label title="1 Action"
+      ><span>Strike: Burst</span>
+      <input type="hidden" value="0" name="attr_strike_range_burst" />
+      <span>+</span>
+      <span name="attr_strike_range_burst"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a burst shot!}} {{Range Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_burst} ]]}}"
+        name="roll_bonus_strike_range_burst"
+      ></button>
+    </label>
+    <label
+      ><span>Strike: Aimed</span>
+      <input type="hidden" value="0" name="attr_strike_range_aimed" />
+      <span>+</span>
+      <span name="attr_strike_range_aimed"></span>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Aimed Single</span>
+      <input type="hidden" value="0" name="attr_strike_range_aimed_single" />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed single shot!}} {{Range Aimed Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_single} ]]}}"
+        name="roll_bonus_strike_range_aimed_single"
+      ></button>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Aimed Pulse</span>
+      <input type="hidden" value="0" name="attr_strike_range_aimed_pulse" />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_pulse"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed pulse shot!}} {{Range Aimed Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_pulse} ]]}}"
+        name="roll_bonus_strike_range_aimed_pulse"
+      ></button>
+    </label>
+    <label
+      ><span>Strike: Called</span>
+      <input type="hidden" value="0" name="attr_strike_range_called" />
+      <span>+</span>
+      <span name="attr_strike_range_called"></span>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Called Single</span>
+      <input type="hidden" value="0" name="attr_strike_range_called_single" />
+      <span>+</span>
+      <span name="attr_strike_range_called_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called single shot!}} {{Range Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_single} ]]}}"
+        name="roll_bonus_strike_range_called_single"
+      ></button>
+    </label>
+    <label title="2 Actions"
+      ><span>Strike: Called Pulse</span>
+      <input type="hidden" value="0" name="attr_strike_range_called_pulse" />
+      <span>+</span>
+      <span name="attr_strike_range_called_pulse"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with a called pulse shot!}} {{Range Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_called_pulse} ]]}}"
+        name="roll_bonus_strike_range_called_pulse"
+      ></button>
+    </label>
+    <label title="3 Actions"
+      ><span>Strike: Aimed Called Single</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_strike_range_aimed_called_single"
+      />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_called_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called single shot!}} {{Range Aimed Called Single Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_single} ]]}}"
+        name="roll_bonus_strike_range_aimed_called_single"
+      ></button>
+    </label>
+    <label title="3 Actions"
+      ><span>Strike: Aimed Called Pulse</span>
+      <input
+        type="hidden"
+        value="0"
+        name="attr_strike_range_aimed_called_pulse"
+      />
+      <span>+</span>
+      <span name="attr_strike_range_aimed_called_pulse"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} shoots with an aimed called pulse shot!}} {{Range Aimed Called Pulse Strike=[[ d20cs>[[ {{ @{opt_critical},0 }dl1 } * (@{critical}-20) + 20]] + @{strike_range_aimed_called_pulse} ]]}}"
+        name="roll_bonus_strike_range_aimed_called_pulse"
+      ></button>
+    </label>
+    <hr />
+    <label
+      title="Using a gun to shoot a weapon out of an opponent's hand requires a called shot and careful aim (only the gunslinger can shoot to disarm on a quick draw)"
+      ><span>Disarm</span>
+      <input type="hidden" value="0" name="attr_disarm_range" />
+      <span>+</span>
+      <span name="attr_disarm_range"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to disarm at range!}} {{Range Disarm=[[d20+@{disarm_range} + ?{Type of shot?|
+          No additional bonus,0|
+          Called Single (2 Actions),@{strike_range_called_single}|
+          Called Pulse (2 Actions),@{strike_range_called_pulse}|
+          Aimed Called Single (3 Actions),@{strike_range_aimed_called_single}|
+          Aimed Called Pulse (3 Actions),@{strike_range_aimed_called_pulse}|
+          Quick Draw Single (1 Action),@{strike_range_single}|
+          Quick Draw Pulse (1 Action),@{strike_range_burst}
+        }]]}}"
+        name="roll_bonus_disarm_range"
+      ></button>
+    </label>
+    <hr />
+    <label
+      ><span>Damage</span>
+      <input type="hidden" value="0" name="attr_damage_range" />
+      <span></span>
+      <span name="attr_damage_range"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage!}} {{Range Damage=[[@{damage_range}]]}}"
+        name="roll_bonus_damage_range"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Single</span>
+      <input type="hidden" value="0" name="attr_damage_range_single" />
+      <span></span>
+      <span name="attr_damage_range_single"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a single shot!}} {{Range Damage=[[@{damage_range_single}]]}}"
+        name="roll_bonus_damage_range_single"
+      ></button>
+    </label>
+    <label
+      ><span>Damage: Pulse/Burst</span>
+      <input type="hidden" value="0" name="attr_damage_range_burst" />
+      <span></span>
+      <span name="attr_damage_range_burst"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} inflicts range damage from a burst!}} {{Range Damage=[[@{damage_range_burst}]]}}"
+        name="roll_bonus_damage_range_burst"
+      ></button>
+    </label>
+  </div>
+  <div class="combat-defense bonus-type-container">
+    <h3><span>&#x1F6E1;</span> Defense <span>&#x1F977;</span></h3>
+    <label
+      ><span>Parry</span>
+      <input type="hidden" value="0" name="attr_parry" />
+      <span>+</span>
+      <span name="attr_parry"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to parry!}} {{Parry=[[d20+@{parry}]]}}"
+        name="roll_bonus_parry"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge</span>
+      <input type="hidden" value="0" name="attr_dodge" />
+      <span>+</span>
+      <span name="attr_dodge"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge!}} {{ Dodge=[[ d20+@{dodge} - @{opt_dodge_penalty} ]] }}"
+        name="roll_bonus_dodge"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Flight</span>
+      <input type="hidden" value="0" name="attr_dodge_flight" />
+      <span>+</span>
+      <span name="attr_dodge_flight"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge in flight!}} {{Dodge in Flight=[[d20+@{dodge_flight} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_flight"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Auto</span>
+      <input type="hidden" value="0" name="attr_dodge_auto" />
+      <span>+</span>
+      <span name="attr_dodge_auto"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to auto dodge!}} {{Auto Dodge=[[d20+@{dodge_auto} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_auto"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Teleport</span>
+      <input type="hidden" value="0" name="attr_dodge_teleport" />
+      <span>+</span>
+      <span name="attr_dodge_teleport"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to teleport dodge!}} {{Teleport Dodge=[[d20+@{dodge_teleport} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_teleport"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Motion</span>
+      <input type="hidden" value="0" name="attr_dodge_motion" />
+      <span>+</span>
+      <span name="attr_dodge_motion"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge while in motion!}} {{Dodge in Motion=[[d20+@{dodge_motion} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_motion"
+      ></button>
+    </label>
+    <label
+      ><span>Dodge: Underwater</span>
+      <input type="hidden" value="0" name="attr_dodge_underwater" />
+      <span>+</span>
+      <span name="attr_dodge_underwater"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to dodge underwater!}} {{Dodge Underwater=[[d20+@{dodge_underwater} - @{opt_dodge_penalty} ]]}}"
+        name="roll_bonus_dodge_underwater"
+      ></button>
+    </label>
+    <label
+      ><span>Roll w/ Impact</span>
+      <input type="hidden" value="0" name="attr_roll" />
+      <span>+</span>
+      <span name="attr_roll"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to roll with impact!}} {{Roll w/ Impact=[[d20+@{roll}]]}}"
+        name="roll_bonus_roll"
+      ></button>
+    </label>
+    <label
+      ><span>Break Fall</span>
+      <input type="hidden" value="0" name="attr_breakfall" />
+      <span>+</span>
+      <span name="attr_breakfall"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} attempts to break fall!}} {{Break Fall=[[d20+@{breakfall}]]}}"
+        name="roll_bonus_breakfall"
+      ></button>
+    </label>
+  </div>
+  <div class="bonus-type-container">
+    <h3><span>&#x1F340;</span> Saving Throws <span>&#x1FAA6;</span></h3>
+    <label
+      ><span>Coma/Death</span>
+      <input type="hidden" value="0" name="attr_comadeath" />
+      <span>+</span>
+      <span name="attr_comadeath"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries not to die!}} {{target=[[50+@{comadeath}]]}} {{roll=[[d100]]}}"
+        name="roll_bonus_comadeath"
+      ></button>
+    </label>
+    <label
+      ><span>Curses vs. 15</span>
+      <input type="hidden" value="0" name="attr_curses" />
+      <span>+</span>
+      <span name="attr_curses"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against being cursed!}} {{target=[[15]]}} {{roll=[[d20+@{curses}+?{Add modifier?|
+            None,0|
+            Magic,@{magic}|
+            Psionics,@{psionics}
+          }]]}}"
+        name="roll_bonus_curses"
+      ></button>
+    </label>
+    <label
+      ><span>Despair</span>
+      <input type="hidden" value="0" name="attr_despair" />
+      <span>+</span>
+      <span name="attr_despair"></span>
+      <button
+        type="roll"
+        value="?{Type of Despair|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. magic despair!&amp;#125;&amp;#125; {{Save vs. Magic Despair=[[d20+@{despair}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to save vs. psionic despair!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{despair}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to save vs. despair!&amp;#125;&amp;#125; {{Save vs. Despair=[[d20+@{despair}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_despair"
+      ></button>
+    </label>
+    <label
+      ><span>Disease</span>
+      <input type="hidden" value="0" name="attr_disease" />
+      <span>+</span>
+      <span name="attr_disease"></span>
+      <button
+        type="roll"
+        value="?{Type of Disease|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Magic Disease=[[d20+@{disease}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{disease}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} tries to fight off a disease!&amp;#125;&amp;#125; {{Save vs. Disease=[[d20+@{disease}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_disease"
+      ></button>
+    </label>
+    <label
+      ><span>Drugs vs. 15</span>
+      <input type="hidden" value="0" name="attr_drugs" />
+      <span>+</span>
+      <span name="attr_drugs"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against harmful drugs!}} {{target=[[15]]}} {{roll=[[d20+@{drugs}]]}}"
+        name="roll_bonus_drugs"
+      ></button>
+    </label>
+    <label
+      ><span>Fatigue</span>
+      <input type="hidden" value="0" name="attr_fatigue" />
+      <span>+</span>
+      <span name="attr_fatigue"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to push through the fatigue!}} {{Fatigue=[[d20+@{fatigue}]]}}"
+        name="roll_bonus_fatigue"
+      ></button>
+    </label>
+    <label
+      ><span>Horror Factor</span>
+      <input type="hidden" value="0" name="attr_horrorfactor" />
+      <span>+</span>
+      <span name="attr_horrorfactor"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against horror factor!}} {{Save vs. Horror Factor=[[d20+@{horrorfactor}]]}}"
+        name="roll_bonus_horrorfactor"
+      ></button>
+    </label>
+    <label
+      ><span>Illusions</span>
+      <input type="hidden" value="0" name="attr_illusions" />
+      <span>+</span>
+      <span name="attr_illusions"></span>
+      <button
+        type="roll"
+        value="?{Type of Illusion|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the magic illusion!&amp;#125;&amp;#125; {{Save vs. Magic Illusions=[[d20+@{illusions}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to see through the psionic illusion!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{illusions}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to see through the illusion!&amp;#125;&amp;#125; {{Save vs. Illusions=[[d20+@{illusions}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_illusions"
+      ></button>
+    </label>
+    <label
+      ><span>Insanity</span>
+      <input type="hidden" value="0" name="attr_insanity" />
+      <span>+</span>
+      <span name="attr_insanity"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:goe} {{title=@{character_name} tries to save against insanity!}} {{target=[[12]]}} {{roll=[[d20+@{insanity}]]}}"
+        name="roll_bonus_insanity"
+      ></button>
+    </label>
+    <label
+      ><span>Magic</span>
+      <input type="hidden" value="0" name="attr_magic" />
+      <span>+</span>
+      <span name="attr_magic"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to save against magic attack!}} {{Save vs. Magic=[[d20+@{magic}]]}}"
+        name="roll_bonus_magic"
+      ></button>
+    </label>
+    <label
+      ><span>Maintain Balance</span>
+      <input type="hidden" value="0" name="attr_maintainbalance" />
+      <span>+</span>
+      <span name="attr_maintainbalance"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} tries to stay standing!}} {{Maintain Balance=[[d20+@{maintainbalance}]]}}"
+        name="roll_bonus_maintainbalance"
+      ></button>
+    </label>
+    <label
+      ><span>Mind Control</span>
+      <input type="hidden" value="0" name="attr_mindcontrol" />
+      <span>+</span>
+      <span name="attr_mindcontrol"></span>
+      <button
+        type="roll"
+        value="?{Type of Mind Control Attack|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off magic mind control!&amp;#125;&amp;#125; {{Save vs. Magic Mind Control=[[d20+@{mindcontrol}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to fight off psionic mind control!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{mindcontrol}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to fight off mind control!&amp;#125;&amp;#125; {{Save vs. Mind Control=[[d20+@{mindcontrol}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_mindcontrol"
+      ></button>
+    </label>
+    <label
+      ><span>Pain</span>
+      <input type="hidden" value="0" name="attr_pain" />
+      <span>+</span>
+      <span name="attr_pain"></span>
+      <button
+        type="roll"
+        value="?{Type of Pain Attack|
+          Magic,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the magic pain!&amp;#125;&amp;#125; {{Save vs. Magic Pain=[[d20+@{pain}+@{magic}]]&amp;#125;&amp;#125;|
+          Psionic,
+            @{opt_whisper}&{template:goe&amp;#125; {{title=@{character_name} attempts to push through the psionic pain!&amp;#125;&amp;#125; {{target=[[@{psionic_ability}]]&amp;#125;&amp;#125; {{roll=[[d20+@{pain}+@{psionics}]]&amp;#125;&amp;#125;|
+          Other,
+            @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the pain!&amp;#125;&amp;#125; {{Save vs. Pain=[[d20+@{pain}]]&amp;#125;&amp;#125;
+        }"
+        name="roll_bonus_pain"
       ></button>
     </label>
     <label
@@ -14323,7 +14338,3 @@ on("clicked:migrate", async (e) => {
 </rolltemplate>
 
 <!-- endinject -->
-
-
-
-

--- a/Palladium Rifts by Grinning Gecko/src/js/ammo.js
+++ b/Palladium Rifts by Grinning Gecko/src/js/ammo.js
@@ -1,0 +1,79 @@
+async function deductRoundsFromNextActiveAmmo(section, rounds) {
+  console.log("deductRoundsFromNextActiveAmmo", section, rounds);
+  const ids = await getSectionIDsOrderedAsync(section);
+  const attrKeys = ids
+    .flatMap((id) => [
+      `repeating_${section}_${id}_is_active`,
+      `repeating_${section}_${id}_clip`,
+      `repeating_${section}_${id}_name`,
+    ]);
+  const attrs = {};
+  const a = await getAttrsAsync(attrKeys);
+  
+  let ammoCarry = rounds;
+  let currentRounds = false;
+
+  const activeIds = ids.reduce((acc, cur) => {
+    if (Boolean(Number(a[`repeating_${section}_${cur}_is_active`]))) {
+      acc.push(cur);
+    }
+    return acc;
+  }, []);
+
+  console.log("deductRoundsFromNextActiveAmmo", a, activeIds);
+
+  let i = 0;
+  let activeRowId;
+  for (activeRowId of activeIds) {
+    currentRounds = Number(a[`repeating_${section}_${activeRowId}_clip`]) - ammoCarry;
+    console.log("deductRoundsFromNextActiveAmmo currentRounds", currentRounds, ammoCarry);
+    if (currentRounds < 0 && ++i < activeIds.length) {
+      console.log(
+        "deductRoundsFromNextActiveAmmo",
+        "BELOW ZERO on " + activeRowId
+      );
+      attrs[`repeating_${section}_${activeRowId}_clip`] = 0;
+      ammoCarry = Math.abs(currentRounds);
+    } else {
+      attrs[`repeating_${section}_${activeRowId}_clip`] = currentRounds;
+      break;
+    }
+  }
+  await setAttrsAsync(attrs);
+  // await updateActiveArmor(activeRowId);
+  return {
+    currentRounds,
+    ammo_name: a[`repeating_${section}_${activeRowId}_name`],
+  };
+}
+
+on("clicked:ammodeductrounds", async (e) => {
+  console.log("clicked:ammodeductrounds", e);
+  const a = await getAttrsAsync([
+    `ammorounds`,
+    `character_name`,
+    `outputusage`,
+  ]);
+  const { currentRounds, ammo_name } = await deductRoundsFromNextActiveAmmo(
+    "ammo",
+    +a[`ammorounds`]
+  );
+  const outputUsage = Boolean(Number(a.outputusage));
+  if (outputUsage) {
+    // const b = await getAttrsAsync([`active_armor_mdc`, `active_armor_name`]);
+    const chat = await startRoll(
+      `@{opt_whisper}&{template:ammo} {{character_name=${a["character_name"]}}} {{spent=${a["ammorounds"]}}} {{name=${ammo_name}}} {{remaining=${currentRounds}}}`
+    );
+    finishRoll(chat.rollId);
+  }
+});
+
+on("clicked:repeating_ammo:resetclip", async (e) => {
+  console.log("clicked:repeating_ammo:resetclip", e);
+  const [r, section, rowId] = e.sourceAttribute.split("_");
+  const a = await getAttrsAsync([`repeating_ammo_${rowId}_roundsperclip`]);
+  await setAttrsAsync({
+    [`repeating_ammo_${rowId}_clip`]: a[`repeating_ammo_${rowId}_roundsperclip`],
+  });
+  // await updateActiveArmor(rowId);
+});

--- a/Palladium Rifts by Grinning Gecko/src/js/armor.js
+++ b/Palladium Rifts by Grinning Gecko/src/js/armor.js
@@ -5,6 +5,7 @@ async function applyDamageToNextActiveArmor(section, damage) {
     .flatMap((id) => [
       `repeating_${section}_${id}_is_active`,
       `repeating_${section}_${id}_mdc`,
+      `repeating_${section}_${id}_name`,
     ])
     .concat(["outputarmorwarnings"]);
   const attrs = {};
@@ -47,7 +48,10 @@ async function applyDamageToNextActiveArmor(section, damage) {
   }
   await setAttrsAsync(attrs);
   await updateActiveArmor(activeRowId);
-  return currentMdc;
+  return {
+    currentMdc,
+    armor_name: a[`repeating_${section}_${activeRowId}_name`],
+  };
 }
 
 /**
@@ -89,7 +93,7 @@ on("clicked:armorapplydamage", async (e) => {
     `active_armor_name`,
     `outputusage`,
   ]);
-  const currentMdc = await applyDamageToNextActiveArmor(
+  const { currentMdc, armor_name } = await applyDamageToNextActiveArmor(
     "armor",
     +a[`armordamage`]
   );
@@ -97,11 +101,7 @@ on("clicked:armorapplydamage", async (e) => {
   if (outputUsage) {
     // const b = await getAttrsAsync([`active_armor_mdc`, `active_armor_name`]);
     const chat = await startRoll(
-      `@{opt_whisper}&{template:damage} {{character_name=${
-        a["character_name"]
-      }}} {{spent=${a["armordamage"]}}} {{name=${
-        a[`active_armor_name`]
-      }}} {{remaining=${currentMdc}}}`
+      `@{opt_whisper}&{template:damage} {{character_name=${a["character_name"]}}} {{spent=${a["armordamage"]}}} {{name=${armor_name}}} {{remaining=${currentMdc}}}`
     );
     finishRoll(chat.rollId);
   }

--- a/Palladium Rifts by Grinning Gecko/src/js/attributes.js
+++ b/Palladium Rifts by Grinning Gecko/src/js/attributes.js
@@ -245,51 +245,51 @@ async function psBonusComplete(prefix = "") {
       }
       if (ps <= 15) {
         restrained_punch = "1D6";
-        punch = "4D6";
-        power_punch = "1D4";
-        power_punch_unit = "mdc";
+        punch = kick = "4D6";
+        power_punch = leap_kick = "1D4";
+        power_punch_unit = leap_kick_unit = "mdc";
       } else if (ps <= 20) {
         restrained_punch = "3D6";
-        punch = "1D6";
-        power_punch = "2D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "1D6";
+        power_punch = leap_kick = "2D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 25) {
         restrained_punch = "4D6";
-        punch = "2D6";
-        power_punch = "4D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "2D6";
+        power_punch = leap_kick = "4D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 30) {
         restrained_punch = "5D6";
-        punch = "3D6";
-        power_punch = "6D6";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "3D6";
+        power_punch = leap_kick = "6D6";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 35) {
         restrained_punch = "5D6";
-        punch = "4D6";
-        power_punch = "1D4*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "4D6";
+        power_punch = leap_kick = "1D4*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 40) {
         restrained_punch = "6D6";
-        punch = "5D6";
-        power_punch = "1D6*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "5D6";
+        power_punch = leap_kick = "1D6*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 50) {
         restrained_punch = "1D6*10";
-        punch = "6D6";
-        power_punch = "2D4*10";
-        punch_unit = power_punch_unit = "mdc";
+        punch = kick = "6D6";
+        power_punch = leap_kick = "2D4*10";
+        punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else if (ps <= 60) {
         restrained_punch = "1D6";
-        punch = "1D6*10";
-        power_punch = "2D6*10";
-        restrained_punch_unit = punch_unit = power_punch_unit = "mdc";
+        punch = kick = "1D6*10";
+        power_punch = leap_kick = "2D6*10";
+        restrained_punch_unit = punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       } else {
         // > 60
         const extra = Math.ceil((ps - 60) / 10) * 10;
         restrained_punch = "1D6";
-        punch = `1D6*10+${extra}`;
-        power_punch = `2D6*10+${extra * 2}`;
-        restrained_punch_unit = punch_unit = power_punch_unit = "mdc";
+        punch = kick = `1D6*10+${extra}`;
+        power_punch = leap_kick = `2D6*10+${extra * 2}`;
+        restrained_punch_unit = punch_unit = power_punch_unit = kick_unit = leap_kick_unit = "mdc";
       }
       break;
   }

--- a/Palladium Rifts by Grinning Gecko/src/js/migrate.js
+++ b/Palladium Rifts by Grinning Gecko/src/js/migrate.js
@@ -166,6 +166,12 @@ async function migrateAttributes() {
       version: "1.5.0",
       function: migrateAddRowIds,
     },
+    {
+      version: "1.6.0",
+    },
+    {
+      version: "1.6.1",
+    },
   ];
 
   const { version, migrated } = await getAttrsAsync(["version", "migrated"]);

--- a/Palladium Rifts by Grinning Gecko/src/partials/active.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/active.html
@@ -1229,7 +1229,7 @@
             <span name="attr_active_profile_mod_trust"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{active_profile_mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{active_profile_mod_trust}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_trust"
             ></button>
           </label>
@@ -1243,7 +1243,7 @@
             <span name="attr_active_profile_mod_intimidate"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{active_profile_mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{active_profile_mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_intimidate"
             ></button>
           </label>
@@ -1257,7 +1257,7 @@
             <span name="attr_active_profile_mod_charmimpress"></span>
             <button
               type="roll"
-              value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{active_profile_mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+              value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{active_profile_mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
               name="roll_active_profile_charmimpress"
             ></button>
           </label>

--- a/Palladium Rifts by Grinning Gecko/src/partials/active.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/active.html
@@ -65,6 +65,21 @@
             TT
           </button>
         </label>
+        <label class="roller"
+          ><span>Perception</span>
+          <input
+            type="hidden"
+            value="0"
+            name="attr_active_profile_perceptioncheck"
+          />
+          <span>+</span>
+          <span name="attr_active_profile_perceptioncheck"></span>
+          <button
+            type="roll"
+            value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{active_profile_perceptioncheck}]]}}"
+            name="roll_active_profile_bonus_perceptioncheck"
+          ></button>
+        </label>
       </div>
       <div class="modifiers-combat">
         <div class="combat-offense-melee bonus-type-container">

--- a/Palladium Rifts by Grinning Gecko/src/partials/active.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/active.html
@@ -1300,6 +1300,11 @@
               name="attr_active_profile_mod_restrained_punch_unit"
             />
             <span name="attr_active_profile_mod_restrained_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{active_profile_mod_restrained_punch}]]}}"
+              name="roll_active_profile_damage_restrained_punch"
+            ></button>
           </label>
 
           <label
@@ -1312,6 +1317,11 @@
             <span name="attr_active_profile_mod_punch"></span>
             <input type="hidden" name="attr_active_profile_mod_punch_unit" />
             <span name="attr_active_profile_mod_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{active_profile_mod_punch}]]}}"
+              name="roll_active_profile_damage_punch"
+            ></button>
           </label>
 
           <label
@@ -1327,6 +1337,11 @@
               name="attr_active_profile_mod_power_punch_unit"
             />
             <span name="attr_active_profile_mod_power_punch_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{active_profile_mod_power_punch}]]}}"
+              name="roll_active_profile_damage_power_punch"
+            ></button>
           </label>
 
           <label
@@ -1339,6 +1354,11 @@
             <span name="attr_active_profile_mod_kick"></span>
             <input type="hidden" name="attr_active_profile_mod_kick_unit" />
             <span name="attr_active_profile_mod_kick_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{active_profile_mod_kick}]]}}"
+              name="roll_active_profile_damage_kick"
+            ></button>
           </label>
 
           <label
@@ -1354,6 +1374,11 @@
               name="attr_active_profile_mod_leap_kick_unit"
             />
             <span name="attr_active_profile_mod_leap_kick_unit"></span>
+            <button
+              type="roll"
+              value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{active_profile_mod_leap_kick}]]}}"
+              name="roll_active_profile_damage_leap_kick"
+            ></button>
           </label>
 
           <label

--- a/Palladium Rifts by Grinning Gecko/src/partials/ammo.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/ammo.html
@@ -1,0 +1,14 @@
+<label
+  ><input type="checkbox" class="is-active" name="attr_is_active" value="1"
+/></label>
+<input type="text" placeholder="Weapon Name" name="attr_name" />
+<input type="number" placeholder="Clips" name="attr_fullclips" />
+<input type="number" placeholder="Rounds per Clip" name="attr_roundsperclip" value="0" />
+<input
+  type="number"
+  class="danger"
+  placeholder="Current Clip"
+  name="attr_clip"
+  value="0"
+/>
+<button type="action" name="act_resetclip">Reset Clip</button>

--- a/Palladium Rifts by Grinning Gecko/src/partials/magic-summary.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/magic-summary.html
@@ -25,7 +25,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_spell_skill"
     ></button>
     <input type="number" value="0" name="attr_ppecost" />

--- a/Palladium Rifts by Grinning Gecko/src/partials/powersabilities-summary.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/powersabilities-summary.html
@@ -26,7 +26,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_powerability_skill"
     ></button>
   </div>

--- a/Palladium Rifts by Grinning Gecko/src/partials/psionics-summary.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/psionics-summary.html
@@ -24,7 +24,7 @@
     <span name="attr_percentage"></span>
     <button
       type="roll"
-      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+      value="@{opt_whisper}&{template:skill} [[ [[{@{percentage} + [[ {{ @{opt_iq_bonus},0 }dl1 } * @{active_profile_mod_iq_bonus} ]] +(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[1]]}} {{roll=$[[2]]}} {{total=$[[3]]}} {{add_skill=[[@{opt_add_skill}]]}}"
       name="roll_psionic_skill"
     ></button>
     <input type="number" value="0" name="attr_ispcost" />

--- a/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers.html
@@ -400,6 +400,10 @@
     ><span>Initiative</span>
     <input type="number" value="0" name="attr_initiative" />
   </label>
+  <label
+    ><span>Perception</span>
+    <input type="number" value="0" name="attr_perceptioncheck" />
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -640,10 +644,6 @@
     <label
       ><span>Pain</span>
       <input type="number" value="0" name="attr_pain" />
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="number" value="0" name="attr_perceptioncheck" />
     </label>
     <label
       ><span>Poison: Lethal</span>

--- a/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers_readonly.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers_readonly.html
@@ -18,6 +18,17 @@
       name="roll_bonus_initiative"
     ></button>
   </label>
+  <label class="roller"
+    ><span>Perception</span>
+    <input type="hidden" value="0" name="attr_perceptioncheck" />
+    <span>+</span>
+    <span name="attr_perceptioncheck"></span>
+    <button
+      type="roll"
+      value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
+      name="roll_bonus_perceptioncheck"
+    ></button>
+  </label>
 </div>
 <div class="modifiers-combat">
   <div class="combat-offense-melee bonus-type-container">
@@ -658,17 +669,6 @@
             @{opt_whisper}&{template:custom&amp;#125; {{title=@{character_name} attempts to push through the pain!&amp;#125;&amp;#125; {{Save vs. Pain=[[d20+@{pain}]]&amp;#125;&amp;#125;
         }"
         name="roll_bonus_pain"
-      ></button>
-    </label>
-    <label
-      ><span>Perception</span>
-      <input type="hidden" value="0" name="attr_perceptioncheck" />
-      <span>+</span>
-      <span name="attr_perceptioncheck"></span>
-      <button
-        type="roll"
-        value="@{opt_whisper}&{template:custom} {{title=@{character_name} looks around carefully &#x1F440;}} {{Perception Check=[[d20+@{perceptioncheck}]]}}"
-        name="roll_bonus_perceptioncheck"
       ></button>
     </label>
     <label

--- a/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers_readonly.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers_readonly.html
@@ -947,7 +947,7 @@
       <span name="attr_mod_trust"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to gain someone's trust}} {{target=[[{@{mod_trust}+?({Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_trust"
       ></button>
     </label>
@@ -957,7 +957,7 @@
       <span name="attr_mod_intimidate"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} tries to intimidate someone}} {{target=[[{@{mod_intimidate}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_intimidate"
       ></button>
     </label>
@@ -967,7 +967,7 @@
       <span name="attr_mod_charmimpress"></span>
       <button
         type="roll"
-        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+?{Modifier?|0},98}kl1]]}} {{roll=[[d100]]}}"
+        value="@{opt_whisper}&{template:skill} {{title=@{character_name} uses Charm/Impress}} {{target=[[{@{mod_charmimpress}+(?{Modifier?|0}),98}kl1]]}} {{roll=[[d100]]}}"
         name="roll_charmimpress"
       ></button>
     </label>

--- a/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers_readonly.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/repeating_modifiers_readonly.html
@@ -990,6 +990,11 @@
       <span name="attr_mod_restrained_punch"></span>
       <input type="hidden" name="attr_mod_restrained_punch_unit" />
       <span name="attr_mod_restrained_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Restrained Punch}} {{Punch Damage=[[@{mod_restrained_punch}]]}}"
+        name="roll_damage_restrained_punch"
+      ></button>
     </label>
 
     <label
@@ -998,6 +1003,11 @@
       <span name="attr_mod_punch"></span>
       <input type="hidden" name="attr_mod_punch_unit" />
       <span name="attr_mod_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Punch}} {{Punch Damage=[[@{mod_punch}]]}}"
+        name="roll_damage_punch"
+      ></button>
     </label>
 
     <label
@@ -1006,6 +1016,11 @@
       <span name="attr_mod_power_punch"></span>
       <input type="hidden" name="attr_mod_power_punch_unit" />
       <span name="attr_mod_power_punch_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} throws a Power Punch}} {{Punch Damage=[[@{mod_power_punch}]]}}"
+        name="roll_damage_power_punch"
+      ></button>
     </label>
 
     <label
@@ -1014,6 +1029,11 @@
       <span name="attr_mod_kick"></span>
       <input type="hidden" name="attr_mod_kick_unit" />
       <span name="attr_mod_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Kick}} {{Kick Damage=[[@{mod_kick}]]}}"
+        name="roll_damage_kick"
+      ></button>
     </label>
 
     <label
@@ -1022,6 +1042,11 @@
       <span name="attr_mod_leap_kick"></span>
       <input type="hidden" name="attr_mod_leap_kick_unit" />
       <span name="attr_mod_leap_kick_unit"></span>
+      <button
+        type="roll"
+        value="@{opt_whisper}&{template:custom} {{title=@{character_name} delivers a Leap Kick}} {{Kick Damage=[[@{mod_leap_kick}]]}}"
+        name="roll_damage_leap_kick"
+      ></button>
     </label>
 
     <label

--- a/Palladium Rifts by Grinning Gecko/src/partials/roll-templates.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/roll-templates.html
@@ -168,6 +168,15 @@
   </div>
 </rolltemplate>
 
+<rolltemplate class="sheet-rolltemplate-ammo">
+  <div class="sheet-container sheet-color-{{color}}">
+    <span class="character_name">{{character_name}}</span> fired
+    <span class="spent">{{spent}}</span> rounds, leaving their
+    <span class="name">{{name}}</span> with
+    <span class="remaining">{{remaining}}</span> remaining rounds!
+  </div>
+</rolltemplate>
+
 <rolltemplate class="sheet-rolltemplate-castspell">
   <div class="sheet-container sheet-color-{{color}}">
     <span class="character_name">{{character_name}}</span> casts

--- a/Palladium Rifts by Grinning Gecko/src/partials/skills.html
+++ b/Palladium Rifts by Grinning Gecko/src/partials/skills.html
@@ -39,7 +39,7 @@
           <span class="readonly" name="attr_total"></span>
           <button
             type="roll"
-            value="@{opt_whisper}&{template:skill} [[ [[{@{total}+?{Modifier?|0},98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[0]]}} {{roll=$[[1]]}} {{total=$[[2]]}} {{add_skill=[[@{opt_add_skill}]]}}"
+            value="@{opt_whisper}&{template:skill} [[ [[{@{total}+(?{Modifier?|0}),98}kl1]] + [[1d100]] ]] {{title=@{character_name} uses @{name}}} {{target=$[[0]]}} {{roll=$[[1]]}} {{total=$[[2]]}} {{add_skill=[[@{opt_add_skill}]]}}"
             name="roll_skill"
           ></button>
         </div>

--- a/Palladium Rifts by Grinning Gecko/src/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/src/rifts.html
@@ -490,6 +490,36 @@
                 </fieldset>
               </div>
               <hr />
+              <div class="armor">
+                <h3>Ammo</h3>
+                <div class="armor-damage">
+                  <label
+                    >Rounds
+                    <input
+                      type="number"
+                      placeholder="Rounds"
+                      name="attr_ammorounds"
+                    />
+                  </label>
+                  <button type="action" name="act_ammodeductrounds">
+                    Deduct Rounds
+                  </button>
+                </div>
+                <div class="armor-labels heading">
+                  <label>Active</label>
+                  <label>Weapon</label>
+                  <label>Full Clips</label>
+                  <label>Rounds per Clip</label>
+                  <label>Current Clip</label>
+                </div>
+                <fieldset class="repeating_ammo">
+                  <div class="repeating_ammo-inner">
+                    <!-- inject:partials/ammo.html -->
+                    <!-- endinject -->
+                  </div>
+                </fieldset>
+              </div>
+              <hr />
               <div class="profile-builder">
                 <div class="profiles repeating-bonuses-outer">
                   <div class="profiles-inner">

--- a/Palladium Rifts by Grinning Gecko/src/rifts.html
+++ b/Palladium Rifts by Grinning Gecko/src/rifts.html
@@ -701,6 +701,9 @@
   /* inject:js/armor.js */
   /* endinject */
 
+  /* inject:js/ammo.js */
+  /* endinject */
+
   /* inject:js/profiles.js */
   /* endinject */
 

--- a/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
+++ b/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
@@ -700,7 +700,8 @@ a {
         grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
       }
 
-      .repeating_armor-inner, .repeating_ammo-inner {
+      .repeating_armor-inner,
+      .repeating_ammo-inner {
         display: grid;
         gap: 0.5rem;
         grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
@@ -1211,6 +1212,19 @@ body.sheet-darkmode {
         }
       }
 
+      .repitem:nth-child(odd):not(.picker *) {
+        // background-color: #222;
+        opacity: 0.7;
+
+        &:has(details.info[open]) {
+          opacity: 1;
+        }
+      }
+
+      .repitem:nth-child(even):not(.picker *) {
+        background-color: #222;
+      }
+
       .ss-2c {
         border-color: #444;
       }
@@ -1241,7 +1255,7 @@ body.sheet-darkmode {
         }
 
         > div {
-            span[name^="attr_"] {
+          span[name^="attr_"] {
             background-color: #444;
             border-color: #555;
           }

--- a/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
+++ b/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
@@ -502,13 +502,14 @@ a {
     .bonus-ps-container {
       display: grid;
       gap: 0.5rem;
-      grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 
       label {
         display: grid;
         align-items: center;
         gap: 0.5rem;
-        grid-template-columns: 6.5rem 6rem 1fr;
+        grid-template-columns: 6.5rem minmax(4rem, 1fr) 4rem 4rem;
+        // grid-template-columns: auto auto auto auto;
 
         &.select {
           select {
@@ -520,7 +521,15 @@ a {
           width: 6rem;
         }
 
-        span {
+        > span {
+          @include center;
+
+          &[name^="attr_"] {
+            @include readonly;
+          }
+        }
+
+        > label span {
           @include center;
 
           &[name^="attr_"] {
@@ -533,7 +542,7 @@ a {
     .bonus-type-container {
       display: grid;
       gap: 1rem;
-      grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
       // grid-template-columns: 1fr 1fr 1fr 1fr;
 
       &.attributes {
@@ -751,14 +760,14 @@ a {
         }
 
         .bonus-ps-container {
-          grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+          grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
         }
 
         .bonus-type-container {
           grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 
           &.attributes {
-            grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
             > label {
               display: grid;
               gap: 0.5rem;
@@ -1229,6 +1238,13 @@ body.sheet-darkmode {
         hr {
           border-color: #444;
           background-color: #444;
+        }
+
+        > div {
+            span[name^="attr_"] {
+            background-color: #444;
+            border-color: #555;
+          }
         }
 
         label {

--- a/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
+++ b/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
@@ -468,7 +468,7 @@ a {
     .modifiers-attributes {
       display: grid;
       gap: 1rem;
-      grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
       align-items: start;
       margin-top: 0.5rem;
 
@@ -755,7 +755,7 @@ a {
         }
 
         .bonus-type-container {
-          grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+          grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 
           &.attributes {
             grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));

--- a/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
+++ b/Palladium Rifts by Grinning Gecko/src/scss/rifts.scss
@@ -700,7 +700,7 @@ a {
         grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;
       }
 
-      .repeating_armor-inner {
+      .repeating_armor-inner, .repeating_ammo-inner {
         display: grid;
         gap: 0.5rem;
         grid-template-columns: 4rem 1fr 7rem 10rem 10rem 10rem;


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

## New Sheet Details

<!-- If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by < >. -->

- The name of this game is: <   >  _(i.e. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: <   > _(i.e. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: <   > _(i.e. Dungeons & Dragons, FATE)_

- [x] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.

<!-- Please check any that apply: -->

- [ ] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] This game is not a traditionally published game, but a copy of the game rules can be purchased/downloaded/found at: <   >
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

## [1.6.1] - 2025-01-27

### Added

- Add roll buttons to punch and kick damage.
- Add kick damage to Supernatural Strength.
- Add Ammo tracker to Profile tab.

### Changed

- Move Perception from Saving Throws to beside Initiative.
- Active Profile columns now fill the width.
- Fix issue where damage that rolls into the next layer now outputs the correct layer name.
- Alternating colors on repeating rows, except in the Modifier Picker.
- Fix issue where using a `+` in a skill modifier dialog would cause the roll to be 0.

