### PR TITLE
[Dolmenwood] Bugfix: Repair CSS and formatting caused by legacy setting.

### DIFF
--- a/Dolmenwood/dolmenwood.css
+++ b/Dolmenwood/dolmenwood.css
@@ -409,7 +409,7 @@ textarea[name="attr_descGoalBel"] {
 
 input[name="attr_background"],
 input[name="attr_languages"],
-select[name="attr_moonsign"] {
+input[name="attr_moonsign"] {
   width: 480px;
 }
 

--- a/Dolmenwood/dolmenwood.html
+++ b/Dolmenwood/dolmenwood.html
@@ -128,46 +128,7 @@
           <div class="flex">
             <label class="inline-flex">
               <span data-i18n="moon-sign">Moon Sign:</span>
-              <select name="attr_moonsign">
-                <option value="1W" data-i18n="1W">Grinning Waxing - 50% chance of guardian undead ignoring the character's presence. (Though they act normally if provoked.)</option>
-                <option value="1f" data-i18n="1f">Grinning Full - +1 bonus to Saving Throws against the powers of undead monsters.</option>
-                <option value="1w" data-i18n="1w">Grinning Waning - +1 Attack bonus against undead monsters.</option>
-                <option value="2W" data-i18n="2W">Dead Waxing - +1 bonus to Attack and Damage Rolls the Round after killing a foe.</option>
-                <option value="2f" data-i18n="2f">Dead Full - If killed by non-magical means, the character returns to life after 1 Turn with 1 Hit Point. Their Constitution and Wisdom are permanently halved (to a minimum score of 3). This supernatural avoidance of death only takes effect once ever.</option>
-                <option value="2w" data-i18n="2w">Dead Waning - Undead monsters attack all others in the party before attacking the character.</option>
-                <option value="3W" data-i18n="3W">Beast Waxing - +2 bonus to Charisma (maximum 18) when interacting with dogs and horses.</option>
-                <option value="3f" data-i18n="3f">Beast Full - Wild animals attack all others in the party before attacking the character.</option>
-                <option value="3w" data-i18n="3w">Beast Waning - +1 Attack bonus against wolves and bears.</option>
-                <option value="4W" data-i18n="4W">Squamous Waxing - Effects of poison are delayed by 1 Turn.</option>
-                <option value="4f" data-i18n="4f">Squamous Full - +2 bonus to Saving Throws against the breath attacks and magical powers of wyrms and dragons.</option>
-                <option value="4w" data-i18n="4w">Squamous Waning - +1 Attack bonus against serpents and wyrms.</option>
-                <option value="5W" data-i18n="5W">Knight's Waxing - +2 bonus to Charisma (maximum 18) when interacting with nobles.</option>
-                <option value="5f" data-i18n="5f">Knight's Full - +1 AC bonus against attacks with metal weapons.</option>
-                <option value="5w" data-i18n="5w">Knight's Waning - On a tied Initiative roll when in melee with knights or soldiers, the character acts first, as if they had won.</option>
-                <option value="6W" data-i18n="6W">Rotting Waxing - +2 bonus to Charisma (maximum 18) when interacting with sentient fungi.</option>
-                <option value="6f" data-i18n="6f">Rotting Full - +2 AC bonus against attacks by fungal monsters.</option>
-                <option value="6w" data-i18n="6w">Rotting Waning - In the character's presence, fungal monsters suffer a -1 penalty to Attack and Damage Rolls.</option>
-                <option value="7W" data-i18n="7W">Maiden's Waxing - +2 bonus to Charisma (maximum 18) when interacting with demi-fey.</option>
-                <option value="7f" data-i18n="7f">Maiden's Full - +2 bonus to Saving Throws against charms and glamours.</option>
-                <option value="7w" data-i18n="7w">Maiden's Waning - +1 bonus to Attack and Damage Rolls against shape-changers and those cloaked with illusions.</option>
-                <option value="8W" data-i18n="8W">Witch's Waxing - When the character receives magical healing, they gain 1 additional Hit Point. This applies at most once per day to each type of magical healing (e.g. specific spell, Class trait, potion, etc.).</option>
-                <option value="8f" data-i18n="8f">Witch's Full - +1 bonus to Saving Throws against holy magic.</option>
-                <option value="8w" data-i18n="8w">Witch's Waning - +1 bonus to Attack Rolls against witches and holy spell casters.</option>
-                <option value="9W" data-i18n="9W">Robber's Waxing - +2 bonus to Charisma (maximum 18) when interacting with Chaotic mortals.</option>
-                <option value="9f" data-i18n="9f">Robber's Full - +1 AC bonus against attacks by Chaotic mortals, fairies, or demi-fey.</option>
-                <option value="9w" data-i18n="9w">Robber's Waning - +1 Attack bonus against Chaotic mortals, fairies, and demi-fey.</option>
-                <option value="10W" data-i18n="10W">Goat Waxing - +2 bonus to Charisma (maximum 18) when interacting with breggles (including crookhorns).</option>
-                <option value="10f" data-i18n="10f">Goat Full - Breggles (including crookhorns) attack all others in the party before attacking the character.</option>
-                <option value="10w" data-i18n="10w">Goat Waning - +1 Attack bonus against breggles (including crookhorns).</option>
-                <option value="11W" data-i18n="11W">Narrow Waxing - +2 bonus to Charisma (maximum 18) when interacting with fairies, but suffer a -1 penalty to all Saving Throws against fairy magic.</option>
-                <option value="11f" data-i18n="11f">Narrow Full - If the character is afflicted by a curse or a Geas spell, there is a 1-in-4 chance of the caster also being affected by their own magic.</option>
-                <option value="11w" data-i18n="11w">Narrow Waning - +1 Attack bonus against fairies and demi-fey.</option>
-                <option value="12W" data-i18n="12W">Black Waxing - +1 bonus to Search Checks to find secret doors.</option>
-                <option value="12f" data-i18n="12f">Black Full - +2 bonus to AC and Saving Throws when surprised.</option>
-                <option value="12w" data-i18n="12w">Black Waning - +2 bonus to Saving Throws versus illusions and glamours.</option>
-                <option value="none" data-i18n="none">None</option>
-                <option value="custom" data-i18n="custom">Custom</option>
-              </select>
+              <input type="text" name="attr_moonsign" />
             </label>
           </div>
         </div>

--- a/Dolmenwood/sheet.json
+++ b/Dolmenwood/sheet.json
@@ -35,5 +35,5 @@
       ]
     }
   ],
-  "legacy": true
+  "legacy": false
 }


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title
- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

The formatting was incorrect due to my following some legacy code. This removes that error. It also makes the moonsign field more flexible for creative GMs.