### PR TITLE
Shadowdark-Unofficial: BUGFIX CSS for Modify mode Overlay for Repeaters itemcontrol

### DIFF
--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.css
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.css
@@ -716,12 +716,26 @@ label.sheet-form-checkbox {
   z-index: 9999;
 }
 
+.ui-dialog .charsheet .repcontainer .repitem .itemcontrol {
+  position: static;
+  height: auto;
+  min-height: 30px;
+}
+
+.ui-dialog .charsheet .repcontainer .repitem {
+  min-height: 30px;
+}
+
 .sheet-sd .sheet-checkbox-cog {
   display: inline-block;
   height: 20px;
   position: absolute;
   align-self: flex-end;
   width: 20px;
+}
+
+.sheet-sd .repcontainer.editmode .repitem .sheet-fieldset-item .sheet-checkbox-cog {
+  display: none;
 }
 
 .sheet-sd h1 .sheet-checkbox-cog {
@@ -925,7 +939,7 @@ label.sheet-form-checkbox {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1000;
+  z-index: 10000;
   height: calc(100vh - 50px);
   max-height: calc(100vh - 50px);
   overflow: auto;


### PR DESCRIPTION
# Submission Checklist

## Shadowdark-Unofficial: BUGFIX CSS for Modify mode Overlay for Repeaters itemcontrol

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

Modify Mode fixed for Features and Attacks: The item control no longer blocks the entire UI due to absolute positioned element with `height: 100%`

The item control handle now shows above the item being dragged or deleted.

The repeater items were previously using relative position and the absolute positioned `.itemcontrol` was using its dimensions, but I recently changed the edit form into a dialog which necessitated the removal of the relative positioned parent element. 