### PR TITLE
[PokemonTabletopAdventures_v3] Refactor: Skills Visual Update

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.css
+++ b/PokemonTabletopAdventures_v3/PTA3.css
@@ -585,6 +585,66 @@ div.sheet-pokemon-move span.sheet-readonly-field input[type="number"] {
   font-style: italic;
 }
 
+div.sheet-collapsible-skill {
+  background-color: var(--background-color);
+  display: grid;
+  grid-template-columns: 12fr 3fr 1fr;
+  padding: 0 8px;
+  position: relative;
+}
+
+div.sheet-collapsible-skill > input.sheet-options-flag,
+div.sheet-collapsible-skill > input.sheet-options-flag + span {
+  display: block;
+  grid-column: 3;
+  grid-row: 1;
+  height: auto;
+  width: auto;
+  position: relative;
+  margin-left: 4px;
+  margin-top: 2px;
+}
+
+div.sheet-3col-centered {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.sheet-skills-column > .sheet-collapsible-skill > div.sheet-options,
+.sheet-collapsible-skill.sheet-capture > div.sheet-options {
+  background: #0001;
+  border: 1px solid var(--foreground-color);
+  grid-area: 2 / 1 / 2 / 4;
+  padding: 0 8px;
+  padding-bottom: 4px;
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+}
+
+.sheet-collapsible-skill.sheet-capture > div.sheet-options {
+  grid-template-columns: 2fr 1fr;
+}
+
+.sheet-collapsible-skill > .sheet-options > span > select {
+  width: 50%;
+  margin-right: 10px;
+}
+
+.sheet-collapsible-skill > .sheet-options > span + span + span {
+  grid-column: 1 / 3;
+}
+
+.sheet-collapsible-skill.sheet-capture > .sheet-options > span + span + span {
+  grid-column: auto;
+}
+
+.sheet-skills-column > .sheet-collapsible-skill > input.sheet-skill-total,
+.sheet-collapsible-skill.sheet-capture > input.sheet-skill-total {
+  height: 24px;
+  width: 80%;
+  margin-left: 8px;
+}
+
 div.sheet-collapsible-feature,
 div.sheet-feature-container,
 div.sheet-pokemon-move,
@@ -687,10 +747,10 @@ div.sheet-skill-selection .sheet-no-dropdown {
   margin-top: 10px;
 }
 
-.sheet-2col-centered {
+.sheet-two-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  align-items: center;
+  align-items: start;
 }
 
 .sheet-move-modifiers {
@@ -802,11 +862,6 @@ label.sheet-afflictions-text {
 
 .sheet-tiny-text {
   width: 50px;
-}
-
-.charsheet input.sheet-total-display.sheet-tiny-number[type="text"] {
-  width: 25px;
-  padding: 0px;
 }
 
 .sheet-damage-dice {
@@ -1110,28 +1165,83 @@ input.sheet-character-type[value="hybrid"] ~ div.sheet-tab-hybrid {
 }
 
 input.sheet-skill-color-setting[value="ATK"] + input[type="number"].sheet-skill-total,
-input.sheet-skill-color-setting[value="ATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
+input.sheet-skill-color-setting[value="ATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="ATK"] + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="ATK"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
   background-color: var(--stat-ro-atk);
+  border-color: #555555;
 }
 
 input.sheet-skill-color-setting[value="DEF"] + input[type="number"].sheet-skill-total,
-input.sheet-skill-color-setting[value="DEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
+input.sheet-skill-color-setting[value="DEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="DEF"] + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="DEF"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
   background-color: var(--stat-ro-def);
+  border-color: #555555;
 }
 
 input.sheet-skill-color-setting[value="SPATK"] + input[type="number"].sheet-skill-total,
-input.sheet-skill-color-setting[value="SPATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
+input.sheet-skill-color-setting[value="SPATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="SPATK"] + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="SPATK"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
   background-color: var(--stat-ro-spatk);
+  border-color: #555555;
 }
 
 input.sheet-skill-color-setting[value="SPDEF"] + input[type="number"].sheet-skill-total,
-input.sheet-skill-color-setting[value="SPDEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
+input.sheet-skill-color-setting[value="SPDEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="SPDEF"] + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="SPDEF"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
   background-color: var(--stat-ro-spdef);
+  border-color: #555555;
 }
 
 input.sheet-skill-color-setting[value="SPD"] + input[type="number"].sheet-skill-total,
-input.sheet-skill-color-setting[value="SPD"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover {
+input.sheet-skill-color-setting[value="SPD"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="SPD"] + button[type="roll"].sheet-skill-roller:hover,
+input.sheet-skill-color-setting[value="SPD"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
   background-color: var(--stat-ro-spd);
+  border-color: #555555;
+}
+
+.sheet-darkmode input.sheet-skill-color-setting[value="ATK"] + input[type="number"].sheet-skill-total,
+.sheet-darkmode input.sheet-skill-color-setting[value="ATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="ATK"] + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="ATK"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
+  border-color: var(--stat-atk);
+  color: var(--stat-atk);
+}
+
+.sheet-darkmode input.sheet-skill-color-setting[value="DEF"] + input[type="number"].sheet-skill-total,
+.sheet-darkmode input.sheet-skill-color-setting[value="DEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="DEF"] + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="DEF"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
+  border-color: var(--stat-def);
+  color: var(--stat-def);
+}
+
+.sheet-darkmode input.sheet-skill-color-setting[value="SPATK"] + input[type="number"].sheet-skill-total,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPATK"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPATK"] + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPATK"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
+  border-color: var(--stat-spatk);
+  color: var(--stat-spatk);
+}
+
+.sheet-darkmode input.sheet-skill-color-setting[value="SPDEF"] + input[type="number"].sheet-skill-total,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPDEF"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPDEF"] + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPDEF"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
+  border-color: var(--stat-spdef);
+  color: var(--stat-spdef);
+}
+
+.sheet-darkmode input.sheet-skill-color-setting[value="SPD"] + input[type="number"].sheet-skill-total,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPD"] + .sheet-skill-total + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPD"] + button[type="roll"].sheet-skill-roller:hover,
+.sheet-darkmode input.sheet-skill-color-setting[value="SPD"] + button[type="roll"].sheet-skill-roller + .sheet-skill-total {
+  border-color: var(--stat-spd);
+  color: var(--stat-spd);
 }
 
 input.sheet-skill-total {
@@ -1317,53 +1427,53 @@ button[type="roll"].sheet-stat-roller:hover {
   padding: 0px;
 }
 
-.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-atk-skill {
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-ATK-skill {
   --border-color: var(--poke-all-dark-background);
   --header-bg: var(--atk-gradient);
 }
 
-.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-def-skill {
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-DEF-skill {
   --border-color: var(--poke-all-dark-background);
   --header-bg: var(--def-gradient);
 }
 
-.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-spatk-skill {
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-SPATK-skill {
   --border-color: var(--poke-all-dark-background);
   --header-bg: var(--spatk-gradient);
 }
 
-.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-spdef-skill {
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-SPDEF-skill {
   --border-color: var(--poke-all-dark-background);
   --header-bg: var(--spdef-gradient);
 }
 
-.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-spd-skill {
+.sheet-rolltemplate-inline-skill-roll .sheet-rolltemplate-color-setting-SPD-skill {
   --border-color: var(--poke-all-dark-background);
   --header-bg: var(--spd-gradient);
 }
 
 
-.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-atk-skill {
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-ATK-skill {
   --border-color: var(--atk-gradient);
   --header-bg: var(--atk-header-dark);
 }
 
-.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-def-skill {
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-DEF-skill {
   --border-color: var(--def-gradient);
   --header-bg: var(--def-header-dark);
 }
 
-.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spatk-skill {
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-SPATK-skill {
   --border-color: var(--spatk-gradient);
   --header-bg: var(--spatk-header-dark);
 }
 
-.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spdef-skill {
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-SPDEF-skill {
   --border-color: var(--spdef-gradient);
   --header-bg: var(--spdef-header-dark);
 }
 
-.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spd-skill {
+.sheet-rolltemplate-inline-skill-roll.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-SPD-skill {
   --border-color: var(--spd-gradient);
   --header-bg: var(--spd-header-dark);
 }
@@ -1513,31 +1623,31 @@ button[type="roll"].sheet-stat-roller:hover {
   --header-bg: var(--poke-water);
 }
 
-.sheet-rolltemplate-color-setting-atk-skill {
+.sheet-rolltemplate-color-setting-ATK-skill {
   --border-color: var(--atk-gradient);
   --box-bg: linear-gradient(var(--header-bg), var(--border-color));
   --header-bg: var(--atk-header);
 }
 
-.sheet-rolltemplate-color-setting-def-skill {
+.sheet-rolltemplate-color-setting-DEF-skill {
   --border-color: var(--def-gradient);
   --box-bg: linear-gradient(var(--header-bg), var(--border-color));
   --header-bg: var(--def-header);
 }
 
-.sheet-rolltemplate-color-setting-spatk-skill {
+.sheet-rolltemplate-color-setting-SPATK-skill {
   --border-color: var(--spatk-gradient);
   --box-bg: linear-gradient(var(--header-bg), var(--border-color));
   --header-bg: var(--spatk-header);
 }
 
-.sheet-rolltemplate-color-setting-spdef-skill {
+.sheet-rolltemplate-color-setting-SPDEF-skill {
   --border-color: var(--spdef-gradient);
   --box-bg: linear-gradient(var(--header-bg), var(--border-color));
   --header-bg: var(--spdef-header);
 }
 
-.sheet-rolltemplate-color-setting-spd-skill {
+.sheet-rolltemplate-color-setting-SPD-skill {
   --border-color: var(--spd-gradient);
   --box-bg: linear-gradient(var(--header-bg), var(--border-color));
   --header-bg: var(--spd-header);
@@ -1621,23 +1731,23 @@ button[type="roll"].sheet-stat-roller:hover {
   --header-bg: var(--poke-water-dark);
 }
 
-.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-atk-skill {
+.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-ATK-skill {
   --header-bg: var(--atk-header-dark);
 }
 
-.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-def-skill {
+.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-DEF-skill {
   --header-bg: var(--def-header-dark);
 }
 
-.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spatk-skill {
+.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-SPATK-skill {
   --header-bg: var(--spatk-header-dark);
 }
 
-.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spdef-skill {
+.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-SPDEF-skill {
   --header-bg: var(--spdef-header-dark);
 }
 
-.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-spd-skill {
+.sheet-rolltemplate-darkmode .sheet-rolltemplate-color-setting-SPD-skill {
   --header-bg: var(--spd-header-dark);
 }
 
@@ -2230,7 +2340,11 @@ input.sheet-capitalize {
       overflow: auto;
   }
 
-  .sheet-2col-centered {
+  .sheet-two-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .sheet-3col-centered {
     grid-template-columns: 1fr;
   }
 
@@ -2315,18 +2429,6 @@ input.sheet-capitalize {
 
   .sheet-half-text {
     width: 65px;
-  }
-
-  .sheet-capture-pokemon-skill-m1 {
-    align-items: center;
-    display: grid;
-    grid-template-columns: 1fr 6fr 1fr;
-  }
-
-  .sheet-capture-pokemon-skill-m2 {
-    align-items: center;
-    display: grid;
-    grid-template-columns: 1.5fr 1fr 1fr;
   }
 
   .sheet-move-modifiers {

--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1,18 +1,36 @@
+<!-- Table of Contents: -->
 <!--
-Table of Contents:
 - Character Sheet
-  - Character Page........L#40
-  - Configuration Page....L#1591
+  - Character Page........L#58
+    - Form Buttons........L#65
+    - Info Sections
+      - Trainer...........L#99
+      - Pokemon...........L#148
+      - Hybrid............L#294
+    - Avatar..............L#435
+    - Trainer Stats.......L#569
+    - Pokemon Stats.......L#660
+    - Skills
+      - Trainer...........L#795
+      - Pokemon/Hybrid....L#1398
+    - Capture Pokemon.....L#1599
+    - Features
+      - Origin Feature....L#1688
+      - Class Features....L#1771
+    - Passives............L#1857
+    - Moves...............L#1879
+    - Notes...............L#2139
+  - Configuration Page....L#2205
 - Roll Templates
-  - Move-Roll.............L#2111
-  - Dual-Hit-Move-Roll....L#2244
-  - Ten-Hit-Move-Roll.....L#2409
-  - Multi-Hit-Move-Roll...L#2998
-  - Triple-Hit-Move-Roll..L#3322
-  - Skill-Roll............L#3540
-  - Inline-Skill-Roll.....L#3559
-  - Feature-Output........L#3579
-- Sheet Scripts...........L#3595
+  - Move-Roll.............L#2725
+  - Dual-Hit-Move-Roll....L#2858
+  - Ten-Hit-Move-Roll.....L#3023
+  - Multi-Hit-Move-Roll...L#3612
+  - Triple-Hit-Move-Roll..L#3936
+  - Skill-Roll............L#4174
+  - Inline-Skill-Roll.....L#4173
+  - Feature-Output........L#4193
+- Sheet Scripts...........L#4209
 -->
 
 <!-- Background coloring strategy inspired by the GURPS sheet -->
@@ -87,7 +105,7 @@ Table of Contents:
         </div>
         <div class="sheet-options">
           <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_class1"></span> (Level <span name="attr_level1"></span>)</h3>
-          <div class="sheet-2col-centered">
+          <div class="sheet-two-columns">
             <div class="sheet-character-name-grid">
               <b>Name</b>
               <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
@@ -137,7 +155,7 @@ Table of Contents:
         <div class="sheet-options">
           <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
           <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_species"></span></h3>
-          <div class="sheet-2col-centered">
+          <div class="sheet-two-columns">
             <div class="sheet-character-name-grid">
               <b>Name</b>
               <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
@@ -283,7 +301,7 @@ Table of Contents:
         <div class="sheet-options">
           <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
           <h3 class="sheet-section-header"><span name="attr_character_name"></span> the <span name="attr_pokemon_advanced_class"></span> <span name="attr_species"></span> (Level <span name="attr_level1"></span>)</h3>
-          <div class="sheet-2col-centered">
+          <div class="sheet-two-columns">
             <div class="sheet-character-name-grid">
               <b>Name</b>
               <input class="sheet-top-information" name="attr_character_name" spellcheck="false" title="Attribute: character_name" type="text" />
@@ -430,7 +448,7 @@ Table of Contents:
               <b>Attack</b><br />
               <input class="sheet-stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_attack_check" type="roll"
-                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=ATK}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_ATKMOD" title="Attribute: ATKMOD"></span>
               </button>
               <br />
@@ -440,7 +458,7 @@ Table of Contents:
               <b>Defense</b><br />
               <input class="sheet-stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_defense_check" type="roll"
-                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=DEF}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_DEFMOD" title="Attribute: DEFMOD"></span>
               </button>
               <br />
@@ -450,7 +468,7 @@ Table of Contents:
               <b>Special Attack</b><br />
               <input class="sheet-stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_special_attack_check" type="roll"
-                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=SPATK}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_SPATKMOD" title="Attribute: SPATKMOD"></span>
               </button>
               <br />
@@ -460,7 +478,7 @@ Table of Contents:
               <b>Special Defense</b><br />
               <input class="sheet-stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_special_defense_check" type="roll"
-                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=SPDEF}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_SPDEFMOD" title="Attribute: SPDEFMOD"></span>
               </button>
               <br />
@@ -470,7 +488,7 @@ Table of Contents:
               <b>Speed</b><br />
               <input class="sheet-stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" readonly /><br />
               <button class="sheet-stat-roller" name="roll_speed_check" type="roll"
-                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=SPD}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
                 <span name="attr_SPDMOD" title="Attribute: SPDMOD"></span>
               </button>
               <br />
@@ -494,7 +512,7 @@ Table of Contents:
                 <b>Attack</b><br />
                 <input class="sheet-stat-ball-color" name="attr_ATK" title="Attribute: ATK" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_attack_check" type="roll"
-                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=ATK}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Attack Check}} {{skill-roll=[[ 1d20 + [[ @{ATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_ATKMOD" title="Attribute: ATKMOD"></span>
                 </button>
                 <br />
@@ -504,7 +522,7 @@ Table of Contents:
                 <b>Defense</b><br />
                 <input class="sheet-stat-ball-color" name="attr_DEF" title="Attribute: DEF" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_defense_check" type="roll"
-                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=DEF}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Defense Check}} {{skill-roll=[[ 1d20 + [[ @{DEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_DEFMOD" title="Attribute: DEFMOD"></span>
                 </button>
                 <br />
@@ -514,7 +532,7 @@ Table of Contents:
                 <b>Special Attack</b><br />
                 <input class="sheet-stat-ball-color" name="attr_SPATK" title="Attribute: SPATK" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_special_attack_check" type="roll"
-                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=SPATK}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Attack Check}} {{skill-roll=[[ 1d20 + [[ @{SPATKMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_SPATKMOD" title="Attribute: SPATKMOD"></span>
                 </button>
                 <br />
@@ -524,7 +542,7 @@ Table of Contents:
                 <b>Special Defense</b><br />
                 <input class="sheet-stat-ball-color" name="attr_SPDEF" title="Attribute: SPDEF" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_special_defense_check" type="roll"
-                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=SPDEF}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Special Defense Check}} {{skill-roll=[[ 1d20 + [[ @{SPDEFMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_SPDEFMOD" title="Attribute: SPDEFMOD"></span>
                 </button>
                 <br />
@@ -534,7 +552,7 @@ Table of Contents:
                 <b>Speed</b><br />
                 <input class="sheet-stat-ball-color" name="attr_SPD" title="Attribute: SPD" type="number" readonly /><br />
                 <button class="sheet-stat-roller" name="roll_speed_check" type="roll"
-                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=SPD}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Generic Speed Check}} {{skill-roll=[[ 1d20 + [[ @{SPDMOD} + ?{Temp Modifier|0} ]] ]]}}">
                   <span name="attr_SPDMOD" title="Attribute: SPDMOD"></span>
                 </button>
                 <br />
@@ -594,7 +612,7 @@ Table of Contents:
               <p><label class="sheet-afflictions-text"><input name="attr_Toxified" value="1" title="Attribute: Toxified" type="checkbox" /> Toxified</label></p>
               <p><label class="sheet-afflictions-text"><input name="attr_Stunned" value="1" title="Attribute: Stunned" type="checkbox" /> Stunned</label></p>
             </div>
-            <div class="sheet-2col-centered">
+            <div class="sheet-two-columns">
               <b>Movement</b>
               <b class="sheet-hide-on-mobile">Bonus</b>
               <span><input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" /><b>ft</b></span>
@@ -685,7 +703,7 @@ Table of Contents:
               <p><label class="sheet-afflictions-text" ><input name="attr_Toxified" value="1" title="Attribute: Toxified" type="checkbox" /> Toxified</label></p>
               <p><label class="sheet-afflictions-text" ><input name="attr_Stunned" value="1" title="Attribute: Stunned" type="checkbox" /> Stunned</label></p>
             </div>
-            <div class="sheet-2col-centered">
+            <div class="sheet-two-columns">
               <b>Movement</b>
               <b class="sheet-hide-on-mobile">Bonus</b>
               <span><input class="sheet-speed-read-color" name="attr_movement" readonly title="Attribute: movement" type="number" /><b>ft</b></span>
@@ -760,309 +778,905 @@ Table of Contents:
       <div class="sheet-display-when-custom2"><textarea class="sheet-2row-textarea-wide" name="attr_custom2-notes" placeholder="Additional Notes" spellcheck="false" title="Attribute: custom2-notes"></textarea></div>
       <div class="sheet-display-when-custom3"><textarea class="sheet-2row-textarea-wide" name="attr_custom3-notes" placeholder="Additional Notes" spellcheck="false" title="Attribute: custom3-notes"></textarea></div>
     </div>
+    <br />
 
     <!-- SKILLS -->
 
-    <div class="sheet-tab-trainer sheet-tab-pokemon sheet-tab-hybrid">
-      <br />
-
-      <div class="sheet-character-skill-labels">
-        <b>Total</b>
-        <b>Skill Name</b>
-        <b>Talent</b>
-        <b>Bonus</b>
-        <b class="sheet-hide-on-mobile">Total</b>
-        <b class="sheet-hide-on-mobile">Skill Name</b>
-        <b class="sheet-hide-on-mobile">Talent</b>
-        <b class="sheet-hide-on-mobile">Bonus</b>
+    <div class="sheet-feature-container">
+      <input checked class="sheet-options-flag" name="attr_skills_options_flag" type="checkbox" />
+      <span name="attr_skills_flag">-</span>
+      <div class="sheet-display">
+        <h3 class="sheet-section-header">Skills</h3>
       </div>
+      <div class="sheet-options">
+        <input class="sheet-character-type" name="attr_character-type" type="hidden" value="pokemon" />
+        <h3 class="sheet-section-header">Skills</h3>
 
-      <div class="sheet-2col-centered">
-        <div class="sheet-character-skills">
-          <input class="sheet-skill-color-setting" name="attr_acrobatics_ability_mod" type="hidden" value="SPD" />
-          <input class="sheet-skill-total" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_acrobaticscheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Acrobatics (<span name="attr_acrobatics_ability_mod"></span>)
-          </button>
-          <input name="attr_acrobaticstalent1" value="2" title="Attribute: acrobaticstalent1" type="checkbox" />
-          <input name="attr_acrobaticstalent2" value="2" title="Attribute: acrobaticstalent2" type="checkbox" />
-          <input name="attr_acrobatics" value="0" title="Attribute: acrobatics" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_athletics_ability_mod" type="hidden" value="ATK" />
-          <input class="sheet-skill-total" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_athleticscheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=atk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Athletics (<span name="attr_athletics_ability_mod"></span>)
-          </button>
-          <input name="attr_athleticstalent1" value="2" title="Attribute: athleticstalent1" type="checkbox" />
-          <input name="attr_athleticstalent2" value="2" title="Attribute: athleticstalent2" type="checkbox" />
-          <input name="attr_athletics" value="0" title="Attribute: athletics" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_bluff_ability_mod" type="hidden" value="SPDEF" />
-          <input class="sheet-skill-total" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_bluffcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Bluff/Deception (<span name="attr_bluff_ability_mod"></span>)
-          </button>
-          <input name="attr_blufftalent1" value="2" title="Attribute: blufftalent1" type="checkbox" />
-          <input name="attr_blufftalent2" value="2" title="Attribute: blufftalent2" type="checkbox" />
-          <input name="attr_bluff" value="0" title="Attribute: bluff" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_concentration_ability_mod" type="hidden" value="DEF" />
-          <input class="sheet-skill-total" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_concentrationcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Concentration (<span name="attr_concentration_ability_mod"></span>)
-          </button>
-          <input name="attr_concentrationtalent1" value="2" title="Attribute: concentrationtalent1" type="checkbox" />
-          <input name="attr_concentrationtalent2" value="2" title="Attribute: concentrationtalent2" type="checkbox" />
-          <input name="attr_concentration" value="0" title="Attribute: concentration" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_constitution_ability_mod" type="hidden" value="DEF" />
-          <input class="sheet-skill-total" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_constitutioncheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=def}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Constitution (<span name="attr_constitution_ability_mod"></span>)
-          </button>
-          <input name="attr_constitutiontalent1" value="2" title="Attribute: constitutiontalent1" type="checkbox" />
-          <input name="attr_constitutiontalent2" value="2" title="Attribute: constitutiontalent2" type="checkbox" />
-          <input name="attr_constitution" value="0" title="Attribute: constitution" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_diplomacy_ability_mod" type="hidden" value="SPDEF" />
-          <input class="sheet-skill-total" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_diplomacycheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Diplomacy/Persuasion (<span name="attr_diplomacy_ability_mod"></span>)
-          </button>
-          <input name="attr_diplomacytalent1" value="2" title="Attribute: diplomacytalent1" type="checkbox" />
-          <input name="attr_diplomacytalent2" value="2" title="Attribute: diplomacytalent2" type="checkbox" />
-          <input name="attr_diplomacy" value="0" title="Attribute: diplomacy" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_engineering_ability_mod" type="hidden" value="SPATK" />
-          <input class="sheet-skill-total" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_engineeringcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Engineering/Operation (<span name="attr_engineering_ability_mod"></span>)
-          </button>
-          <input name="attr_engineeringtalent1" value="2" title="Attribute: engineeringtalent1" type="checkbox" />
-          <input name="attr_engineeringtalent2" value="2" title="Attribute: engineeringtalent2" type="checkbox" />
-          <input name="attr_engineering" value="0" title="Attribute: engineering" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_history_ability_mod" type="hidden" value="SPATK" />
-          <input class="sheet-skill-total" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_historycheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            History (<span name="attr_history_ability_mod"></span>)
-          </button>
-          <input name="attr_historytalent1" value="2" title="Attribute: historytalent1" type="checkbox" />
-          <input name="attr_historytalent2" value="2" title="Attribute: historytalent2" type="checkbox" />
-          <input name="attr_history" value="0" title="Attribute: history" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_insight_ability_mod" type="hidden" value="SPDEF" />
-          <input class="sheet-skill-total" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_insightcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Insight (<span name="attr_insight_ability_mod"></span>)
-          </button>
-          <input name="attr_insighttalent1" value="2" title="Attribute: insighttalent1" type="checkbox" />
-          <input name="attr_insighttalent2" value="2" title="Attribute: insighttalent2" type="checkbox" />
-          <input name="attr_insight" value="0" title="Attribute: insight" type="number" />
-        </div>
-        <div class="sheet-character-skills">
-          <input class="sheet-skill-color-setting" name="attr_investigate_ability_mod" type="hidden" value="SPATK" />
-          <input class="sheet-skill-total" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_investigatecheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Investigate (<span name="attr_investigate_ability_mod"></span>)
-          </button>
-          <input name="attr_investigatetalent1" value="2" title="Attribute: investigatetalent1" type="checkbox" />
-          <input name="attr_investigatetalent2" value="2" title="Attribute: investigatetalent2" type="checkbox" />
-          <input name="attr_investigate" value="0" title="Attribute: investigate" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_medicine_ability_mod" type="hidden" value="SPATK" />
-          <input class="sheet-skill-total" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_medicinecheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Medicine (<span name="attr_medicine_ability_mod"></span>)
-          </button>
-          <input name="attr_medicinetalent1" value="2" title="Attribute: medicinetalent1" type="checkbox" />
-          <input name="attr_medicinetalent2" value="2" title="Attribute: medicinetalent2" type="checkbox" />
-          <input name="attr_medicine" value="0" title="Attribute: medicine" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_nature_ability_mod" type="hidden" value="SPATK" />
-          <input class="sheet-skill-total" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_naturecheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Nature (<span name="attr_nature_ability_mod"></span>)
-          </button>
-          <input name="attr_naturetalent1" value="2" title="Attribute: naturetalent1" type="checkbox" />
-          <input name="attr_naturetalent2" value="2" title="Attribute: naturetalent2" type="checkbox" />
-          <input name="attr_nature" value="0" title="Attribute: nature" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_perception_ability_mod" type="hidden" value="SPDEF" />
-          <input class="sheet-skill-total" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_perceptioncheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Perception (<span name="attr_perception_ability_mod"></span>)
-          </button>
-          <input name="attr_perceptiontalent1" value="2" title="Attribute: perceptiontalent1" type="checkbox" />
-          <input name="attr_perceptiontalent2" value="2" title="Attribute: perceptiontalent2" type="checkbox" />
-          <input name="attr_perception" value="0" title="Attribute: perception" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_perform_ability_mod" type="hidden" value="SPDEF" />
-          <input class="sheet-skill-total" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_performcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Perform (<span name="attr_perform_ability_mod"></span>)
-          </button>
-          <input name="attr_performtalent1" value="2" title="Attribute: performtalent1" type="checkbox" />
-          <input name="attr_performtalent2" value="2" title="Attribute: performtalent2" type="checkbox" />
-          <input name="attr_perform" value="0" title="Attribute: perform" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_handling_ability_mod" type="hidden" value="SPDEF" />
-          <input class="sheet-skill-total" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_handlingcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spdef}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Pokémon Handling (<span name="attr_handling_ability_mod"></span>)
-          </button>
-          <input name="attr_handlingtalent1" value="2" title="Attribute: handlingtalent1" type="checkbox" />
-          <input name="attr_handlingtalent2" value="2" title="Attribute: handlingtalent2" type="checkbox" />
-          <input name="attr_handling" value="0" title="Attribute: handling" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_programming_ability_mod" type="hidden" value="SPATK" />
-          <input class="sheet-skill-total" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll" value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spatk}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Programming (<span name="attr_programming_ability_mod"></span>)
-          </button>
-          <input name="attr_programmingtalent1" value="2" title="Attribute: programmingtalent1" type="checkbox" />
-          <input name="attr_programmingtalent2" value="2" title="Attribute: programmingtalent2" type="checkbox" />
-          <input name="attr_programming" value="0" title="Attribute: programming" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_sleight_ability_mod" type="hidden" value="SPD" />
-          <input class="sheet-skill-total" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_sleightofhandcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Sleight of Hand (<span name="attr_sleight_ability_mod"></span>)
-          </button>
-          <input name="attr_sleightofhandtalent1" value="2" title="Attribute: sleightofhandtalent1" type="checkbox" />
-          <input name="attr_sleightofhandtalent2" value="2" title="Attribute: sleightofhandtalent2" type="checkbox" />
-          <input name="attr_sleightofhand" value="0" title="Attribute: sleightofhand" type="number" />
-          <input class="sheet-skill-color-setting" name="attr_stealth_ability_mod" type="hidden" value="SPD" />
-          <input class="sheet-skill-total" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_stealthcheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} + ?{Temporary Bonus|0} ]] ]]}}">
-            Stealth (<span name="attr_stealth_ability_mod"></span>)
-          </button>
-          <input name="attr_stealthtalent1" value="2" title="Attribute: stealthtalent1" type="checkbox" />
-          <input name="attr_stealthtalent2" value="2" title="Attribute: stealthtalent2" type="checkbox" />
-          <input name="attr_stealth" value="0" title="Attribute: stealth" type="number" />
-        </div>
-      </div>
-    </div>
+        <div class="sheet-tab-trainer">
+          <div class="sheet-two-columns">
+            <div class="sheet-skills-column">
+              <div class="sheet-collapsible-skill sheet-acrobatics">
+                <input class="sheet-skill-color-setting" name="attr_acrobatics_ability_mod" type="hidden" value="SPD" />
+                <button class="sheet-skill-roller" name="roll_acrobaticscheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{acrobatics_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + @{acrobatics_total} ]]}}">
+                  Acrobatics (<span name="attr_acrobatics_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_acrobatics_options_flag" type="checkbox" />
+                <span name="attr_acrobatics_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_acrobaticstalent1" value="2" title="Attribute: acrobaticstalent1" type="checkbox" />
+                    <input name="attr_acrobaticstalent2" value="2" title="Attribute: acrobaticstalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_acrobatics_ability_mod" title="Select the attribute you want to use for Acrobatics.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option selected value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Acrobatics."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_acrobatics" value="0" title="Attribute: acrobatics" type="number" />
+                  </span>
+                </div>
+              </div>
 
-    <!-- CAPTURE POKEMON -->
+              <div class="sheet-collapsible-skill sheet-athletics">
+                <input class="sheet-skill-color-setting" name="attr_athletics_ability_mod" type="hidden" value="ATK" />
+                <button class="sheet-skill-roller" name="roll_athleticscheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{athletics_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + @{athletics_total} ]]}}">
+                  Athletics (<span name="attr_athletics_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_athletics_options_flag" type="checkbox" />
+                <span name="attr_athletics_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_athleticstalent1" value="2" title="Attribute: athleticstalent1" type="checkbox" />
+                    <input name="attr_athleticstalent2" value="2" title="Attribute: athleticstalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_athletics_ability_mod" title="Select the attribute you want to use for Athletics.">
+                      <option selected value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Athletics."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_athletics" value="0" title="Attribute: athletics" type="number" />
+                  </span>
+                </div>
+              </div>
 
-    <div class="sheet-tab-trainer">
-      <div>
-        <hr class="sheet-skill-separator" />
-        <!-- Desktop version -->
-        <div class="sheet-capture-pokemon-skill sheet-tab-trainer sheet-hide-on-mobile">
-          <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
-          <input class="sheet-skill-total" name="attr_capture_total" readonly title="The value added to your skill check to hit a Pokémon with a Pokéball. Note - this can be ignored if the target Pokémon is at or below half of their max HP.
-          Attribute: capture_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
-            Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
-          </button>
-          <input name="attr_capture_default_custom_modifier" type="hidden" value="0" />
-          <select class="sheet-ball-picker" name="attr_ball_capture_modifier" title="Select which Pokéball you want to use - this presumes the benefit is applied for conditional balls such as Quick Ball.
-          Attribute: ball_capture_modifier">
-            <option value="+5" selected>Basic Ball</option>
-            <option value="+0">Great Ball</option>
-            <option value="-5">Ultra Ball</option>
-            <option value="-20">Park Ball</option>
-            <option value="-20">Safari Ball</option>
-            <option value="-20">Sport Ball</option>
-            <option value="-5">Cherish Ball</option>
-            <option value="-5">Luxury Ball</option>
-            <option value="-5">Premier Ball</option>
-            <option value="-12">Dive Ball</option>
-            <option value="-7">Dusk Ball</option>
-            <option value="-8">Fast Ball</option>
-            <option value="-10">Lure Ball</option>
-            <option value="-20">Quick Ball</option>
-            <option value="-10">Repeat Ball</option>
-            <option value="-10">1m Timer Ball</option>
-            <option value="-25">2m Timer Ball</option>
-            <option value="+0">Friend Ball</option>
-            <option value="+0">Heal Ball</option>
-            <option value="-10">Dream Ball</option>
-            <option value="-15">Heavy Ball</option>
-            <option value="-10">Level Ball</option>
-            <option value="-10">Love Ball</option>
-            <option value="-10">Moon Ball</option>
-            <option value="-10">Nest Ball</option>
-            <option value="-15">Type Ball</option>
-            <option value="-12">Terrain Ball</option>
-            <option value="-10">Save Ball</option>
-            <option value="-100">Master Ball</option>
-            <option value="+ ?{Custom Ball Modifier|@{capture_default_custom_modifier}}">Custom Ball</option>
-          </select>
-          <span title="The modifier applied to your capture rolls because of your selected Pokéball. This value can be configured for custom balls in the Configuration page.
-          Attribute: capture_display">
-            <b>Ball Mod:</b>
-            <input class="sheet-total-display sheet-tiny-number" name="attr_capture_display" readonly type="text" />
-          </span>
-          <input name="attr_capture_roll_bonus" title="Use this field to assign a static modifier to your capture rolls - things like a Capture Specialist's Capture Point feature.
-          Attribute: capture_roll_bonus" type="number" value="0" />
-          <span title="The total modifier applied to your d100 capture rolls. If an asterisk * is shown, that means you've selected a custom ball. Attribute: capture_roll_total">
-            <b>Total:</b>
-            <input class="sheet-skill-total sheet-total-display sheet-tiny-number" name="attr_capture_roll_total" readonly type="text" />
-          </span>
+              <div class="sheet-collapsible-skill sheet-bluff">
+                <input class="sheet-skill-color-setting" name="attr_bluff_ability_mod" type="hidden" value="SPDEF" />
+                <button class="sheet-skill-roller" name="roll_bluffcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{bluff_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + @{bluff_total} ]]}}">
+                  Bluff/Deception (<span name="attr_bluff_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_bluff_options_flag" type="checkbox" />
+                <span name="attr_bluff_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_blufftalent1" value="2" title="Attribute: blufftalent1" type="checkbox" />
+                    <input name="attr_blufftalent2" value="2" title="Attribute: blufftalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_bluff_ability_mod" title="Select the attribute you want to use for Bluff/Deception.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option selected value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Bluff/Deception."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_bluff" value="0" title="Attribute: bluff" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-concentration">
+                <input class="sheet-skill-color-setting" name="attr_concentration_ability_mod" type="hidden" value="DEF" />
+                <button class="sheet-skill-roller" name="roll_concentrationcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{concentration_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + @{concentration_total} ]]}}">
+                  Concentration (<span name="attr_concentration_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_concentration_options_flag" type="checkbox" />
+                <span name="attr_concentration_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_concentrationtalent1" value="2" title="Attribute: concentrationtalent1" type="checkbox" />
+                    <input name="attr_concentrationtalent2" value="2" title="Attribute: concentrationtalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_concentration_ability_mod" title="Select the attribute you want to use for Concentration.">
+                      <option value="ATK">Attack</option>
+                      <option selected value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Concentration."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_concentration" value="0" title="Attribute: concentration" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-constitution">
+                <input class="sheet-skill-color-setting" name="attr_constitution_ability_mod" type="hidden" value="DEF" />
+                <button class="sheet-skill-roller" name="roll_constitutioncheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{constitution_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + @{constitution_total} ]]}}">
+                  Constitution (<span name="attr_constitution_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_constitution_options_flag" type="checkbox" />
+                <span name="attr_constitution_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_constitutiontalent1" value="2" title="Attribute: constitutiontalent1" type="checkbox" />
+                    <input name="attr_constitutiontalent2" value="2" title="Attribute: constitutiontalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_constitution_ability_mod" title="Select the attribute you want to use for Constitution.">
+                      <option value="ATK">Attack</option>
+                      <option selected value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Constitution."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_constitution" value="0" title="Attribute: constitution" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-diplomacy">
+                <input class="sheet-skill-color-setting" name="attr_diplomacy_ability_mod" type="hidden" value="DEF" />
+                <button class="sheet-skill-roller" name="roll_diplomacycheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{diplomacy_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + @{diplomacy_total} ]]}}">
+                  Diplomacy/Persuasion (<span name="attr_diplomacy_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_diplomacy_options_flag" type="checkbox" />
+                <span name="attr_diplomacy_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_diplomacytalent1" value="2" title="Attribute: diplomacytalent1" type="checkbox" />
+                    <input name="attr_diplomacytalent2" value="2" title="Attribute: diplomacytalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_diplomacy_ability_mod" title="Select the attribute you want to use for Diplomacy/Persuasion.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option selected value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Diplomacy/Persuasion."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_diplomacy" value="0" title="Attribute: diplomacy" type="number" />
+                  </span>
+                </div>
+              </div>
+                
+              <div class="sheet-collapsible-skill sheet-engineering">
+                <input class="sheet-skill-color-setting" name="attr_engineering_ability_mod" type="hidden" value="SPD" />
+                <button class="sheet-skill-roller" name="roll_engineeringcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{engineering_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + @{engineering_total} ]]}}">
+                  Engineering/Operation (<span name="attr_engineering_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_engineering_options_flag" type="checkbox" />
+                <span name="attr_engineering_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_engineeringtalent1" value="2" title="Attribute: engineeringtalent1" type="checkbox" />
+                    <input name="attr_engineeringtalent2" value="2" title="Attribute: engineeringtalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_engineering_ability_mod" title="Select the attribute you want to use for Engineering/Operation.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option selected value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Engineering/Operation."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_engineering" value="0" title="Attribute: engineering" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-history">
+                <input class="sheet-skill-color-setting" name="attr_history_ability_mod" type="hidden" value="SPATK" />
+                <button class="sheet-skill-roller" name="roll_historycheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{history_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + @{history_total} ]]}}">
+                  History (<span name="attr_history_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_history_options_flag" type="checkbox" />
+                <span name="attr_history_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_historytalent1" value="2" title="Attribute: historytalent1" type="checkbox" />
+                    <input name="attr_historytalent2" value="2" title="Attribute: historytalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_history_ability_mod" title="Select the attribute you want to use for History.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option selected value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for History."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_history" value="0" title="Attribute: history" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-insight">
+                <input class="sheet-skill-color-setting" name="attr_insight_ability_mod" type="hidden" value="SPDEF" />
+                <button class="sheet-skill-roller" name="roll_insightcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{insight_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + @{insight_total} ]]}}">
+                  Insight (<span name="attr_insight_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_insight_options_flag" type="checkbox" />
+                <span name="attr_insight_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_insighttalent1" value="2" title="Attribute: insighttalent1" type="checkbox" />
+                    <input name="attr_insighttalent2" value="2" title="Attribute: insighttalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_insight_ability_mod" title="Select the attribute you want to use for Insight.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option selected value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Insight."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_insight" value="0" title="Attribute: insight" type="number" />
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div class="sheet-skills-column">
+              <div class="sheet-collapsible-skill sheet-investigate">
+                <input class="sheet-skill-color-setting" name="attr_investigate_ability_mod" type="hidden" value="SPATK" />
+                <button class="sheet-skill-roller" name="roll_investigatecheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{investigate_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + @{investigate_total} ]]}}">
+                  Investigate (<span name="attr_investigate_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_investigate_options_flag" type="checkbox" />
+                <span name="attr_investigate_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_investigatetalent1" value="2" title="Attribute: investigatetalent1" type="checkbox" />
+                    <input name="attr_investigatetalent2" value="2" title="Attribute: investigatetalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_investigate_ability_mod" title="Select the attribute you want to use for Investigate.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option selected value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Investigate."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_investigate" value="0" title="Attribute: investigate" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-medicine">
+                <input class="sheet-skill-color-setting" name="attr_medicine_ability_mod" type="hidden" value="SPATK" />
+                <button class="sheet-skill-roller" name="roll_medicinecheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{medicine_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + @{medicine_total} ]]}}">
+                  Medicine (<span name="attr_medicine_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_medicine_options_flag" type="checkbox" />
+                <span name="attr_medicine_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_medicinetalent1" value="2" title="Attribute: medicinetalent1" type="checkbox" />
+                    <input name="attr_medicinetalent2" value="2" title="Attribute: medicinetalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_medicine_ability_mod" title="Select the attribute you want to use for Medicine.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option selected value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Medicine."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_medicine" value="0" title="Attribute: medicine" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-nature">
+                <input class="sheet-skill-color-setting" name="attr_nature_ability_mod" type="hidden" value="SPATK" />
+                <button class="sheet-skill-roller" name="roll_naturecheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{nature_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + @{nature_total} ]]}}">
+                  Nature (<span name="attr_nature_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_nature_options_flag" type="checkbox" />
+                <span name="attr_nature_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_naturetalent1" value="2" title="Attribute: naturetalent1" type="checkbox" />
+                    <input name="attr_naturetalent2" value="2" title="Attribute: naturetalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_nature_ability_mod" title="Select the attribute you want to use for Nature.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option selected value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Nature."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_nature" value="0" title="Attribute: nature" type="number" />
+                  </span>
+                </div>
+              </div>
+                
+              <div class="sheet-collapsible-skill sheet-perception">
+                <input class="sheet-skill-color-setting" name="attr_perception_ability_mod" type="hidden" value="SPDEF" />
+                <button class="sheet-skill-roller" name="roll_perceptioncheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{perception_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + @{perception_total} ]]}}">
+                  Perception (<span name="attr_perception_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_perception_options_flag" type="checkbox" />
+                <span name="attr_perception_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_perceptiontalent1" value="2" title="Attribute: perceptiontalent1" type="checkbox" />
+                    <input name="attr_perceptiontalent2" value="2" title="Attribute: perceptiontalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_perception_ability_mod" title="Select the attribute you want to use for Perception.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option selected value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Perception."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_perception" value="0" title="Attribute: perception" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-perform">
+                <input class="sheet-skill-color-setting" name="attr_perform_ability_mod" type="hidden" value="SPDEF" />
+                <button class="sheet-skill-roller" name="roll_performcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{perform_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + @{perform_total} ]]}}">
+                  Perform (<span name="attr_perform_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_perform_options_flag" type="checkbox" />
+                <span name="attr_perform_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_performtalent1" value="2" title="Attribute: performtalent1" type="checkbox" />
+                    <input name="attr_performtalent2" value="2" title="Attribute: performtalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_perform_ability_mod" title="Select the attribute you want to use for Perform.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option selected value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Perform."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_perform" value="0" title="Attribute: perform" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-handling">
+                <input class="sheet-skill-color-setting" name="attr_handling_ability_mod" type="hidden" value="SPDEF" />
+                <button class="sheet-skill-roller" name="roll_handlingcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{handling_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokémon Handling}} {{skill-roll=[[ 1d20!kh2 + @{handling_total} ]]}}">
+                  Pokémon Handling (<span name="attr_handling_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_handling_options_flag" type="checkbox" />
+                <span name="attr_handling_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_handlingtalent1" value="2" title="Attribute: handlingtalent1" type="checkbox" />
+                    <input name="attr_handlingtalent2" value="2" title="Attribute: handlingtalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_handling_ability_mod" title="Select the attribute you want to use for Pokémon Handling.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option selected value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Pokémon Handling."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_handling" value="0" title="Attribute: handling" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-programming">
+                <input class="sheet-skill-color-setting" name="attr_programming_ability_mod" type="hidden" value="SPATK" />
+                <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{programming_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + @{programming_total} ]]}}">
+                  Programming (<span name="attr_programming_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_programming_options_flag" type="checkbox" />
+                <span name="attr_programming_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_programmingtalent1" value="2" title="Attribute: programmingtalent1" type="checkbox" />
+                    <input name="attr_programmingtalent2" value="2" title="Attribute: programmingtalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_programming_ability_mod" title="Select the attribute you want to use for Programming.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option selected value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Programming."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_programming" value="0" title="Attribute: programming" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-sleightofhand">
+                <input class="sheet-skill-color-setting" name="attr_sleightofhand_ability_mod" type="hidden" value="SPD" />
+                <button class="sheet-skill-roller" name="roll_sleightofhandcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{sleightofhand_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + @{sleightofhand_total} ]]}}">
+                  Sleight of Hand (<span name="attr_sleightofhand_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_sleightofhand_options_flag" type="checkbox" />
+                <span name="attr_sleightofhand_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_sleightofhandtalent1" value="2" title="Attribute: sleightofhandtalent1" type="checkbox" />
+                    <input name="attr_sleightofhandtalent2" value="2" title="Attribute: sleightofhandtalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_sleightofhand_ability_mod" title="Select the attribute you want to use for Sleight of Hand.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option selected value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Sleight of Hand."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_sleightofhand" value="0" title="Attribute: sleightofhand" type="number" />
+                  </span>
+                </div>
+              </div>
+
+              <div class="sheet-collapsible-skill sheet-stealth">
+                <input class="sheet-skill-color-setting" name="attr_stealth_ability_mod" type="hidden" value="SPD" />
+                <button class="sheet-skill-roller" name="roll_stealthcheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{stealth_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + @{stealth_total} ]]}}">
+                  Stealth (<span name="attr_stealth_ability_mod"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
+                <input checked class="sheet-options-flag" name="attr_stealth_options_flag" type="checkbox" />
+                <span name="attr_stealth_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Talents</b>
+                    <input name="attr_stealthtalent1" value="2" title="Attribute: stealthtalent1" type="checkbox" />
+                    <input name="attr_stealthtalent2" value="2" title="Attribute: stealthtalent2" type="checkbox" />
+                  </span>
+                  <span>
+                    <b>Base Attribute</b>
+                    <select class="sheet-no-dropdown" name="attr_stealth_ability_mod" title="Select the attribute you want to use for Stealth.">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option selected value="SPD">Speed</option>
+                    </select>
+                    <b class="sheet-info-tooltip" title="Select the attribute you want to use for Stealth."> ℹ </b>
+                  </span>
+                  <span>
+                    <b>Bonus</b>
+                    <input name="attr_stealth" value="0" title="Attribute: stealth" type="number" />
+                  </span>
+                </div>
+              </div>
+                
+            </div>
+          </div>
         </div>
-        <!-- Mobile version -->
-        <div class="sheet-capture-pokemon-skill-m1 sheet-tab-trainer sheet-show-on-mobile">
-          <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
-          <input class="sheet-skill-total" name="attr_capture_total" readonly title="The value added to your skill check to hit a Pokémon with a Pokéball. Note - this can be ignored if the target Pokémon is at or below half of their max HP.
-          Attribute: capture_total" type="number" />
-          <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
-            value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=spd}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + @{capture_roll_bonus} ]] }}">
-            Capture Pokémon (<span name="attr_capture_ability_mod"></span>)
-          </button>
-          <input name="attr_capture_roll_bonus" title="Use this field to assign a static modifier to your capture rolls - things like a Capture Specialist's Capture Point feature.
-          Attribute: capture_roll_bonus" type="number" value="0" />
-          <input name="attr_capture_default_custom_modifier" type="hidden" value="0" />
+        
+        <div class="sheet-tab-pokemon sheet-tab-hybrid">
+          <div class="sheet-character-skill-labels">
+            <b>Total</b>
+            <b>Skill Name</b>
+            <b>Talent</b>
+            <b>Bonus</b>
+            <b class="sheet-hide-on-mobile">Total</b>
+            <b class="sheet-hide-on-mobile">Skill Name</b>
+            <b class="sheet-hide-on-mobile">Talent</b>
+            <b class="sheet-hide-on-mobile">Bonus</b>
+          </div>
+    
+          <div class="sheet-two-columns">
+            <div class="sheet-character-skills">
+              <input class="sheet-skill-color-setting" name="attr_acrobatics_ability_mod" type="hidden" value="SPD" />
+              <input class="sheet-skill-total" name="attr_acrobatics_total" readonly title="Attribute: acrobatics_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_acrobaticscheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{acrobatics_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Acrobatics}} {{skill-roll=[[ 1d20!kh2 + [[ @{acrobatics_total} ]] ]]}}">
+                Acrobatics (<span name="attr_acrobatics_ability_mod"></span>)
+              </button>
+              <input name="attr_acrobaticstalent1" value="2" title="Attribute: acrobaticstalent1" type="checkbox" />
+              <input name="attr_acrobaticstalent2" value="2" title="Attribute: acrobaticstalent2" type="checkbox" />
+              <input name="attr_acrobatics" value="0" title="Attribute: acrobatics" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_athletics_ability_mod" type="hidden" value="ATK" />
+              <input class="sheet-skill-total" name="attr_athletics_total" readonly title="Attribute: athletics_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_athleticscheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{athletics_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Athletics}} {{skill-roll=[[ 1d20!kh2 + [[ @{athletics_total} ]] ]]}}">
+                Athletics (<span name="attr_athletics_ability_mod"></span>)
+              </button>
+              <input name="attr_athleticstalent1" value="2" title="Attribute: athleticstalent1" type="checkbox" />
+              <input name="attr_athleticstalent2" value="2" title="Attribute: athleticstalent2" type="checkbox" />
+              <input name="attr_athletics" value="0" title="Attribute: athletics" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_bluff_ability_mod" type="hidden" value="SPDEF" />
+              <input class="sheet-skill-total" name="attr_bluff_total" readonly title="Attribute: bluff_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_bluffcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{bluff_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Bluff/Deception}} {{skill-roll=[[ 1d20!kh2 + [[ @{bluff_total} ]] ]]}}">
+                Bluff/Deception (<span name="attr_bluff_ability_mod"></span>)
+              </button>
+              <input name="attr_blufftalent1" value="2" title="Attribute: blufftalent1" type="checkbox" />
+              <input name="attr_blufftalent2" value="2" title="Attribute: blufftalent2" type="checkbox" />
+              <input name="attr_bluff" value="0" title="Attribute: bluff" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_concentration_ability_mod" type="hidden" value="DEF" />
+              <input class="sheet-skill-total" name="attr_concentration_total" readonly title="Attribute: concentration_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_concentrationcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{concentration_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Concentration}} {{skill-roll=[[ 1d20!kh2 + [[ @{concentration_total} ]] ]]}}">
+                Concentration (<span name="attr_concentration_ability_mod"></span>)
+              </button>
+              <input name="attr_concentrationtalent1" value="2" title="Attribute: concentrationtalent1" type="checkbox" />
+              <input name="attr_concentrationtalent2" value="2" title="Attribute: concentrationtalent2" type="checkbox" />
+              <input name="attr_concentration" value="0" title="Attribute: concentration" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_constitution_ability_mod" type="hidden" value="DEF" />
+              <input class="sheet-skill-total" name="attr_constitution_total" readonly title="Attribute: constitution_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_constitutioncheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{constitution_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Constitution}} {{skill-roll=[[ 1d20!kh2 + [[ @{constitution_total} ]] ]]}}">
+                Constitution (<span name="attr_constitution_ability_mod"></span>)
+              </button>
+              <input name="attr_constitutiontalent1" value="2" title="Attribute: constitutiontalent1" type="checkbox" />
+              <input name="attr_constitutiontalent2" value="2" title="Attribute: constitutiontalent2" type="checkbox" />
+              <input name="attr_constitution" value="0" title="Attribute: constitution" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_diplomacy_ability_mod" type="hidden" value="SPDEF" />
+              <input class="sheet-skill-total" name="attr_diplomacy_total" readonly title="Attribute: diplomacy_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_diplomacycheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{diplomacy_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Diplomacy/Persuasion}} {{skill-roll=[[ 1d20!kh2 + [[ @{diplomacy_total} ]] ]]}}">
+                Diplomacy/Persuasion (<span name="attr_diplomacy_ability_mod"></span>)
+              </button>
+              <input name="attr_diplomacytalent1" value="2" title="Attribute: diplomacytalent1" type="checkbox" />
+              <input name="attr_diplomacytalent2" value="2" title="Attribute: diplomacytalent2" type="checkbox" />
+              <input name="attr_diplomacy" value="0" title="Attribute: diplomacy" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_engineering_ability_mod" type="hidden" value="SPATK" />
+              <input class="sheet-skill-total" name="attr_engineering_total" readonly title="Attribute: engineering_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_engineeringcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{engineering_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Engineering/Operation}} {{skill-roll=[[ 1d20!kh2 + [[ @{engineering_total} ]] ]]}}">
+                Engineering/Operation (<span name="attr_engineering_ability_mod"></span>)
+              </button>
+              <input name="attr_engineeringtalent1" value="2" title="Attribute: engineeringtalent1" type="checkbox" />
+              <input name="attr_engineeringtalent2" value="2" title="Attribute: engineeringtalent2" type="checkbox" />
+              <input name="attr_engineering" value="0" title="Attribute: engineering" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_history_ability_mod" type="hidden" value="SPATK" />
+              <input class="sheet-skill-total" name="attr_history_total" readonly title="Attribute: history_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_historycheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{history_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=History}} {{skill-roll=[[ 1d20!kh2 + [[ @{history_total} ]] ]]}}">
+                History (<span name="attr_history_ability_mod"></span>)
+              </button>
+              <input name="attr_historytalent1" value="2" title="Attribute: historytalent1" type="checkbox" />
+              <input name="attr_historytalent2" value="2" title="Attribute: historytalent2" type="checkbox" />
+              <input name="attr_history" value="0" title="Attribute: history" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_insight_ability_mod" type="hidden" value="SPDEF" />
+              <input class="sheet-skill-total" name="attr_insight_total" readonly title="Attribute: insight_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_insightcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{insight_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Insight}} {{skill-roll=[[ 1d20!kh2 + [[ @{insight_total} ]] ]]}}">
+                Insight (<span name="attr_insight_ability_mod"></span>)
+              </button>
+              <input name="attr_insighttalent1" value="2" title="Attribute: insighttalent1" type="checkbox" />
+              <input name="attr_insighttalent2" value="2" title="Attribute: insighttalent2" type="checkbox" />
+              <input name="attr_insight" value="0" title="Attribute: insight" type="number" />
+            </div>
+
+            <div class="sheet-character-skills">
+              <input class="sheet-skill-color-setting" name="attr_investigate_ability_mod" type="hidden" value="SPATK" />
+              <input class="sheet-skill-total" name="attr_investigate_total" readonly title="Attribute: investigate_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_investigatecheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{investigate_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Investigate}} {{skill-roll=[[ 1d20!kh2 + [[ @{investigate_total} ]] ]]}}">
+                Investigate (<span name="attr_investigate_ability_mod"></span>)
+              </button>
+              <input name="attr_investigatetalent1" value="2" title="Attribute: investigatetalent1" type="checkbox" />
+              <input name="attr_investigatetalent2" value="2" title="Attribute: investigatetalent2" type="checkbox" />
+              <input name="attr_investigate" value="0" title="Attribute: investigate" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_medicine_ability_mod" type="hidden" value="SPATK" />
+              <input class="sheet-skill-total" name="attr_medicine_total" readonly title="Attribute: medicine_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_medicinecheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{medicine_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Medicine}} {{skill-roll=[[ 1d20!kh2 + [[ @{medicine_total} ]] ]]}}">
+                Medicine (<span name="attr_medicine_ability_mod"></span>)
+              </button>
+              <input name="attr_medicinetalent1" value="2" title="Attribute: medicinetalent1" type="checkbox" />
+              <input name="attr_medicinetalent2" value="2" title="Attribute: medicinetalent2" type="checkbox" />
+              <input name="attr_medicine" value="0" title="Attribute: medicine" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_nature_ability_mod" type="hidden" value="SPATK" />
+              <input class="sheet-skill-total" name="attr_nature_total" readonly title="Attribute: nature_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_naturecheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{nature_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Nature}} {{skill-roll=[[ 1d20!kh2 + [[ @{nature_total} ]] ]]}}">
+                Nature (<span name="attr_nature_ability_mod"></span>)
+              </button>
+              <input name="attr_naturetalent1" value="2" title="Attribute: naturetalent1" type="checkbox" />
+              <input name="attr_naturetalent2" value="2" title="Attribute: naturetalent2" type="checkbox" />
+              <input name="attr_nature" value="0" title="Attribute: nature" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_perception_ability_mod" type="hidden" value="SPDEF" />
+              <input class="sheet-skill-total" name="attr_perception_total" readonly title="Attribute: perception_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_perceptioncheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{perception_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perception}} {{skill-roll=[[ 1d20!kh2 + [[ @{perception_total} ]] ]]}}">
+                Perception (<span name="attr_perception_ability_mod"></span>)
+              </button>
+              <input name="attr_perceptiontalent1" value="2" title="Attribute: perceptiontalent1" type="checkbox" />
+              <input name="attr_perceptiontalent2" value="2" title="Attribute: perceptiontalent2" type="checkbox" />
+              <input name="attr_perception" value="0" title="Attribute: perception" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_perform_ability_mod" type="hidden" value="SPDEF" />
+              <input class="sheet-skill-total" name="attr_perform_total" readonly title="Attribute: perform_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_performcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{perform_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Perform}} {{skill-roll=[[ 1d20!kh2 + [[ @{perform_total} ]] ]]}}">
+                Perform (<span name="attr_perform_ability_mod"></span>)
+              </button>
+              <input name="attr_performtalent1" value="2" title="Attribute: performtalent1" type="checkbox" />
+              <input name="attr_performtalent2" value="2" title="Attribute: performtalent2" type="checkbox" />
+              <input name="attr_perform" value="0" title="Attribute: perform" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_handling_ability_mod" type="hidden" value="SPDEF" />
+              <input class="sheet-skill-total" name="attr_handling_total" readonly title="Attribute: handling_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_handlingcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{handling_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Pokemon Handling}} {{skill-roll=[[ 1d20!kh2 + [[ @{handling_total} ]] ]]}}">
+                Pokémon Handling (<span name="attr_handling_ability_mod"></span>)
+              </button>
+              <input name="attr_handlingtalent1" value="2" title="Attribute: handlingtalent1" type="checkbox" />
+              <input name="attr_handlingtalent2" value="2" title="Attribute: handlingtalent2" type="checkbox" />
+              <input name="attr_handling" value="0" title="Attribute: handling" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_programming_ability_mod" type="hidden" value="SPATK" />
+              <input class="sheet-skill-total" name="attr_programming_total" readonly title="Attribute: programming_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_programmingcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{programming_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Programming}} {{skill-roll=[[ 1d20!kh2 + [[ @{programming_total} ]] ]]}}">
+                Programming (<span name="attr_programming_ability_mod"></span>)
+              </button>
+              <input name="attr_programmingtalent1" value="2" title="Attribute: programmingtalent1" type="checkbox" />
+              <input name="attr_programmingtalent2" value="2" title="Attribute: programmingtalent2" type="checkbox" />
+              <input name="attr_programming" value="0" title="Attribute: programming" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_sleight_ability_mod" type="hidden" value="SPD" />
+              <input class="sheet-skill-total" name="attr_sleightofhand_total" readonly title="Attribute: sleightofhand_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_sleightofhandcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{sleight_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Sleight of Hand}} {{skill-roll=[[ 1d20!kh2 + [[ @{sleightofhand_total} ]] ]]}}">
+                Sleight of Hand (<span name="attr_sleight_ability_mod"></span>)
+              </button>
+              <input name="attr_sleightofhandtalent1" value="2" title="Attribute: sleightofhandtalent1" type="checkbox" />
+              <input name="attr_sleightofhandtalent2" value="2" title="Attribute: sleightofhandtalent2" type="checkbox" />
+              <input name="attr_sleightofhand" value="0" title="Attribute: sleightofhand" type="number" />
+
+              <input class="sheet-skill-color-setting" name="attr_stealth_ability_mod" type="hidden" value="SPD" />
+              <input class="sheet-skill-total" name="attr_stealth_total" readonly title="Attribute: stealth_total" type="number" />
+              <button class="sheet-skill-roller" name="roll_stealthcheck" type="roll"
+                value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{stealth_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Stealth}} {{skill-roll=[[ 1d20!kh2 + [[ @{stealth_total} ]] ]]}}">
+                Stealth (<span name="attr_stealth_ability_mod"></span>)
+              </button>
+              <input name="attr_stealthtalent1" value="2" title="Attribute: stealthtalent1" type="checkbox" />
+              <input name="attr_stealthtalent2" value="2" title="Attribute: stealthtalent2" type="checkbox" />
+              <input name="attr_stealth" value="0" title="Attribute: stealth" type="number" />
+            </div>
+          </div>
         </div>
-        <div class="sheet-capture-pokemon-skill-m2 sheet-tab-trainer sheet-show-on-mobile">
-          <select class="sheet-ball-picker" name="attr_ball_capture_modifier" title="Select which Pokéball you want to use - this presumes the benefit is applied for conditional balls such as Quick Ball.
-          Attribute: ball_capture_modifier">
-            <option value="+5" selected>Basic Ball</option>
-            <option value="+0">Great Ball</option>
-            <option value="-5">Ultra Ball</option>
-            <option value="-20">Park Ball</option>
-            <option value="-20">Safari Ball</option>
-            <option value="-20">Sport Ball</option>
-            <option value="-5">Cherish Ball</option>
-            <option value="-5">Luxury Ball</option>
-            <option value="-5">Premier Ball</option>
-            <option value="-12">Dive Ball</option>
-            <option value="-7">Dusk Ball</option>
-            <option value="-8">Fast Ball</option>
-            <option value="-10">Lure Ball</option>
-            <option value="-20">Quick Ball</option>
-            <option value="-10">Repeat Ball</option>
-            <option value="-10">1m Timer Ball</option>
-            <option value="-25">2m Timer Ball</option>
-            <option value="+0">Friend Ball</option>
-            <option value="+0">Heal Ball</option>
-            <option value="-10">Dream Ball</option>
-            <option value="-15">Heavy Ball</option>
-            <option value="-10">Level Ball</option>
-            <option value="-10">Love Ball</option>
-            <option value="-10">Moon Ball</option>
-            <option value="-10">Nest Ball</option>
-            <option value="-15">Type Ball</option>
-            <option value="-12">Terrain Ball</option>
-            <option value="-10">Save Ball</option>
-            <option value="-100">Master Ball</option>
-            <option value="+ ?{Custom Ball Modifier|@{capture_default_custom_modifier}}">Custom Ball</option>
-          </select>
-          <span title="The modifier applied to your capture rolls because of your selected Pokéball. This value can be configured for custom balls in the Configuration page.
-          Attribute: capture_display">
-            <b>Ball Mod:</b>
-            <input class="sheet-total-display sheet-tiny-number" name="attr_capture_display" readonly type="text" />
-          </span>
-          <span title="The total modifier applied to your d100 capture rolls. If an asterisk * is shown, that means you've selected a custom ball. Attribute: capture_roll_total">
-            <b>Total:</b>
-            <input class="sheet-skill-total sheet-total-display sheet-tiny-number" name="attr_capture_roll_total" readonly type="text" />
-          </span>
+        
+        <!-- CAPTURE POKEMON -->
+    
+        <div class="sheet-tab-trainer">
+          <div>
+            <hr class="sheet-skill-separator" />
+              <div class="sheet-collapsible-skill sheet-capture">
+                <input name="attr_capture_skill_roll" type="hidden" value="[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} [@{selected_ball}] + @{capture_roll_bonus} ]]" />
+                <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
+                <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
+                  value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{capture_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=@{capture_skill_roll}}}">
+                  Capture Pokémon (<span name="attr_selected_ball"></span>)
+                </button>
+                <input class="sheet-skill-total" name="attr_capture_roll_total" readonly title="Attribute: capture_roll_total" type="number" />
+                <input class="sheet-options-flag" name="attr_capture_options_flag" type="checkbox" />
+                <span name="attr_capture_flag">y</span>
+                <div class="sheet-options">
+                  <span>
+                    <b>Selected Ball:</b>
+                    <select class="sheet-ball-picker" name="attr_selected_ball" title="Select which Pokéball you want to use - this presumes the benefit is applied for conditional balls such as Quick Ball.
+                    Attribute: selected_ball">
+                      <option>Basic Ball</option>
+                      <option>Great Ball</option>
+                      <option>Ultra Ball</option>
+                      <option>Park Ball</option>
+                      <option>Safari Ball</option>
+                      <option>Sport Ball</option>
+                      <option>Cherish Ball</option>
+                      <option>Luxury Ball</option>
+                      <option>Premier Ball</option>
+                      <option>Dive Ball</option>
+                      <option>Dusk Ball</option>
+                      <option>Fast Ball</option>
+                      <option>Lure Ball</option>
+                      <option>Quick Ball</option>
+                      <option>Repeat Ball</option>
+                      <option>1min Timer Ball</option>
+                      <option>2min Timer Ball</option>
+                      <option>Friend Ball</option>
+                      <option>Heal Ball</option>
+                      <option>Dream Ball</option>
+                      <option>Heavy Ball</option>
+                      <option>Level Ball</option>
+                      <option>Love Ball</option>
+                      <option>Moon Ball</option>
+                      <option>Nest Ball</option>
+                      <option>Type Ball</option>
+                      <option>Terrain Ball</option>
+                      <option>Save Ball</option>
+                      <option>Master Ball</option>
+                      <option>Custom Ball</option>
+                    </select>
+                    <span title="The modifier applied to your capture rolls because of your selected Pokéball. This value can be configured for custom balls in the Configuration page.
+                    Attribute: capture_display">
+                      <b>Modifier:</b>
+                      <input class="sheet-total-display" name="attr_capture_display" readonly type="text" />
+                    </span>
+                  </span>
+                  <span title="Use this field to assign a static modifier to your capture rolls - things like a Capture Specialist's Capture Point feature.
+              Attribute: capture_roll_bonus">
+                    <b>Capture Bonus:</b>
+                    <input name="attr_capture_roll_bonus" title="Use this field to assign a static modifier to your capture rolls - things like a Capture Specialist's Capture Point feature.
+                    Attribute: capture_roll_bonus" type="number" value="0" />
+                  </span>
+                  <span title="Select the attribute you want to use for Capture Pokémon.">
+                    <b>Accuracy Attribute</b>
+                    <select name="attr_capture_ability_mod">
+                      <option value="ATK">Attack</option>
+                      <option value="DEF">Defense</option>
+                      <option value="SPATK">Special Attack</option>
+                      <option value="SPDEF">Special Defense</option>
+                      <option selected value="SPD">Speed</option>
+                    </select>
+                  </span>
+                  <span title="Controls whether the skill check to hit a pokémon is made.
+                  Attribute: capture_skill_roll_flag">
+                    <b>Make skill check:</b>
+                    <input checked name="attr_capture_skill_roll_flag" type="checkbox" />
+                  </span>
+                </div>
+              </div>
+          </div>
         </div>
+
       </div>
     </div>
     <br />
@@ -1665,45 +2279,6 @@ Table of Contents:
           <br />For best results, leave this as something you can add to a die-roll.
         </p>
       </div>
-      <div class="sheet-skill-modifier-selection">
-        <b>Skill Modifier Selection</b>
-        <div class="sheet-skill-selection">
-          <select class="sheet-no-dropdown" name="attr_skill_modifier_selection" title="Select the skill you want to modify">
-            <option selected value="acrobatics">Acrobatics</option>
-            <option value="athletics">Athletics</option>
-            <option value="bluff">Bluff/Deception</option>
-            <option value="concentration">Concentration</option>
-            <option value="constitution">Constitution</option>
-            <option value="diplomacy">Diplomacy/Persuasion</option>
-            <option value="engineering">Engineering/Operation</option>
-            <option value="history">History</option>
-            <option value="insight">Insight</option>
-            <option value="investigate">Investigate</option>
-            <option value="medicine">Medicine</option>
-            <option value="nature">Nature</option>
-            <option value="perception">Perception</option>
-            <option value="perform">Perform</option>
-            <option value="handling">Pokémon Handling</option>
-            <option value="programming">Programming</option>
-            <option value="sleight">Sleight of Hand</option>
-            <option value="stealth">Stealth</option>
-            <option value="capture">Capture Pokémon</option>
-          </select>
-          <b class="sheet-info-tooltip" title="Select the skill you want to modify"> ℹ </b>
-          <select class="sheet-no-dropdown" name="attr_skill_modifier_ability" title="Select the attribute you want to use for the selected skill.">
-            <option value="ATK">Attack</option>
-            <option value="DEF">Defense</option>
-            <option value="SPATK">Special Attack</option>
-            <option value="SPDEF">Special Defense</option>
-            <option selected value="SPD">Speed</option>
-          </select>
-          <b class="sheet-info-tooltip" title="Select the attribute you want to use for the selected skill."> ℹ </b>
-        </div>
-        <p class="sheet-dark-text">
-          This setting allows you to change the stat each skill is associated with. Select the skill you want to modify with the left
-          field, and then assign the stat you want to use with the right field. Use this for features like the Ninja's "Ninjutsu".
-        </p>
-      </div>
       <div class="sheet-custom-ball-default-selecton">
         <b title="Default value: 0">Custom Ball Default:</b>
         <b class="sheet-info-tooltip" title="Default value: 0"> ℹ </b>
@@ -1712,6 +2287,7 @@ Table of Contents:
           This setting allows you to specify a default modifier to be used for the Custom Ball when capturing pokémon. You can use an attribute for this value.
         </p>
       </div>
+      <div class="sheet-placeholder"></div>
       <div class="sheet-json-import">
         <b>Character Data Import</b>
         <p class="sheet-dark-text">
@@ -3949,6 +4525,20 @@ Table of Contents:
     recalculateStat("spd");
   });
 
+  on("change:character-type", function(eventInfo) {
+    switch (eventInfo.newValue) {
+      case eventInfo.previousValue:
+        break;
+      default:
+        recalculateStat("atk");
+        recalculateStat("def");
+        recalculateStat("spatk");
+        recalculateStat("spdef");
+        recalculateStat("spd");
+        break;
+    }
+  });
+
   function recalculateStat(abilityPrefix) {
     const ability = abilityPrefix.toUpperCase();
     const baseStat = `${abilityPrefix}base`;
@@ -3958,7 +4548,7 @@ Table of Contents:
     getAttrs([ability, baseStat, natureStat, bonusStat, formStat, "character-type", "movebonus", "Burned", "Poisoned", "Toxified", "Paralyzed", "dyna_active"], function(values) {
       let baseValue = parseInt(values[baseStat]) || 0;
       if(baseValue == 0) return; // Needed to avoid wiping out old data too quickly
-      let natureValue = parseInt(values[natureStat]) || 0;
+      let natureValue = values["character-type"] != "trainer" ? parseInt(values[natureStat]) || 0 : 0;
       let bonusValue = parseInt(values[bonusStat]) || 0;
       let formValue = parseInt(values[formStat]) || 0;
       let totalValue = baseValue + natureValue + bonusValue + formValue;
@@ -4508,35 +5098,109 @@ Table of Contents:
     });
   });
 
-  on("change:ball_capture_modifier change:capture_roll_bonus sheet:opened", function () {
-    getAttrs(["ball_capture_modifier", "capture_default_custom_modifier", "capture_roll_bonus"], function (values) {
+  on("change:ball_capture_modifier change:capture_roll_bonus change:selected_ball sheet:opened", function () {
+    getAttrs(["ball_capture_modifier", "capture_default_custom_modifier", "capture_roll_bonus", "capture_skill_roll_flag", "selected_ball"], function (values) {
 
+      let selectedBallModifier;
+      switch (values.selected_ball) {
+        case "Basic Ball":
+          selectedBallModifier = "5";
+          break;
+        case "Cherish Ball":
+        case "Luxury Ball":
+        case "Premier Ball":
+        case "Ultra Ball":
+          selectedBallModifier = "-5";
+          break;
+        case "Dusk Ball":
+          selectedBallModifier = "-7";
+          break;
+        case "Fast Ball":
+          selectedBallModifier = "-8";
+          break;
+        case "Dream Ball":
+        case "Level Ball":
+        case "Love Ball":
+        case "Moon Ball":
+        case "Nest Ball":
+        case "Save Ball":
+        case "Lure Ball":
+        case "Repeat Ball":
+        case "1min Timer Ball":
+          selectedBallModifier = "-10";
+          break;
+        case "Dive Ball":
+        case "Terrain Ball":
+          selectedBallModifier = "-12";
+          break;
+        case "Heavy Ball":
+        case "Type Ball":
+          selectedBallModifier = "-15";
+          break;
+        case "Park Ball":
+        case "Quick Ball":
+        case "Safari Ball":
+        case "Sport Ball":
+          selectedBallModifier = "-20";
+          break;
+        case "2min Timer Ball":
+          selectedBallModifier = "-25";
+          break;
+        case "Master Ball":
+          selectedBallModifier = "-100";
+          break;
+        case "Custom Ball":
+          selectedBallModifier = "+ ?{Custom Ball Modifier|@{capture_default_custom_modifier}}";
+          break;
+        case "Friend Ball":
+        case "Great Ball":
+        case "Heal Ball":
+        default:
+          selectedBallModifier = "0";
+      }
+
+      const showSkillRoll = `[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} [${values.selected_ball}}] + @{capture_roll_bonus} ]]`;
+      const skipSkillRoll = `[[ d100 @{ball_capture_modifier} [${values.selected_ball}] + @{capture_roll_bonus} ]]`;
+      const skillRoll = values.capture_skill_roll_flag == "on" ? showSkillRoll : skipSkillRoll;
       const ball = values.ball_capture_modifier;
       const bonus = parseInt(values.capture_roll_bonus) || 0;
 
       let display;
       let isCustomPokeball = false;
-      if (ball.includes("Custom")) {
+      if (selectedBallModifier.includes("Custom")) {
         display = values.capture_default_custom_modifier;
         isCustomPokeball = true;
       } else {
-         display = ball;
+         display = selectedBallModifier;
       }
       
       let total = bonus;
-      if (isCustomPokeball) {
+      if (isCustomPokeball && isNaN(values.capture_default_custom_modifier)) {
         total = `${total}*`;
       } else {
-        total += parseInt(display) || 0;
+        total += parseInt(display);
       }
     
       setAttrs({
+        "ball_capture_modifier": selectedBallModifier,
         "capture_display": display,
-        "capture_roll_total": total
+        "capture_roll_total": total,
+        "capture_skill_roll": skillRoll
       });
     });
   });
 
+  on("change:capture_skill_roll_flag", function (eventInfo) {
+    getAttrs(["selected_ball"], function(values) {
+      const flag = eventInfo.newValue;
+      const showSkillRoll = `[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} [${values.selected_ball}] + @{capture_roll_bonus} ]]`;
+      const skipSkillRoll = `[[ d100 @{ball_capture_modifier} [${values.selected_ball}] + @{capture_roll_bonus} ]]`;
+      const skillRoll = flag == "on" ? showSkillRoll : skipSkillRoll;
+      setAttrs({ "capture_skill_roll": skillRoll });
+    });
+  });
+  
+  // Skill Functions
   function getSkillAttributes(statLabel, talent1Label, talent2Label, userBonusLabel, totalLabel) {
     getAttrs([statLabel, talent1Label, talent2Label, totalLabel, userBonusLabel], function (attributes) {
       const stat = parseInt(attributes[statLabel]) || 0;
@@ -4597,6 +5261,10 @@ Table of Contents:
 
   on("change:origin_options_flag", function (eventInfo) {
     updateFlagAttr("origin_flag", eventInfo.newValue);
+  });
+
+  on("change:origin_skills_options_flag", function (eventInfo) {
+    updateFlagAttr("skills_flag", eventInfo.newValue);
   });
 
   on("change:origin_feature_options_flag", function (eventInfo) {

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,6 +23,12 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Jul 14, 2025
+- Added a collapsing section for skills
+- Fixed an issue where pokémon nature would affect trainer stats
+- Updated skill and capture pokémon visuals, for trainers only (for now)
+- Removed now-unneeded configuration page entry for skill attribute selection
+
 ### Jun 28, 2025
 - Reinstated 1/combat frequency option to accommodate homebrew
 


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.


# Changes / Description

- Adds collapsible section for skills
- Adds collapsible skills
  - Adds collapsing functionality to skills section as a whole
  - Adds new design for the skills in the trainer sheet
    - Adds collapsing functionality to individual skills
    - Consolidates individual skill configuration into the character page
  - Fixes bug with skills not updating the roll template colour based on the attribute selected to roll for that skill
- Updates capture pokemon to new skill visuals
  - Updates visuals of the capture pokemon field to match the new skill visuals
  - Updates configuration of the capture pokemon field to surface the selected pokeball name
  - Displays the selected pokeball in the capture pokemon button to indicate which is used when collapsed
  - Updates the calculation of the modifier to parse in the custom ball value if the default is a number
  - Updates the total field to indicate the current total capture modifier instead of the skill bonus
  - Adds a configuration option to not make the skill roll to hit a target pokémon
  - Adds the selected ball to the capture roll title for easy checking after an attempt is thrown
- Removes the now-unnecessary skill attribute selection from the configuration page
- Resolves bug with trainer stats and natures
  - Resolves a bug where trainer stats would be affected by a selected nature if the character sheet has any pokémon configuration
  - Adds a sheet-worker to recalculate the stats when the character-type is changed

