### PR TITLE
[PokemonTabletopAdventures_v3] Bugfix: Correctly adds all ball modifiers

### DIFF
--- a/PokemonTabletopAdventures_v3/PTA3.html
+++ b/PokemonTabletopAdventures_v3/PTA3.html
@@ -1458,7 +1458,7 @@
           <div>
             <hr class="sheet-skill-separator" />
               <div class="sheet-collapsible-skill sheet-capture">
-                <input name="attr_capture_skill_roll" type="hidden" value="[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} [@{selected_ball}] + @{capture_roll_bonus} ]]" />
+                <input name="attr_capture_skill_roll" type="hidden" value="[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} + [@{selected_ball}] + @{capture_roll_bonus} ]]" />
                 <input class="sheet-skill-color-setting" name="attr_capture_ability_mod" type="hidden" value="SPD" />
                 <button class="sheet-skill-roller" name="roll_capturecheck" type="roll"
                   value="@{publicity_roll} &{template:@{skill_template}} {{base-attribute=@{capture_ability_mod}}} {{character-id=@{character_id}}} {{character-name=@{character_name}}} {{skill-name=Capture Pokémon}} {{skill-roll=@{capture_skill_roll}}}">
@@ -5052,8 +5052,8 @@ const skillOptionsFlags = [
           selectedBallModifier = "0";
       }
 
-      const showSkillRoll = `[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 @{ball_capture_modifier} [${values.selected_ball}}] + @{capture_roll_bonus} ]]`;
-      const skipSkillRoll = `[[ d100 @{ball_capture_modifier} [${values.selected_ball}] + @{capture_roll_bonus} ]]`;
+      const showSkillRoll = `[[ 1d20 + @{capture_total} ]] Capture Roll: [[ d100 + @{ball_capture_modifier} [${values.selected_ball}}] + @{capture_roll_bonus} ]]`;
+      const skipSkillRoll = `[[ d100 + @{ball_capture_modifier} [${values.selected_ball}] + @{capture_roll_bonus} ]]`;
       const skillRoll = values.capture_skill_roll_flag == "on" ? showSkillRoll : skipSkillRoll;
       const ball = values.ball_capture_modifier;
       const bonus = parseInt(values.capture_roll_bonus) || 0;

--- a/PokemonTabletopAdventures_v3/README.md
+++ b/PokemonTabletopAdventures_v3/README.md
@@ -23,6 +23,9 @@ Things we want to add to the character sheet, presented in no particular order o
 
 ## Changelog
 
+### Aug 16, 2025
+- Resolved an issue with capture rolls not adding all ball modifiers correctly
+
 ### Jul 26, 2025
 - Resolved a few niggling issue with skills
   - Sleight of Hand had a mismatch in attribute name for the selected ability modifier


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

- Ensures the ball capture modifier is added to the d100 roll every time