### PR TITLE
Update Shadowdark-Unofficial sheet to add option for Auto Roll Damage and make repeater forms into dialogs and fix typos

### DIFF
--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.css
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.css
@@ -57,6 +57,12 @@ input::placeholder {
   flex: 1 0 50%;
 }
 
+.sheet-sd .sheet-form-body textarea.attr_atk_desc {
+  height: 200px;
+  min-height: 80px;
+  max-height: 300px;
+}
+
 .sd-row {
   display: flex;
   flex-direction: row;
@@ -208,6 +214,33 @@ input::placeholder {
   background-color: darkred;
   color: #eee;
   background-image: linear-gradient(to left, rgba(31, 31, 31, 1), rgba(31, 31, 31, 0));
+}
+
+.sheet-sd .sheet-form-body h1 {
+  background-color: transparent;
+  font-size: 16px;
+  line-height: 20px;
+  margin: 0;
+  background-image: none;
+  color: #222;
+  padding-left: 0;
+}
+
+.sheet-darkmode .sheet-sd .sheet-form-body h1 {
+  color: #eee;
+}
+
+.charsheet .sheet-sd .sheet-form-body button[type=roll] {
+  font-size: 16px;
+  border-radius: 4px;
+  border: 1px solid green;
+  background-color: rgba(0, 50, 10, 0.5);
+  padding: 2px 16px;
+}
+
+.charsheet .sheet-sd .sheet-form-body button[type=roll]:hover,
+.charsheet .sheet-sd .sheet-form-body button[type=roll]:active {
+  background-color: rgba(0, 200, 20, 0.5);
 }
 
 /* fields */
@@ -418,6 +451,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk,
+.sheet-rolltemplate-atkdmg,
 .sheet-rolltemplate-dmg,
 .sheet-rolltemplate-simple,
 .sheet-rolltemplate-traits {
@@ -429,6 +463,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .sheet-char-name,
+.sheet-rolltemplate-atkdmg .sheet-char-name,
 .sheet-rolltemplate-dmg .sheet-char-name,
 .sheet-rolltemplate-simple .sheet-char-name,
 .sheet-rolltemplate-traits .sheet-char-name {
@@ -440,6 +475,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .sheet-info,
+.sheet-rolltemplate-atkdmg .sheet-info,
 .sheet-rolltemplate-dmg .sheet-info,
 .sheet-rolltemplate-simple .sheet-info,
 .sheet-rolltemplate-traits .sheet-info {
@@ -448,6 +484,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .sheet-label,
+.sheet-rolltemplate-atkdmg .sheet-label,
 .sheet-rolltemplate-dmg .sheet-label,
 .sheet-rolltemplate-simple .sheet-label,
 .sheet-rolltemplate-traits .sheet-label {
@@ -455,18 +492,21 @@ label.sheet-form-checkbox {
   color: #000;
 }
 
-.sheet-rolltemplate-atk .sheet-label a {
+.sheet-rolltemplate-atk .sheet-label a, 
+.sheet-rolltemplate-atkdmg .sheet-label a {
   background-color: #fff;
   color: #000;
   font-weight: bold;
   text-transform: uppercase;
 }
 
-.sheet-rolltemplate-atk .sheet-label a:hover {
+.sheet-rolltemplate-atk .sheet-label a:hover,
+.sheet-rolltemplate-atkdmg .sheet-label a:hover {
   text-decoration: underline;
 }
 
 .sheet-rolltemplate-atk .sheet-roll-name,
+.sheet-rolltemplate-atkdmg .sheet-roll-name,
 .sheet-rolltemplate-dmg .sheet-roll-name,
 .sheet-rolltemplate-simple .sheet-roll-name,
 .sheet-rolltemplate-traits .sheet-trait-name {
@@ -483,6 +523,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .sheet-result,
+.sheet-rolltemplate-atkdmg .sheet-result,
 .sheet-rolltemplate-dmg .sheet-result,
 .sheet-rolltemplate-simple .sheet-result {
   text-align: center;
@@ -492,6 +533,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .sheet-result div,
+.sheet-rolltemplate-atkdmg .sheet-result div,
 .sheet-rolltemplate-dmg .sheet-result div,
 .sheet-rolltemplate-simple .sheet-result div {
   display: inline-block;
@@ -506,6 +548,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .inlinerollresult,
+.sheet-rolltemplate-atkdmg .inlinerollresult,
 .sheet-rolltemplate-dmg .inlinerollresult,
 .sheet-rolltemplate-simple .inlinerollresult {
   font-size: 18px;
@@ -522,6 +565,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .inlinerollresult.importantroll,
+.sheet-rolltemplate-atkdmg .inlinerollresult.importantroll,
 .sheet-rolltemplate-dmg .inlinerollresult.importantroll,
 .sheet-rolltemplate-simple .inlinerollresult.importantroll {
   background-color: #111;
@@ -529,6 +573,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .inlinerollresult.fullcrit,
+.sheet-rolltemplate-atkdmg .inlinerollresult.fullcrit,
 .sheet-rolltemplate-dmg .inlinerollresult.fullcrit,
 .sheet-rolltemplate-simple .inlinerollresult.fullcrit {
   background-color: #111;
@@ -537,6 +582,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .inlinerollresult.fullfail,
+.sheet-rolltemplate-atkdmg .inlinerollresult.fullfail,
 .sheet-rolltemplate-dmg .inlinerollresult.fullfail,
 .sheet-rolltemplate-simple .inlinerollresult.fullfail {
   color: #fff;
@@ -545,9 +591,11 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .sheet-crit-success,
+.sheet-rolltemplate-atkdmg .sheet-crit-success,
 .sheet-rolltemplate-dmg .sheet-crit-success,
 .sheet-rolltemplate-simple .sheet-crit-success,
 .sheet-rolltemplate-atk .sheet-crit-fail,
+.sheet-rolltemplate-atkdmg .sheet-crit-fail,
 .sheet-rolltemplate-dmg .sheet-crit-fail,
 .sheet-rolltemplate-simple .sheet-crit-fail {
   display: block;
@@ -556,6 +604,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-rolltemplate-atk .sheet-roll-unused .inlinerollresult,
+.sheet-rolltemplate-atkdmg .sheet-roll-unused .inlinerollresult,
 .sheet-rolltemplate-dmg .sheet-roll-unused .inlinerollresult,
 .sheet-rolltemplate-simple .sheet-roll-unused .inlinerollresult {
   font-size: 15px;
@@ -576,13 +625,15 @@ label.sheet-form-checkbox {
 
 /* PC sheets */
 .sheet-sd .sheet-checkbox-cog:hover span {
-  color: black;
+  color: #333;
+  color: #fff;
   opacity: 1;
+  background-color: rgba(0, 0, 0, 0.9);
 }
 
-.darkmode .sheet-sd .sheet-checkbox-cog:hover span {
-  color: white;
-  opacity: 1;
+.sheet-darkmode .sheet-sd .sheet-checkbox-cog:hover span {
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.7);
 }
 
 .sheet-sd .sheet-feature {
@@ -634,10 +685,6 @@ label.sheet-form-checkbox {
   display: block;
 }
 
-.ui-dialog .sheet-sd .sheet-fieldset-item:hover>.sheet-checkbox-cog span {
-  color: white;
-}
-
 .sheet-sd .repcontainer.editmode .repitem .sheet-fieldset-item {
   opacity: 0.3;
 }
@@ -671,10 +718,14 @@ label.sheet-form-checkbox {
 
 .sheet-sd .sheet-checkbox-cog {
   display: inline-block;
-  height: 18px;
+  height: 20px;
   position: absolute;
-  right: 0;
-  width: 18px;
+  align-self: flex-end;
+  width: 20px;
+}
+
+.sheet-sd h1 .sheet-checkbox-cog {
+  right: 20px;
 }
 
 .sheet-sd .sheet-checkbox-cog input {
@@ -684,10 +735,6 @@ label.sheet-form-checkbox {
   position: relative;
   width: 100%;
   z-index: 1;
-}
-
-.ui-dialog .sheet-sd .sheet-fieldset-item:hover>.sheet-checkbox-cog span {
-  color: #eee;
 }
 
 .sheet-sd .sheet-checkbox-cog input:checked~span::before {
@@ -700,11 +747,13 @@ label.sheet-form-checkbox {
 }
 
 .sheet-sd .sheet-checkbox-cog:hover span {
-  color: black;
+  color: #333;
+  background-color: rgba(255, 255, 255, 0.9);
 }
 
 .sheet-darkmode .sheet-sd .sheet-checkbox-cog:hover span {
   color: #fff;
+  background-color: rgba(0, 0, 0, 0.7);
 }
 
 .sheet-sd .sheet-checkbox-cog:hover input:checked~span {
@@ -712,7 +761,7 @@ label.sheet-form-checkbox {
 }
 
 .sheet-darkmode .sheet-sd .sheet-checkbox-cog span {
-  color: #333;
+  color: #666;
 }
 
 .sheet-sd .sheet-checkbox-cog span {
@@ -721,12 +770,12 @@ label.sheet-form-checkbox {
   box-sizing: border-box;
   display: flex;
   font-family: 'Pictos';
-  font-size: 15px;
+  font-size: 20px;
   height: 100%;
   justify-content: center;
   left: 0;
-  opacity: .3;
-  color: #fff;
+  opacity: 0.5;
+  color: #333;
   position: absolute;
   top: 0;
   width: 100%;
@@ -814,6 +863,11 @@ label.sheet-form-checkbox {
   flex: 0 1 auto;
 }
 
+.ui-dialog .charsheet .sheet-section-actions .repcontainer .repitem,
+.ui-dialog .charsheet .sheet-section-features .repcontainer .repitem {
+  position: inherit;
+}
+
 .ui-dialog .charsheet .custom-counter-item input {
   padding: 2px;
   border-radius: 0;
@@ -859,22 +913,162 @@ label.sheet-form-checkbox {
   margin: 0;
 }
 
-/* repeater edit forms */
+/* repeater edit forms - dialog styling */
+.sheet-sd .sheet-toggle-checked {
+  background-color: #f8f9fa;
+  border: 2px solid #dee2e6;
+  border-radius: 0px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  height: calc(100vh - 50px);
+  max-height: calc(100vh - 50px);
+  overflow: auto;
+  margin: 20px auto;
+  max-width: 95%;
+}
+
+/* blur the background while dialog is open but let click events through so user can change tabs */
+/* kind of annoying because it also blurs scroll bar, disabled for now.
+.sheet-toggle-checked::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    backdrop-filter: blur(1px);
+    z-index: -1;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    pointer-events: none;
+}
+*/
+
+.sheet-darkmode .sheet-sd .sheet-toggle-checked {
+  background-color: #2d3748;
+  border-color: #4a5568;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.sheet-sd .sheet-form {
+  padding: 20px;
+}
+
+.sheet-sd .sheet-form-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sheet-sd .sheet-form-group {
+  margin-bottom: 0;
+}
+
+.sheet-sd .sheet-form-group label {
+  font-weight: 600;
+  color: #374151;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.sheet-darkmode .sheet-sd .sheet-form-group label {
+  color: #e2e8f0;
+}
+
 .sheet-sd .sheet-form-body input[type=text],
 .sheet-sd .sheet-form-body select,
 .sheet-sd .sheet-form-body textarea {
-  font-size: 10px;
-  line-height: 10px;
+  font-size: 12px;
+  line-height: 1.4;
   background-color: #fff;
-  border-radius: 0;
+  border: 1px solid #d1d5db;
+  border-radius: 0px;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-  vertical-align: text-top;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.sheet-sd .sheet-form-body textarea {
+  box-sizing: border-box;
+}
+
+.sheet-darkmode .sheet-sd .sheet-form-body input[type=text],
+.sheet-darkmode .sheet-sd .sheet-form-body select,
+.sheet-darkmode .sheet-sd .sheet-form-body textarea {
+  background-color: #4a5568;
+  border-color: #718096;
+  color: #e2e8f0;
+}
+
+.sheet-sd .sheet-form-body input[type=text]:focus,
+.sheet-sd .sheet-form-body select:focus,
+.sheet-sd .sheet-form-body textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
 .sheet-sd .sheet-form-body input[type=text],
 .sheet-sd .sheet-form-body select {
-  height: 20px;
-  width: 140px;
+  height: auto;
+  min-height: 24px;
+  width: 100%;
+}
+
+.sheet-sd .sheet-form-body textarea {
+  min-height: 80px;
+  resize: vertical;
+  width: 100%;
+}
+
+.sheet-sd .sheet-form-group .sd-row {
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.sheet-sd .sheet-form-group .sd-row .sd-col {
+  flex: 1;
+  min-width: 0;
+  align-self: flex-start;  
+}
+
+.sheet-sd .sheet-form-group .sd-row input[type=text],
+.sheet-sd .sheet-form-group .sd-row select {
+  max-width: none;
+}
+
+.sheet-sd .sheet-form-group select {
+  cursor: pointer;
+}
+
+.sheet-sd .sheet-form-group span {
+  align-self: flex-end;
+  margin: 0 8px;
+  font-weight: 500;
+  line-height: 36px;
+}
+
+.sheet-sd .sheet-form-checkbox {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 8px;
+}
+
+.sheet-sd .sheet-form-checkbox input[type=checkbox] {
+  margin: 0;
+  width: 16px;
+  height: 16px;
+}
+
+.sheet-sd .sheet-form-checkbox span {
+  line-height: 1.4;
+  margin: 0;
 }
 
 .charsheet .sheet-sd .sheet-hidden {
@@ -956,7 +1150,7 @@ label.sheet-radio {
   border: 2px solid gold;
 }
 
-/* "readied" indicator for spells and attacks (you can temporarily lose spells on failed checks) */
+/* first (circle) "equipped" flag for spells and attacks (you can temporarily lose spells on failed checks) */
 input[type=checkbox].atk-equipped {
   cursor: pointer;
   border-radius: 50%;
@@ -964,20 +1158,41 @@ input[type=checkbox].atk-equipped {
   height: 1em;
   background-color: darkred;
   vertical-align: middle;
-  border: 2px solid #aaa;
+  border: 3px solid #aaa;
   appearance: none;
   outline: none;
 }
 
 input[type=checkbox].atk-equipped:checked {
-  background-color: greenyellow;
-  border: 2px solid greenyellow;
+  background-color: seagreen;
+  border-color: seagreen;
+}
+
+/* second (triangle) "fixed" flag for spells and attacks - for broken weapons or forbidden spells which require penance, or whatever the player wants it to mean */
+input[type=checkbox].atk-fixed {
+  cursor: pointer;
+  appearance: none;
+  outline: none;
+  border-radius: 0;
+  width: 1em;
+  height: 1em;
+  background-color: transparent;
+  vertical-align: middle;
+  border-left: 0.5em solid transparent;
+  border-right: 0.5em solid transparent;
+  border-top: 1em solid red; /* point down, like a sad debuff */
+  border-bottom: 0;
+}
+
+input[type=checkbox].atk-fixed:checked {
+  border-top: 0;
+  border-bottom: 1em solid silver; /* point up like a stabby little sword */
 }
 
 /* the fine print */
 .sheet-sd .legal {
   font-size: 11px;
-  color: #999;
+  color: #666;
 }
 
 .sheet-sd .legal .sd-credits {

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -248,7 +248,7 @@
 		<div>
 			<fieldset class="repeating_attack">
 				<div class="sheet-fieldset-item">
-					<div class="sheet-checkbox-cog" title="Toggle details">
+					<div class="sheet-checkbox-cog" title="Edit Details">
 						<input type="checkbox" name="attr_options-flag" checked="checked"><span></span>
 						<span class="sheet-toggle-icon"></span>
 					</div>
@@ -256,85 +256,128 @@
 					<div class="sheet-toggle-checked">
 						<div class="sheet-form">
 							<div class="sheet-form-body">
+								<h1>Attack or Spell Details
+									<div class="sheet-checkbox-cog" title="Close Form">
+										<input type="checkbox" name="attr_options-flag" checked="checked"><span></span>
+										<span class="sheet-toggle-icon"></span>
+									</div>
+									<button type="roll" name="roll_attack" value="@{rollbase}" class="sheet-attack-button" title="Use action in chat">Test Roll</button>
+								</h1>
 								<div class="sheet-form-group">
-									<label>Edit Name:</label>
-									<input type="text" name="attr_atkname" placeholder="Weapon or Spell">
-								</div>
-								<div class="sheet-form-group">
-									<label class="sheet-form-checkbox">
-										<span>Roll Stat + Bonus:</span>
-									</label>
-								</div>
-								<div class="sheet-form-group">
-									<select name="attr_atkattr_base">
-										<option value="@{strength_mod}" selected="selected">STR</option>
-										<option value="@{dexterity_mod}">DEX</option>
-										<option value="@{constitution_mod}">CON</option>
-										<option value="@{intelligence_mod}">INT</option>
-										<option value="@{wisdom_mod}">WIS</option>
-										<option value="@{charisma_mod}">CHA</option>
-										<option value="0">-</option>
-									</select>
-									<span>+</span>
-									<input type="text" name="attr_atkmod">
+									<label for="attr_atkname">Name of Attack, Weapon, or Spell:</label>
+									<input type="text" name="attr_atkname" id="attr_atkname" value="Punch" placeholder="+2 Sentient Scythe of the Swinefolk">
 								</div>
 								<div class="sheet-form-group">
 									<div class="sd-row">
 										<div class="sd-col">
-											<label>Spell Duration:</label>
-											<input type="text" name="attr_duration" placeholder="instant, 1 turn, 1 minute, etc.">
+											<label for="attr_atkattr_base">Roll Stat:</label>
+											<select name="attr_atkattr_base" id="attr_atkattr_base">
+												<option value="@{strength_mod}" selected="selected">STR</option>
+												<option value="@{dexterity_mod}">DEX</option>
+												<option value="@{constitution_mod}">CON</option>
+												<option value="@{intelligence_mod}">INT</option>
+												<option value="@{wisdom_mod}">WIS</option>
+												<option value="@{charisma_mod}">CHA</option>
+												<option value="0">-</option>
+											</select>
 										</div>
 										<div class="sd-col">
-											<label>DC to Cast:</label>
-											<input type="text" name="attr_castdc">
+											<label for="attr_atkmod">Attack Bonus:</label>
+											<input type="text" name="attr_atkmod" id="attr_atkmod" placeholder="0">
 										</div>
 									</div>
 								</div>
 								<div class="sheet-form-group">
-									<label>Attack/Spell Range:</label>
-									<input type="text" name="attr_atkrange" placeholder="close, far, near, etc.">
+									<div class="sd-row">
+										<div class="sd-col">
+											<label for="attr_duration">Spell Duration:</label>
+											<input type="text" id="attr_duration" name="attr_duration" placeholder="instant, 1 turn, 1 minute, etc.">
+										</div>
+										<div class="sd-col">
+											<label for="attr_castdc">DC to Cast:</label>
+											<input type="text" name="attr_castdc" id="attr_castdc" placeholder="15">
+										</div>
+									</div>
 								</div>
 								<div class="sheet-form-group">
-									<label>Other Bonus:</label>
-									<input type="text" name="attr_atkmagic">
-									<label>Minimum Die Roll To Crit:</label>
-									<input type="text" name="attr_atkcritrange" value="20">
+									<label for="attr_atkrange">Attack / Spell Range:</label>
+									<input type="text" id="attr_atkrange" name="attr_atkrange" placeholder="close, far, near, or units">
+								</div>
+								<div class="sheet-form-group">
+									<div class="sd-row">
+										<div class="sd-col">
+											<label for="attr_atkmagic">Magic Bonus added to attacks and damage:</label>
+											<input type="text" name="attr_atkmagic" id="attr_atkmagic" placeholder="0">
+										</div>
+										<div class="sd-col">
+											<label for="attr_atkcritrange">Minimum Die Roll To Crit:</label>
+											<input type="text" id="attr_atkcritrange" name="attr_atkcritrange" value="20" placeholder="20">
+										</div>
+									</div>
 								</div>
 								<div class="sheet-form-group">
 									<label class="sheet-form-checkbox">
 										<input type="checkbox" name="attr_dmgflag" value="{{damage=1}} {{dmg1flag=1}}" checked>
-										<span>Damage Type 1</span>
+										<span>Apply Damage Type 1</span>
 									</label>
 								</div>
 								<div class="sheet-form-group">
-									<label>Damage Roll + Bonus:</label>
-									<input type="text" name="attr_dmgbase">
-									<span>+</span>
-									<input type="text" name="attr_dmgmod">
+									<div class="sd-row">
+										<div class="sd-col">
+											<label for="attr_dmgbase">Damage Roll:</label>
+											<input type="text" id="attr_dmgbase" name="attr_dmgbase" placeholder="1d6" value="1d6">
+										</div>
+										<div class="sd-col">
+											<label for="attr_dmgmod">Damage Bonus:</label>
+											<input type="text" name="attr_dmgmod" id="attr_dmgmod" placeholder="0">
+										</div>
+									</div>
 								</div>
 								<div class="sheet-form-group">
-									<label>Crit Roll or Damage (if not roll twice):</label>
-									<input type="text" name="attr_dmgcustcrit">
+									<label for="attr_dmgcustcrit">Custom Critical Damage (blank for 2x roll):</label>
+									<input type="text" id="attr_dmgcustcrit" name="attr_dmgcustcrit" placeholder="3d6 [Slashing] + 1d12 [Necrotic]">
 								</div>
 								<div class="sheet-form-group">
 									<label class="sheet-form-checkbox">
 										<input type="checkbox" name="attr_dmg2flag" value="{{damage=1}} {{dmg2flag=1}}">
-										<span>Damage Type 2</span>
+										<span>Apply Damage Type 2</span>
 									</label>
 								</div>
 								<div class="sheet-form-group">
-									<label>Damage Roll + Bonus:</label>
-									<input type="text" name="attr_dmg2base">
-									<span>+</span>
-									<input type="text" name="attr_dmg2mod">
+									<div class="sd-row">
+										<div class="sd-col">
+											<label for="attr_dmg2base">Damage Roll:</label>
+											<input type="text" id="attr_dmg2base" name="attr_dmg2base" placeholder="2d6 [Poison]">
+										</div>
+										<div class="sd-col">
+											<label for="attr_dmg2mod">Damage Bonus:</label>
+											<input type="text" id="attr_dmg2mod" name="attr_dmg2mod" placeholder="0">
+										</div>
+									</div>
 								</div>
 								<div class="sheet-form-group">
-									<label>Crit Roll or Damage (if not roll twice):</label>
-									<input type="text" name="attr_dmg2custcrit">
+									<label>Custom Critical Damage (blank for 2x roll):</label>
+									<input type="text" name="attr_dmg2custcrit" placeholder="12d8 [Fire]">
 								</div>
-								<div class="sheet-form-group sheet-form-group-column">
+								<div class="sheet-form-group">
+									<div class="sd-row">
+										<div class="sd-col">
+											<label class="sheet-form-checkbox">
+												<input type="checkbox" name="attr_equipped" checked="checked" value="1">
+												<span>Equipped; Ready to Use</span>
+											</label>
+										</div>
+										<div class="sd-col">
+											<label class="sheet-form-checkbox">
+												<input type="checkbox" name="attr_fixed" checked="checked" value="1">
+												<span>Repaired; Reconciled</span>
+											</label>
+										</div>
+									</div>
+								</div>
+								<div class="sheet-form-group">
 									<label>Description or Flavor Text:</label>
-									<textarea name="attr_atk_desc"></textarea>
+									<textarea name="attr_atk_desc" class="attr_atk_desc" placeholder="Swings the blade in a wide arc!"></textarea>
 								</div>
 							</div>
 						</div>
@@ -343,7 +386,8 @@
 						<div class="sd-attacks">
 							<input type="text" name="attr_atkbonus" class="sheet-hidden" value="">
 							<input type="text" name="attr_atkdmgtype" class="sheet-hidden" value="">
-							<input type="checkbox" name="attr_equipped" class="atk-equipped" value="1" checked="checked" title="Equipped / Usable">
+							<input type="checkbox" name="attr_equipped" class="atk-equipped" value="1" title="Equipped / Usable">
+							<input type="checkbox" name="attr_fixed" class="atk-fixed" value="1" title="Fixed; Reconciled or Broken; Forbidden">
 							<button type="roll" name="roll_attack" value="@{rollbase}" class="sheet-attack-button" title="Use action in chat">
 								<span name="attr_atkname"></span>
 								(<span name="attr_atkbonus"></span>)
@@ -355,6 +399,7 @@
 				<input type="hidden" name="attr_rollbase">
 				<input type="hidden" name="attr_rollbase_dmg">
 				<input type="hidden" name="attr_rollbase_crit">
+				<input type="hidden" name="attr_hldmg">
 				<button type="roll" name="roll_attack_dmg" value="@{rollbase_dmg}" class="sheet-hidden"></button>
 				<button type="roll" name="roll_attack_crit" value="@{rollbase_crit}" class="sheet-hidden"></button>
 			</fieldset>
@@ -383,7 +428,7 @@
 		<div>
 			<fieldset class="repeating_trait">
 				<div class="sheet-fieldset-item">
-					<div class="sheet-checkbox-cog" title="Toggle details">
+					<div class="sheet-checkbox-cog" title="Edit Details">
 						<input type="checkbox" name="attr_options-flag" checked="checked">
 						<span class="sheet-toggle-icon"></span>
 					</div>
@@ -391,22 +436,37 @@
 					<div class="sheet-toggle-checked">
 						<div class="sheet-form">
 							<div class="sheet-form-body">
+								<h1>Define a Talent, Trait, Ability, or open-ended Notes
+									<div class="sheet-checkbox-cog" title="Close Form">
+										<input type="checkbox" name="attr_options-flag" checked="checked"><span></span>
+										<span class="sheet-toggle-icon"></span>
+									</div>
+									<button type="roll" name="roll_output" title="Share feature in chat" value="@{wtype}&{template:traits} @{charname_output} {{name=@{name}}} {{description=@{description}}}">Test Output</button>
+								</h1>
 								<div class="sheet-form-group">
-									<label>
-										Edit Trait<br>
-										<input type="text" name="attr_name" class="trait-name" maxlength="60">
-									</label>
+									<div class="sd-row">
+										<div class="sd-col">
+											<label for="attr_name">
+												<p>Title:</p>
+												<input type="text" name="attr_name" id="attr_name" class="trait-name" maxlength="60">
+											</label>
+										</div>
+									</div>
 								</div>
 								<div class="sheet-form-group">
-									<label>
-										Edit Details<br>
-										<textarea name="attr_description" class="trait-desc"></textarea>
-									</label>
+									<div class="sd-row">
+										<div class="sd-col">
+											<label>
+												<p>Description:</p>
+												<textarea name="attr_description" class="trait-desc"></textarea>
+											</label>
+										</div>
+									</div>
 								</div>
 								<div class="sheet-form-group">
 									<label class="sheet-form-checkbox">
 										<input type="checkbox" name="attr_hide_details" value="1">
-										<span>Hide Details in List View</span>
+										<span>Hide Description in List View</span>
 									</label>
 								</div>
 							</div>
@@ -539,6 +599,14 @@
 					<span>Show NPC Description</span>
 				</label>
 			</div>
+			<div class="sheet-form-group" title="@{dtype}">
+				<label>Auto Damage Roll
+					<select name="attr_dtype" style="max-width: 200px">
+						<option value="pick">Don't Auto Roll Damage</option>
+						<option value="full">Auto Roll Damage & Crit</option>
+					</select>
+				</label>
+			</div>			
 			<div class="sheet-form-group">
 				<label class="sheet-form-checkbox" title="@{pulp_mode}">
 					<input type="checkbox" name="attr_pulp_mode" value="1">
@@ -550,7 +618,7 @@
 					<input type="checkbox" name="attr_show_counters" value="1">
 					<span>Custom Resource Counters</span>
 				</label>
-			</div>
+			</div>			
 			<div class="sheet-form-group">
 				<label class="sheet-form-checkbox">
 					<input type="checkbox" name="attr_init_tiebreaker" value="1">
@@ -559,25 +627,32 @@
 			</div>
 			<div class="sheet-form-group">
 				<label>Core Die Roll:</label>
-				<input type="text" name="attr_core_die" value="1d20" placeholder="1d20" title="@{core_die}">
+				<input type="text" name="attr_core_die" value="1d20" placeholder="1d20" title="@{core_die}" style="max-width: 100px;" maxlength="20">
 			</div>
 			<div class="sheet-form-group">
-				<div>
-					<button type="action" name="act_importjson">Import Shadowdarklings JSON</button>
-					<button type="action" name="act_importmonster">Import Monster Text from Book</button>
-				</div>
-				<label class="sheet-form-checkbox" title="@{sheetwipe_confirm_flag}">
-					<input type="checkbox" name="attr_sheetwipe_confirm_flag" value="1">
-					<span>Confirm Import: "By checking this box, I officially swear that I want to replace my stats"</span>
-				</label>
-			</div>
-			<div class="sheet-form-group">
+				<p>IMPORT CHARACTERS AND MONSTERS</p>
+				<p>Import Monsters from the book or import PCs from Shadowdarklings. To import:</p>
+				<ol>
+					<li>Copy and paste (a) a monster stat block from the official Shadowdark PDF or (b) exported Shadowdarklings JSON below.</li>
+					<li>Click the checkbox to confirm. This additional step prevents accidental overwrites.</li>
+					<li>Click the button to Import JSON or Monster Text. Warning: This will overwrite existing data but will not clear attacks and spells, features, or custom counters.</li>
+				</ol>
 				<label>JSON (Shadowdarklings format) or Monster Text (Core rules PDF format)</label>
 				<textarea name="attr_json" title="@{json}"></textarea>
 			</div>
 			<div class="sheet-form-group">
+				<label class="sheet-form-checkbox" title="@{sheetwipe_confirm_flag}">
+					<input type="checkbox" name="attr_sheetwipe_confirm_flag" value="1">
+					<span>Confirm Import: "By checking this box, I officially swear that I want to replace my stats"</span>
+				</label>
+				<div>
+					<button type="action" name="act_importjson">Import Shadowdarklings JSON</button>
+					<button type="action" name="act_importmonster">Import Monster Text from Book</button>
+				</div>
+			</div>
+			<div class="sheet-form-group">
 				<label>Version:</label>
-				<input type="text" name="attr_version" value="2024.2.29.0" hidden disabled>
+				<input type="text" name="attr_version" value="2025.8.31.0" hidden disabled>
 				<span name="attr_version"></span>
 			</div>
 			<div>
@@ -595,14 +670,12 @@
 					<div>CREDIT AND THANKS:</div>
 					<div>
 						<ul class="sd-credits">
-							<li>Giffyglyph for creating the 5e Darker Dungeons sheet because I copied much the script into this one.</li>
+							<li>Giffyglyph for creating the 5e Darker Dungeons sheet which served as the basis for this sheet.</li>
 							<li>Kelsey for creating Shadowdark RPG, and the entire Shadowdark RPG community for supporting the
 								game, Aritz and Herpopotamus for testing and motivation and letting me bouncing ideas around, and all the folks who
 								kindly shared their time for feedback and testing</li>
-							<li>Roll20 for letting for keeping my friends and me (roll20: CyberSasquatch; discord: thescratch) sane
-								during the pandemic</li>
-							<li>Last but not least: THANK YOU for using this (and for your patience while bugs are worked out)
-							</li>
+							<li>Roll20 for helping keep my friends and me sane during the pandemic</li>
+							<li>Finally: THANK YOU for using this (and for your patience while bugs are worked out)</li>
 						</ul>
 					</div>
 					</p>
@@ -711,6 +784,7 @@
 						{{/disadvantage}}
 					</div>
 					<div class="label">
+						<span>⚔️</span>
 						{{#normal}}
 						{{#rollWasCrit() r1}}<span>{{rnamec}}{{#innate}}<span>, {{innate}}</span>{{/innate}}
 							<span>({{mod}})</span></span>{{/rollWasCrit() r1}}
@@ -810,6 +884,195 @@
 						</div>
 						{{/desc}}
 					</div>
+				</div>
+			</rolltemplate>
+			<rolltemplate class="sheet-rolltemplate-atkdmg">
+				<!-- template for combined attack and damage rolls -->
+				<div class="sheet-container">
+					<div class="char-name">
+						<span>{{charname}}</span>: <span>{{rname}} <span>({{mod}})</span></span>
+					</div>
+					{{#attack}}
+						<div class="result">
+							{{#normal}}
+							<div class="solo">
+								<span>{{r1}}</span>
+							</div>
+							{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
+							{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
+							{{/normal}}
+							{{#advantage}}
+							{{#rollLess() r1 r2}}
+							<div class="adv">
+								<span class="roll-unused">{{r1}}</span>
+							</div>
+							<div class="advspacer"></div>
+							<div class="adv">
+								<span class="roll-used">{{r2}}</span>
+							</div>
+							{{#rollWasCrit() r2}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r2}}
+							{{/rollLess() r1 r2}}
+							{{#rollTotal() r1 r2}}
+							<div class="adv">
+								<span class="roll-used">{{r1}}</span>
+							</div>
+							<div class="advspacer"></div>
+							<div class="adv">
+								<span class="roll-used">{{r2}}</span>
+							</div>
+							{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
+							{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
+							{{/rollTotal() r1 r2}}
+							{{#rollGreater() r1 r2}}
+							<div class="adv">
+								<span class="roll-used">{{r1}}</span>
+							</div>
+							<div class="advspacer"></div>
+							<div class="adv">
+								<span class="roll-unused">{{r2}}</span>
+							</div>
+							{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
+							{{/rollGreater() r1 r2}}
+							{{/advantage}}
+							{{#disadvantage}}
+							{{#rollLess() r1 r2}}
+							<div class="adv">
+								<span class="roll-used">{{r1}}</span>
+							</div>
+							<div class="advspacer"></div>
+							<div class="adv">
+								<span class="roll-unused">{{r2}}</span>
+							</div>
+							{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
+							{{/rollLess() r1 r2}}
+							{{#rollTotal() r1 r2}}
+							<div class="adv">
+								<span class="roll-used">{{r1}}</span>
+							</div>
+							<div class="advspacer"></div>
+							<div class="adv">
+								<span class="roll-used">{{r2}}</span>
+							</div>
+							{{#rollWasCrit() r1}}<div class="crit-success">Critical Success!</div>{{/rollWasCrit() r1}}
+							{{#rollWasFumble() r1}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r1}}
+							{{/rollTotal() r1 r2}}
+							{{#rollGreater() r1 r2}}
+							<div class="adv">
+								<span class="roll-unused">{{r1}}</span>
+							</div>
+							<div class="advspacer"></div>
+							<div class="adv">
+								<span class="roll-used">{{r2}}</span>
+							</div>
+							{{#rollWasFumble() r2}}<div class="crit-fail">Critical Failure!</div>{{/rollWasFumble() r2}}
+							{{/rollGreater() r1 r2}}
+							{{/disadvantage}}
+						</div>
+						{{#range}}
+						<div class="info">
+							<span>Range: {{range}}</span>
+						</div>
+						{{/range}}
+					{{/attack}}
+					{{#desc}}
+					<div class="info">
+						<span>
+							<span class="top"></span><span class="middle">{{desc}}</span><span class="bottom"></span>
+						</span>
+					</div>
+					{{/desc}}
+					{{#damage}}
+					<div class="result">
+						{{#dmg1flag}}
+						{{^dmg2flag}}
+						<div class="solo">
+							<span class="damage">
+								{{dmg1}}
+								{{#attack}}
+									{{#normal}}
+										{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}
+									{{/normal}}
+									{{#advantage}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit1}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/advantage}}
+									{{#disadvantage}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+									{{/disadvantage}}
+								{{/attack}}
+							</span>
+						</div>
+						<div>Damage</div>
+						{{/dmg2flag}}
+						{{/dmg1flag}}
+						{{#dmg2flag}}
+						{{^dmg1flag}}
+						<div class="solo">
+							<span class="damage">
+								{{dmg2}}
+								{{#attack}}
+									{{#normal}}
+										{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}
+									{{/normal}}
+									{{#advantage}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit2}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/advantage}}
+									{{#disadvantage}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+									{{/disadvantage}}
+								{{/attack}}
+							</span>
+						</div>
+						<div>Damage</div>
+						{{/dmg1flag}}
+						{{/dmg2flag}}
+						{{#dmg1flag}}
+						{{#dmg2flag}}
+						<div class="adv">
+							<span class="damage">
+								{{dmg1}}
+								{{#attack}}
+									{{#normal}}
+										{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}
+									{{/normal}}
+									{{#advantage}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit1}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/advantage}}
+									{{#disadvantage}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit1}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+									{{/disadvantage}}
+								{{/attack}}
+							</span>
+						</div>
+						<div class="advspacer"></div>
+						<div class="adv">
+							<span class="damage">
+								{{dmg2}}
+								{{#attack}}
+									{{#normal}}
+										{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}
+									{{/normal}}
+									{{#advantage}}
+										{{#rollLess() r1 r2}}{{#rollWasCrit() r2}} + {{crit2}}{{/rollWasCrit() r2}}{{/rollLess() r1 r2}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+										{{#rollGreater() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollGreater() r1 r2}}
+									{{/advantage}}
+									{{#disadvantage}}
+										{{#rollTotal() r1 r2}}{{#rollWasCrit() r1}} + {{crit2}}{{/rollWasCrit() r1}}{{/rollTotal() r1 r2}}
+									{{/disadvantage}}
+								{{/attack}}
+							</span>
+						</div>
+						<div>Damage</div>
+						{{/dmg2flag}}
+						{{/dmg1flag}}
+					</div>
+					{{/damage}}
 				</div>
 			</rolltemplate>
 			<rolltemplate class="sheet-rolltemplate-simple">
@@ -1484,6 +1747,13 @@
 			update_attacks(attackid);
 		});
 
+		on("change:dtype", function(eventinfo) {
+			if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
+				return;
+			}
+			update_attacks("all");
+		});
+
 		on("change:base_level", function(eventinfo) {
 			if (eventinfo.sourceType && eventinfo.sourceType === "sheetworker") {
 				return;
@@ -1566,6 +1836,7 @@
 				var attr_abr = attr.substring(0, 3);
 				// per SD rules attributes can exceed 18 but mods can"t exceed +4, except for monsters/NPCs
 				const modMax =  v.npc === "1" ? 99 : 4;
+				// todo: add option to toggle enforcing the PC stat mod limit
 				var finalattr = v[attr] && isNaN(v[attr]) === false ? Math.floor((parseInt(v[attr], 10) - 10) / 2) : 0;
 				var update = {};
 				update[attr + "_mod"] = Math.min(modMax, finalattr);
@@ -1603,7 +1874,7 @@
 		};
 
 		var do_update_attack = function(attack_array, source) {
-			var attack_attribs = ["level", "d20", "strength_mod", "dexterity_mod", "constitution_mod", "intelligence_mod", "wisdom_mod", "charisma_mod"];
+			var attack_attribs = ["level", "d20", "dtype", "strength_mod", "dexterity_mod", "constitution_mod", "intelligence_mod", "wisdom_mod", "charisma_mod"];
 			_.each(attack_array, function(attackid) {
 				attack_attribs.push("repeating_attack_" + attackid + "_atkname");
 				attack_attribs.push("repeating_attack_" + attackid + "_atkattr_base");
@@ -1727,6 +1998,14 @@
 					}
 					pickbase = "pick";
 					rollbase = "@{wtype}&{template:atk} {{mod=@{atkbonus}}} {{rname=[@{atkname}](~repeating_attack_attack_dmg)}} {{rnamec=[@{atkname}](~repeating_attack_attack_crit)}} {{r1=[[" + r1 + "cs>@{atkcritrange}" + hbonus + "]]}} " + r2 + "cs>@{atkcritrange}" + hbonus + "]]}} {{range=@{atkrange}}} {{desc=@{atk_desc}}} {{castdc=@{castdc}}} @{charname_output}";
+
+					// auto roll damage also, requires its own roll template
+					if (v.dtype === "full") {
+						pickbase = "full";
+						let hldmgcrit = v["repeating_attack_" + attackid + "_hldmg"] && v["repeating_attack_" + attackid + "_hldmg"] != "" ? v["repeating_attack_" + attackid + "_hldmg"].slice(0, 7) + "crit" + v["repeating_attack_" + attackid + "_hldmg"].slice(7) : "";
+						rollbase = "@{wtype}&{template:atkdmg} {{attack=1}} {{damage=1}} {{mod=@{atkbonus}}} {{rname=@{atkname}}} {{r1=[[" + r1 + "cs>@{atkcritrange}" + hbonus + "]]}} " + r2 + "cs>@{atkcritrange}" + hbonus + "]]}} {{range=@{atkrange}}} @{dmgflag} {{dmg1=[[" + hdmg1 + "]]}} {{dmg1type=" + dmgtype + "}} @{dmg2flag} {{dmg2=[[" + hdmg2 + "]]}} {{dmg2type=" + dmg2type + "}} {{crit1=[[" + crit1 + "[CRIT]]]}} {{crit2=[[" + crit2 + "[CRIT]]]}} {{desc=@{atk_desc}}} @{hldmg} " + hldmgcrit + " @{charname_output}";
+					}
+
 					update["repeating_attack_" + attackid + "_rollbase_dmg"] = "@{wtype}&{template:dmg} {{rname=@{atkname}}} {{range=@{atkrange}}} {{duration=@{duration}}} @{dmgflag} {{dmg1=[[" + hdmg1 + "]]}} {{dmg1type=" + dmgtype + "}} @{dmg2flag} {{dmg2=[[" + hdmg2 + "]]}} {{dmg2type=" + dmg2type + "}} {{desc=@{atk_desc}}} @{charname_output}";
 					update["repeating_attack_" + attackid + "_rollbase_crit"] = "@{wtype}&{template:dmg} {{crit=1}} {{rname=@{atkname}}} {{range=@{atkrange}}} {{duration=@{duration}}} @{dmgflag} {{dmg1=[[" + hdmg1 + "]]}} {{dmg1type=" + dmgtype + "}} @{dmg2flag} {{dmg2=[[" + hdmg2 + "]]}} {{dmg2type=" + dmg2type + "}} {{crit1=[[" + crit1 + "]]}} {{crit2=[[" + crit2 + "]]}} {{desc=@{atk_desc}}} @{charname_output}";
 					update["repeating_attack_" + attackid + "_atkbonus"] = bonus;
@@ -1758,6 +2037,7 @@
 			update[`${prefix}_castdc`] = action.dc || "";
 			update[`${prefix}_atkrange`] = action.range || "";
 			update[`${prefix}_equipped`] = "1"; // default to usable state
+			update[`${prefix}_fixed`] = "1"; // default to fixed state
 			update[`${prefix}_atkmagic`] = action.magBonus || "";
 			update[`${prefix}_atkcritrange`] = action.critRange || "20";
 			update[`${prefix}_dmgflag`] = action.damage === undefined ? "" : "{{damage=1}} {{dmg1flag=1}}";

--- a/Shadowdark-Unofficial/sheet.json
+++ b/Shadowdark-Unofficial/sheet.json
@@ -26,32 +26,6 @@
       "description": "In NPC roll results, show or hide the name of the NPC in the roll result card."
     },
     {
-      "attribute": "rtype",
-      "displayname": "Roll Queries:",
-      "type": "select",
-      "options": [
-        "Always Roll Advantage|{{always=1}} {{r2=[[1d20",
-        "Advantage Toggle|@{advantagetoggle}",
-        "Query Advantage|{{query=1}} ?{Advantage?|Normal Roll,&#123&#123normal=1&#125&#125 &#123&#123r2=[[0d20|Advantage,&#123&#123advantage=1&#125&#125 &#123&#123r2=[[1d20|Disadvantage,&#123&#123disadvantage=1&#125&#125 &#123&#123r2=[[1d20}",
-        "Never Roll Advantage|{{normal=1}} {{r2=[[0d20"
-      ],
-      "default": "{{always=1}} {{r2=[[1d20",
-      "description": "D20 Rolls output according to this option. Always Roll Advantage is the default setting and will roll two D20 on every roll in case of advantage. The expectation is that if there is no advantage or disadvantage you use the left most result. The Advantage Toggle option adds three new buttons to the top of the sheet so that you can toggle advantage on a case by case basis. Query Advantage gives you a prompt every roll asking if the roll has advantage. Never Roll Advantage always rolls a single D20 on any given roll, expecting the player to roll a second time in case of advantage or disadvantage."
-    },
-    {
-      "attribute": "wtype",
-      "displayname": "Whisper Rolls to GM:",
-      "type": "select",
-      "options": [
-        "Never Whisper Rolls|",
-        "Whisper Toggle|@{whispertoggle}",
-        "Query Whisper|?{Whisper?|Public Roll,|Whisper Roll,/w gm }",
-        "Always Whisper Rolls|/w gm "
-      ],
-      "default": "",
-      "description": "All sheet rolls are sent to all players in chat by default. Whisper Toggle gives a set of buttons to quick select your preference on the fly. Query Whisper option gives you a prompt with each roll of whether or not the roll should be sent privately only to yourself and the GM. Always Whisper Rolls will send all rolls only to yourself and the GM."
-    },
-    {
       "attribute": "core_die",
       "displayname": "Core Die Roll:",
       "type": "text",

--- a/Shadowdark-Unofficial/sheet.json
+++ b/Shadowdark-Unofficial/sheet.json
@@ -6,6 +6,7 @@
   "preview": "Shadowdark-Unofficial-Preview.png",
   "legacy": false,
   "printable": true,
+  "mobile": true,
   "compendium": "",
   "instructions": "A tab-free 3rd-Party Shadowdark sheet for PCs (Crawlers) and NPCs (Monsters, etc.). Features: character info, stats, tracking and sharing (to chat) traits/talents/abilities/notes, rollable attacks and spells, dark mode support, responsive design for smartphones, luck token tracking (normal and pulp mode), 20 gear slots and treasure tracking, import JSON from Shadowdarklings.net format, import monsters by parsing copied text straight from the official PDF, level-up XP calculation, 3rd-party license compliant. No compendium support. This Unofficial Shadowdark sheet for Roll20 is an independent product published under the Shadowdark RPG Third-Party License and is not affiliated with The Arcane Library, LLC. Shadowdark RPG © 2023 The Arcane Library, LLC.",
   "useroptions": [
@@ -17,6 +18,40 @@
       "description": "Default sheet type to NPC (monster) instead of PC (Crawler). It is easy to toggle between these in the options section of the sheet."
     },
     {
+      "attribute": "npc_showdesc",
+      "displayname": "Show NPC Description text:",
+      "type": "checkbox",
+      "value": "1",     
+      "default": "0",
+      "description": "In NPC roll results, show or hide the name of the NPC in the roll result card."
+    },
+    {
+      "attribute": "rtype",
+      "displayname": "Roll Queries:",
+      "type": "select",
+      "options": [
+        "Always Roll Advantage|{{always=1}} {{r2=[[1d20",
+        "Advantage Toggle|@{advantagetoggle}",
+        "Query Advantage|{{query=1}} ?{Advantage?|Normal Roll,&#123&#123normal=1&#125&#125 &#123&#123r2=[[0d20|Advantage,&#123&#123advantage=1&#125&#125 &#123&#123r2=[[1d20|Disadvantage,&#123&#123disadvantage=1&#125&#125 &#123&#123r2=[[1d20}",
+        "Never Roll Advantage|{{normal=1}} {{r2=[[0d20"
+      ],
+      "default": "{{always=1}} {{r2=[[1d20",
+      "description": "D20 Rolls output according to this option. Always Roll Advantage is the default setting and will roll two D20 on every roll in case of advantage. The expectation is that if there is no advantage or disadvantage you use the left most result. The Advantage Toggle option adds three new buttons to the top of the sheet so that you can toggle advantage on a case by case basis. Query Advantage gives you a prompt every roll asking if the roll has advantage. Never Roll Advantage always rolls a single D20 on any given roll, expecting the player to roll a second time in case of advantage or disadvantage."
+    },
+    {
+      "attribute": "wtype",
+      "displayname": "Whisper Rolls to GM:",
+      "type": "select",
+      "options": [
+        "Never Whisper Rolls|",
+        "Whisper Toggle|@{whispertoggle}",
+        "Query Whisper|?{Whisper?|Public Roll,|Whisper Roll,/w gm }",
+        "Always Whisper Rolls|/w gm "
+      ],
+      "default": "",
+      "description": "All sheet rolls are sent to all players in chat by default. Whisper Toggle gives a set of buttons to quick select your preference on the fly. Query Whisper option gives you a prompt with each roll of whether or not the roll should be sent privately only to yourself and the GM. Always Whisper Rolls will send all rolls only to yourself and the GM."
+    },
+    {
       "attribute": "core_die",
       "displayname": "Core Die Roll:",
       "type": "text",
@@ -24,19 +59,22 @@
       "description": "Changing the core die will replace the normal 1d20 made with almost all rolls with a randomizer of your choice, such as 2d10 or 3d6."
     },
     {
+      "attribute": "dtype",
+      "displayname": "Auto Damage Roll:",
+      "type": "select",
+      "options": [
+        "Don't Auto Roll Damage|pick",
+        "Auto Roll Damage & Crit|full"
+      ],
+      "default": "pick",
+      "description": "By default, attack damage rolls are not rolled until the hit is confirmed. Damage is rolled from the chat roll template by clicking on the name of the attack in the right hand bar, which then displays the damage. The default method is compatible with 3D dice. Optionally, you can choose to have the Auto Roll Damage & Crit option which will roll damage and critical hit dice at the same time of the attack, presenting all possible outcomes at the time of the attack."
+    },
+    {
       "attribute": "init_tiebreaker",
       "displayname": "Add DEX Tiebreaker to Initiative:",
       "type": "checkbox",
       "value": "@{dexterity}/100",
       "description": "Adds the character's dexterity score as a decimal to the end of the initiative bonus for purposes of breaking ties."
-    },
-    {
-      "attribute": "npc_showdesc",
-      "displayname": "Show NPC Description text:",
-      "type": "checkbox",
-      "value": "1",     
-      "default": "0",
-      "description": "In NPC roll results, show or hide the name of the NPC in the roll result card."
     },
     {
       "attribute": "cd_bar1_v",


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

- Add Auto Roll Damage option
- Update UI for Repeater item forms to use a dialog instead of pushing content around when it opens
- Fix typos in legal text
- Add sword emoji to left side of damage rolling hyperlink because some users were confused about how to roll damage
- Updated mobile property to try to mitigate the roll20 app warning about sheet not working well with mobile (it seems to work) and tested on my pixel phone: Some font issue still, but roll20 wiki has details and I might or might not try to fix later - for now it shows letter "t" but the rolling works. Also, if you enable the new Auto Roll Damage option, the rolls actually work on phone - output rolls and damage properly. (Without this option, the damage link does not work on mobile). Mobile still has known issues, but is actually fairly decent experience now on phone for Shadowdark!
- Add default options for roll type, whisper type, and automatic damage rolling

Known issues or feature ideas:
- mobile experience is still kind of lousy and doesn't load the dice font
- readability and contrast for vision impaired may not be great
- still no option for disabling automatic level/xp feature - might do that in future, but if you hate it: use a custom counter in the meantime
- a requested feature was to allow individual attack/spell to override the roll with advantage option (for wizard casting magic missile) but I may not add that because it takes too much time to test this stuff, sorry. However, if you always leave "roll with adv" on, then it is pretty easy to just ignore the high/low/last die rolled in my opinion. my design philosophy was: keep it simple and flexible, not get bogged down in individual feature requests which can easily be solved already.

**Made with <3 by CyberSasquatch**