### PR TITLE
[Dolmenwood] Bugfix: Repairing the monster text fields to persist data.

### DIFF
--- a/Dolmenwood/dolmenwood.css
+++ b/Dolmenwood/dolmenwood.css
@@ -589,7 +589,7 @@ label.attack span {
   grid-gap: 5px;
   display: grid;
   margin-bottom: 5px;
-  grid-template-columns: 35px 2.5fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 35px 2.5fr 0.75fr 0.5fr 0.5fr 0.5fr;
   font-family: "Metamorphous", serif;
   font-size: 12px;
 }
@@ -598,7 +598,7 @@ label.attack span {
   grid-gap: 5px;
   display: grid;
   margin-bottom: 5px;
-  grid-template-columns: 35px 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 35px 2fr 0.5fr 1fr 0.5fr 0.5fr 0.5fr;
   font-family: "Metamorphous", serif;
   font-size: 12px;
 }
@@ -1042,4 +1042,10 @@ input[name="attr_coinsOverloaded"][value="1"] ~ .sheet-pouch-full {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+textarea.in-monster-row {
+  height: 20px;
+  font-size: 12px;
+  font-family: "Metamorphous", serif;
 }

--- a/Dolmenwood/dolmenwood.html
+++ b/Dolmenwood/dolmenwood.html
@@ -1035,15 +1035,15 @@
 
       <div class="moster-row">
         <span data-i18n="behavior">Behavior:</span>
-        <input type="text" name="monsterBehavior" value="" />
+        <textarea name="attr_behavior" class="in-monster-row" rows="1"></textarea>
         <span data-i18n="speech">Speech:</span>
-        <input type="text" name="monsterSpeech" value="" />
+        <textarea name="attr_monsterSpeech" class="in-monster-row" rows="1"></textarea>
       </div>
       <div class="moster-row">
         <span data-i18n="possessions">Possessions:</span>
-        <input type="text" name="monsterPossessions" value="" />
+        <textarea name="attr_monsterPossessions" class="in-monster-row" rows="1"></textarea>
         <span data-i18n="hoard">Hoard:</span>
-        <input type="text" name="monsterHoard" value="" />
+        <textarea name="attr_monsterHoard" class="in-monster-row" rows="1"></textarea>
       </div>
 
       <div class="divider"></div>


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

Some fields on the monster tab did not have the attr_ prefix on the name. Also some style fixes.
