### PR TITLE
Shadowdark-Unofficial 3 Sep 2025 Fix mobile style and repeaters

### DIFF
--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.css
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.css
@@ -1,6 +1,15 @@
+@font-face {
+    font-family: 'dicefontd20';
+    src: url(data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAAAADV8AA8AAAAAfswAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAABWAAAABwAAAAcZshnhUdERUYAAAF0AAAAHQAAACAAXAAET1MvMgAAAZQAAABKAAAAYHTsWKBjbWFwAAAB4AAAAIsAAAFy/Aj/nWN2dCAAAAJsAAAABAAAAAQARAURZ2FzcAAAAnAAAAAIAAAACAAAABBnbHlmAAACeAAAL/QAAHZ4W6szYWhlYWQAADJsAAAALgAAADYAYWa3aGhlYQAAMpwAAAAdAAAAJA3XCAhobXR4AAAyvAAAACcAAAC8N9QRQmxvY2EAADLkAAAAYAAAAGCBFZGWbWF4cAAAM0QAAAAgAAAAIAERFFpuYW1lAAAzZAAAAZUAAAMD+WL0cnBvc3QAADT8AAAAeAAAAJfHfesMd2ViZgAANXQAAAAGAAAABtylUR8AAAABAAAAAMw9os8AAAAAzUU3kwAAAADNRY0ieNpjYGRgYOADYgkGEGBiYARCPSBmAfMYAAZEAGEAAAB42mNgZlvPOIGBlYGF1ZjlDAMDw0wIzXSGwYhRB8gHSsEBIwMSCPUO92NwYOB9wMCW9i+NgYHdkEEDpobdkF0eSCkwMAIALaAKUQAAeNpjYGBgZoBgGQZGBhDIAfIYwXwWhgAgLQCEzGAZXgYFBgOGEIaSBwz//yOJODAkgkUY/3/9//j/lf9H/+9U0IOahgIY2RjgwoxMQIIJXQED1CoEYEHjs7Kxc3BycfPw8vELCAoJi4iKiUtIIiuQkpaRlZNXUFRSVlFVU9fQ1NLW0WUYPAAAKioWkQAARAURAAEAAf//AA942r19CZQkV3Vl/jX2JSMzMrKyKmvJqMysru6ubuUqqfdWq7W2QBISkiwkIYQkQAv7YjZbYMQxnhkWs4kBZBsvmAEbxp7Bg7E59ox9bA+LfTybj42P8Xg5xxszHLAHqpK570dWq1utEkhNqqo6qzIzIv777753330/IqNLvHSiVOJ3qRtKomSVNj7NSvsOfsaSpX/ofVqrPz34GcHxZ+nTgl5W9PJnLM02D36G0ev98kq5vVJeOcGXJ6vsA5N71Q3f/sQJ+cVSqeSV7iqV9MesC0pxqVZqlvJSt7RR6pfGpYtLR0uXlkoOazGdljMmD7ARGw3LrGypocPydgt/t62SxdrKYYqtjMbJmAUsL/dZm/UdtqLaNdZebbOcKf3o5l97W15Lsq+zVZvv5b+7vvklvnUT/wX+Fbb1PM1/cav1nsnfW5Ov8i+J2uSrk+v4lyZf2Hz0R/JJmX1q897J1zlX/3fydRbyLT15jrjpOy9lvs8emnx28mvq81v3cvYTLFT3sN+fnHTrmw8nk7/4RMY+HNfEm9nHJr/Ie5y9ffLqnmTPmbzW/e6kKflnBoOta/hfD7ZGX7uQfaG6VfXfItzNb72FP/ydAd/98I86E/35z+nJQ1z8aOnR0rdLn9KhPmC/yL7fcZwF52HnHe7/cLe8jnfCu9y7xvu03/L3+hf4I/8S/xb/lf57/Uf8j/g/5/+z/91gGBwMjgfXB3cG9wb3B68N3hr86+D9wUeDnw8+EXw6+FzwO8EXgz8O/mfwZ8FfB38XviT88fCd4fvCR8O/Cf8+KkdZNB/dHt0VvTh6afSu6NHoF6JPRb8R/X70x9GfRP875rGOgziJl+PL4lPxdfEPxffED8avjt8Q/1k5A+jd8u7yvvKh8rHyJeWryteV31/+UPmj5Y+VP17+9+VfL/9e+YvlP05Y4ifNJE+6yZ5kkBxKjiUnkiuTZyXXJzcmtyUvTB5MXpH8cPLm5KHk4eTfJO9NHkk+mvx08vHkl5PPJl9Ifif5r8kfJv8t+WryteQfk28m/68iKm6lUXlf5SOV36j858rvVf6q8neVb1W+XZXVtVKJpZmVZnmWVq0szbu5eezkaZZaaa2f9vOs12SZleENizbFm92sN8z6A2zVOcTGw0HX6lp5a9jCk3w87Pa75iFvMuyCPaq5trSVD8bd4Tiv5hGCt9pPtZWN8ZAfCkbj0RgHwD8cYbCbWWZs7IhvbNA9wvLxIdbtjbutqQ102D7ezXDoHG9hMHqJZoFHzCQloyNWzfrjLO2bHaa/iv1TbGmZH5iGY6RW3zzHTMbd/qDfhUX0nVtVGI4Za9rQ6vbHre4wT6vbLsMBa9gx7447OabCc3PQbVdl2hpqKx1nfQyod7NOTmNhDDwOrfQA01PPDq3d2BRTteD3A3oMq3vDPoynfYc97I+Z9MYHWO0A643pjaYmz6TZGN/9AqBigrX+eNhL+0Nydnc4Gg4OcDIJVvRhLc0WrhvXstoSH/fGI4ySYwjCbB+jBz6Erzvd/jAb15o6MyCmmGQNYxQuK1y9PcXcOIKeA64+bWuORxEAN06DYTz97sPaGu3VN88xOLw3RixEFIUtC4Fhwew+uROmd/MWEIBX+hY8BRsya9hqUnzkHWCSW50hIdayzHbdFlAbDXv4pnmN4K5qHw4bjGHIeNTvkEdgTG+cD3NNwdUlLEZwWE6OSVspxtJp1wCX0SuYQoatUvi/b0KullFoDPtWlfwOJIY9QmDcQyybV3qYXy2lSRKwVRyXDtZKO4AWg+cIYuxP1iIpKAzy6m42JGOKsK3mtTRPaylBhAShWMgG43Q07hEqmEmGZBlhct1BNj5k0XDVrNYf0budYWe4j+GxO0DOUGSS12A6YmI0xiExdF9btfQIw/EIAUQ0+aQ7GA+Ry0j+FqzF6Dm53thO4Z8jLbs4NnmvlcL1I9gxOMJHtNdwTHGbW4MuZS3mRJSADcf0TndI8Buvn/HTh4syyrm0yJRqRlOG86oZBQIgG2dVPBhfIlAZ7UUzp/BpKkNNQC6ztlPaxDUdrGvRmCOwEE2vQ5lmpSCNHrZpWTjmyByDHgbdQY4tsx48H7F8A6QEDOEp2Nwbm9Sj5KONRwNy0AAxhGed7iHRbQ2LoB52R8iTzGAzOoJIG+H9McDoFsSYF87NgBdAmmZJQV6nE8gwifndf9xv0BtMH2dkNJGmBhnBQdNsy4v5099wEgU65gdrekcMRSALDzFEb05G5KfdlE4f0l7ao0ga0jdM7JONh7iZE4FWfA/JiSD6IbgbW9NjPzV0QXv08MIQcT0cmIjOx0UwFdQzPqSKMkBAkDO6BQ2Y9Eb1oBgGSARrhmxCZmnjEQAGqFJjZIaEOcL6FOJ9Awl5IrVQPJBaSEbQHEAcILPpkOR6oMOmBvTBLj3ipLxmmIhgMejToQxJDE1OmuplLEY29ynwRsS48M4BluHfeLhbk49AE61uCsZBooBFEVxwV0YlgmLd0BTFWzokNgJ/IUyIWPopGKsHOHbDMEx3iDppiLJlksvUPap/LaozFEjIQRAGRiH3mVJITFKjVKmRm9IiYMj27cyiX/Bxl0wrMBjn20nX3wZyuA0HpUbW6YKyhsSfw4Khh/mU1VHfh5hBq2sIhbJkPKDZ9of5EqtNub8oAxSpqYmtfDuc+9tBXUR6emZEF3ViukmXShHYE3PUXSA4NimD5MU8jMGmKA3H3bO+EdJpf7gdnMVsirmdUZD6h1SuKB/7TTePOJEcMd4wH2IOVMZ1xOnY04MWXuyf+YSitQjkrhmteHLIMWblCoxMCcdr5BCTfCQzzpw9WUGPIPcWsQV2z4p4yy0qYH36qcIr1X6V6LDQHya0llAKEX09w0wpIoHEEt4DHlYHhyNW0Pm+QlshgoaAaUT5RwIDYIKoQNJgfjzvmlDNjOZoAUqkjN7NYRCpLJN2ra4ps6RkADqiVmF3U0GQF1XSeobpDOcT0YnxaJv6zE8nx+uUy/2ipudppzslkeEUxTHxS5dG7KJKIJwO8/FjYUQslzVZsd3U5+RrkZMgaHLUhSH5owZWoNivEttSdcppa6DfUaQKtVF6mBFVDwg25Cpldt5R8JwiordUkxlU+ohjE5HTCJ3SsilwBH8+3FYsw7zIjP52AKTbU8IzhVmZmJ4KIprLlMzpVXP8aVBua02r8Er3kCoOB4Y4xB8LZpImNNg0sk0JpSdZTkGQUZFXsNPUQzVEKiJDjYXdFLKvCmokTTTsFmJoMDaKjEyB33czI5oOcZDiUGVQc1QaSRzAcUNQ+SFOMhdDACKVkaAGb6qc/DocKIj33lTw9pFCqdUxaTosFJ75VTDRkHSN0cf9qSy0aoU6zSnLzV4oFyqdcg4IttbkhuK6dNBBUSBMKGmze1PUUPRBf1AobcwaDKdSqgwK8WHofDgqpHqfaJu8QpWp22mTSOsoRE4XMhw2jellRSITHI887iqTaUPyWgsepD8zjEAtTnaAQzl0kTAdPEdoZNBamA/wU+MeqWEk5FAZezqmImIy5Gm80mkPjK4AHGmfsKBiNhyDJegQVct0FQQSirnOTS9BWmeJkejAUUlNEtGS+IAOpjI5pMaKOhOqwXlK/QZl8HYXQ3QKa0emFRqOTYbQMHgYjqzhYTY2Qt1oTMoLqlZDI7C11SZ1lLf7eGdojakno8Orfq04MISwIW/kIroBw9GDaWpsc7DB3BwPwWvUGYHYxlhjBcHGTFHJKeRo2P6wc7Yq7BKqaaed4j0wEQ6WwphCu9YANOillkHdIKRG40I8E+IDKks4FnWhXeoEDMkhLw1GQwSW1YYl/SEUU4QKPCb1XmiAnuGqQVHfulQrAE465e68TRIJI6j+Esu7BA1c0s3JP9hOIUz6ALdKThqSEkUaG02U0duo3V24FKFn9LORh6TrYTB1dGPYq2ibPrl5mGKXlMYiBk13U6nKpjoXrNdk1D8YqIni+vAITXIfp3YSh1tiBrIeoTrstse1lAQFJY+F7olsaQ/RGlqtLEeTkyrqZohMqR8d9lNjWP8xdjJJmlKCP9Ye06THhpJOCwpYo4mQ+mOqPeNpN0tvqzGpQsK6RRtCD0PVVKd9LbbrkEBvEXBID8jqHnxAsnPU75o8RvLkilgOj13qIlG5yKoewQaU+/AYiKNrGXW+0h/uFtS+9czTnukgYBC1YoATzovYkPpp2FSlyGgRX9LqQo2YkGTrlOPbqc7bODal0RC0ntXahKPpIts4HqY7RK8HGuJ0nN6QNu43OchXFdPHRLRR1iTQ4N8BxdNoWHAcKSmSyON2rgvCGQ/A4wdYUTWoZxkg2GBQfwUNLqHQImJBP9pqmyMj1NCiwL4h2AySAHGNZ33qVi2FGoii1mr3jO/bB3iaE5GukLOo7iGCaHNstNKHEDCRjrRp0+5DvEXUBnpf6VvtPkmGIeK4j73aVD9oSYdkKn6v9E1zThEPM3pZNyNvGXvgxxUqs7Q+U7Si4zaxJtUrZBA6MNBCiwIEsOStNmVGFW4iBqIuCRrF9N2YDoABU3fpN9EUdaUY3RojqGixpGcyjGo8NYim7lK3TVoLfWtm4orUfT8jOu/SmgcspEbeMA1wIbVNiQgpXhSiXkquh28oSYfUOQ+JfU3VAtaDLmWfARQFY2zWK6oYoEeFv0qRBDrCBKkn7hJ4lvE7+IoqQ96mckVNS4eiQXVNoFRJp4zNIhqN2NnNq6ZMg9jH8oWMviSbfllhyCzBGJccz7h57WDMFZ9jS8et+SWrwTwmffa4L639o2ssFYxzNysLVuZqweNS+S6PmBC+4Lw41t5GdXsfvj0CL8aRHn4J/thBFV6f57zO2RN82crndvGn69IWQrq0Ax1AMCVqVuwqQUcXwozmmwOm9GcxWz4dhFleI2SuZK7wYi2FTmgXm2ub3lS2lB5tq+rm0eJCSoEhtCPphVhhFC0dFSlsJ10hysYs8+hgaEsXk6VZFk5QNguFD8OYii2BsRSTnNvKjee0H3JhNpNTWByllGQhM0dRmTM1XLAn/uJnPE5/Y2gu3ekeZMeFCSwoexUmdKi94nXLFtKLCs9wC3MT5NTUjyOyYlEIvGXhFdeSWliKe5mwqgVEmADiQ502QTApYsnK8CQHppHai8NLyclPtk3TLjxB7nM0tyRzuGN8K5XQTCo7xEEEgqcclG0HHqdpwMOs6avlxNkeJLKAGP7gCxgflgB5KQmyFQ8D0hEM+kqmeyQXPJLS8jANhUjgzry7mGqRWeUAc7WEFstM2IKHFoJIJ7ANMa6Uby0iimGwihAfOGiFBgkxCKGNMPGksBlcJc2kbO35PA5jpjF1JSQhy3zNnzCA4SVVgR+0+VOSG1niSoeTr7Efj3IdqlDbcFYilI/4pBiS/LHs6cYWuSJVkt7RcIZj0eYIUcXIpVqoBWCGBLSljpymUNgwh+k2Fy6cxRFacL+EDZxeUxSNGF/bztTGCzAjrbhTXqtypYXHtCLbmCdZYAeCs+/ni2McbctWzeBRtYWw4sei1MwKOUWzgAEaZgXFe2ceXmrN0go8qqRdZq5tF3HkTOOcT3eAz5GhvIYIl9v5DTRYmf5g/Ils49t7F4ZaqRSIJyGBAqLTYUjkiJKCjo+DBMyxVxmF2pIiGygEAaDA3/gXuBid0xyYtuQ2uQluwR4H3g2lMQmygIeKkGLK43Zgh8JypeGX3VK7UlmWozC0EzpCah+55ii7wxRnBlVElYRBiOWp5YJG3fbElAM4cZlQ2lVmYnzeEmW0I9uOMEllHkA/lnkRsay3kxiJyFZ28NlpckHycnBTjRfxyE/zD2wTLHCdBVmlV6w/4vwv4v3oP87OBfF9hY+wrGW4m4nIHB9cxpTaOdZOV5Xp182n39l6P9L1JGZdTrKIs04Ww22eBqJMLTJ2xgSe7GsF/57LYksT54lmUpe7s0hIfq5/LFAUfOszG6Nxw1Wagt1PU2Mh0pQqHG0ZIMqaLAYVJV6COJNk77xN3ERbIl1AlVpaLoUjklbY0pYCLAe4BZjcRl5Iyy7yhMpjhCwDpeNtsDX+7c2QW8q3wePcj5gbc3Lj6cAXFyK7hTLTV8j4qSCQ5gfEyESZhzhO87ZLxBk+OmPS/BuoDChsICFuU01giTLBqOmns/VNchfKiUbFBIt5NjbybAvbfRexvfXb2Nnhb3/CMJPfAxG59Xpmfe84Qg0C8zxZ3Zx+HYN+QPKwvzLJO7lBNaVDflWkLBh3tTJeIiVhrZq9E+AQsIpDB/p1ViM+9lDvOCg7dqJQi8mINif02RcZCi3fOsYqMfGuIILi4WN0yIyK4Y48QxsVTGaCviLeQJtcEUR2BpkBTKgmcFN+OEFQ8Bg9uluPwoqA/wze3Op6DiNi46jNiC95pWVplJ1Io8LJBASJwJj8d2ZV5tcxwUj57FIaEPqDT94lNUJNqUDDg3jhSjdivNYzTrW7rltlVXawsJyzK7ma44k/eY0PUov/hDb6jGCrVZGxH1eRz2q/hg2fz1u+mmPCwxBrEBbzVA6llyCCEG+8IT2KJCsVyvPCBaQpwl2JNuY35QxeyAK8c9pDkooxfXkalVWgnsfO53XXLUQiIQaaqyjhRezLPgXe5JvguxqoRVOl+SjPPP4YhxTRz8+KEYDsEbVTPrLJg0pM/jYptuQWqubU7Xz60h6b25OJeJPkDtVmLSsVzUMH7yzzKotEQDI6saAeLRnDXEvFEA3WqmRIFrz1LSNlSaB/GJGHKq4pF0Ct2o7ICNcF7bCtF1CaOVM6vVt5Tdl0J281Ev7HAa2tkBtKM/77EFgojnPC3ZoD5Veww76lDFwi9/MBVTDkBrQdtraNT20RTP4Lq/0toqAcLCIQ+KqHIfaEj0hPyCoVCIfHnjblmhdBazJVvAlHW8YfG8zVMeMfZ3FY+GTMojJLth7Bvg3sM+BvJDGOlBQdVCpiqnNTEr88/niuYYrkqQMlZ4G0TCpuPoQyzWPKB4O3tAKAbKovdA2pI2VFsFkABuSJ5VuvRIBR2jLxAsTB5s8jCJRQP6VIjigLsXSC8duXhDBxfbWx7VXwIVgL/vSIzIWrXAWVkIBZTK4g8jxMxJRSiEO/sHnrd3GMK1A0xNarYAp/HvGgy7Z+BnKayQDBr42g4Ef53RZi5pOwg7zpojZXUMeBoGzwIPZMja6T2Pwc4oEatc3fPqOWcpYaL13N+CfJXB88bk08pDKLny3YYTAsZsYmH+eMFFaIMV5tJMzkH6ip8djkVmS5gOK+kk3uA4lx9VYOZhDsTRIVbBMz1xNFAvG+wPtVUmr3gzNeTKaKzRh7VibXM0t5C9TV8AuZOIW4mNyC2dnoCX+OhQ7lx+a7FQLs7zi1US4cM/lzF9L2w4wtSG5qy9aDpma5SagwRKrCr4uqhY3hXO1Cu9fwj8S94jYxuk8IVpkShZIjqcPJG9poJU/Q1EgTCsNlglwIyBjlAno3n8XU+zGdspdqpOKWL1xWIUVM8lNojcaBWc5tqLs2fw/m/iIMTaIdiaOpd4Sq8/l1SN7JhzAe9RaSfYXxLQcGULH5rJSa25FGatOPXRAWsZg+wCLKM+CLzlEqUvih6Wdrqov07FFlEM6+AHPS2p1DYFuGlZDumqSDA7qzbUhKuMMCtyHNMgpWtw7HMEOGSxWOTpYdtnF00QNBKssh1eb4CRpzUwyFGzqr9ZC1IaxsoX3TKlLPw2oskCyLwohBkoDenIDSpygxoip4guSBE9Q67CeVh6qCF9BJDqRouCxwfHhINek9aKDwxqpX4QHqlGS2B/4VLsBhDbRaJI2c2L2G2wn369JHLVg0NqBdlFDOiamJBbPCCGqEMDlegxtYfBZhbDM30tS27WleWKLIDjNZeMuBRyS8KeaIr7Apxc6GwUQdy+1GtByjSXeRB2FolR0OZebJqpAnO9QFtBMzziJDy06SADvb6NpluHcXepPLGW8SgZjmxTRWjKnCYyoySjkEgraaqij00hYYSzcVgxZioC/n4gieZFWPKk0ZDgo4ZaA/T+xNrYakntldBy1SixJZAX9MuvI5eARR7iTkK1JeQjR8QYsf8DDzA9OSkheo2UNWrOhi9cEBEbqhzaHPJKRkIkQ2P08UNl25MTOwtsV9jFKEegCL6naISG1GPHBoo2XUJgQrsrIsbRMSSDXT11F881io6cGIIIjFbeYsBGVf2xb3HWqYGjxq24h2JGzT9NPKwWAw1m8B0aSCZtdVtKYEr3jOUhkt/QIiDlkIxsV4+6FRhbZirmoOFIXyl+EQ3pKpEK4dktt5lCS+1JXQTzThNF2RUErVdL0RArLAnTJq1qZ+j3lpBVIJqk4KpxLuETZxq9HOnLhex5LkBtXDilbOvHaIZYplHxRV0I/pzohlWEQJxbwsEAGFaZsyx1aZTmICBq5fuprNKYWywI3WtLjjijatCaDdIGtdeWagk7QeQGezMrJM+LR4QH2BWVtBNOFb0iZ2uKprDk9BqCY5bJKBjiPCGHOVuglSEg5qA6f8NgsnXdNcOAtmCoSXtBFDq9pDo+KwbgJuIMGpWYSaB7sCYzz4g3jXim1henPXomgtU48CkaVYsAbPoqUl9kUNFZSnNjXBLAC1qEXTIyVMlnEUi0WxXQEU4L56ikCmJSkcAo4k+g7MIgnGCBwkMBgNRlhe2SzWYNpcWYYDmYi1IJoxS3/S8YJdFIIwI/P5+ipbYpC5AGEuoghHZl9UsYoOym1SuWXomDAq/BnbJFkuvkxSpbcEJiHrjM3RIl+IEJ9KT9Ii2414kd+agt0SFtKb2ivL3phmk8MdjwQTl49vcqCEjAAznAe/Cco06qnJZ3ij7O85vAuwQr1A0ahkWRd9G4zmLK4wp7zE1EHIEyPyTOChIjuUCIZ35oPQVz5wg19oiTKWRbkksxWcfwM4EUKGs5ompiTTtLGEdrCV5+rUCCCmR/YpkYV5xD2UUqtG4WMmkvHQhHtCHGjB80fNmiAza3LgQ9rX5J6MhEAoyRoFAYvCKqLYE7nkKS+2o3CjzFhUouo7EfoZMK0qc70Ai6Cl2S5Ch4kWiQKrGMKnmhG4V3Pt9H/Fsa6A8pYiwk+YBNx2m+XYLHJqWnXKxJKS1H1RP1ysK1BfXpan9WaAuqbNoijed6VIaQyfxLR0RnKZYgwAo9qspikUWzlWlNJQ9PAkwhMbWmbhiCZY4eSTMgtR4pBxS3M2irxChZFV7OqXleUthsQVfJcZAJGOptIn9aptmhyte4EApS4bkSk8K2OORQK5IXml7HOoIRvGeApaK0GKmOVjswArVROKh4gkhUpA12hHdo4aYMIcb03X0qSQgb1PqXotAsfDM3Em5HYHCkGkSI/jkUo7E9HKft+Tjlm9NLqmQWsSJMEFyAhtM0UX8NUUmtzyaWeCiRYbyop70O+AOHPRVboWWlXQuaoQJ6AYIFoxkEuLUjB6b5erxLsTrZRzkZwu3PuEkjTnAUxPTqWPeMEwAzy8gorh6AD2U9ik1O9SuqkVCndtg8QrMZ7D9XOMlvNBg7JJlG9Tqw+PbRAGVkjL/VYrkAFxvgeBRWEJNQpczWKcgCEZSXYLSTpPhRYUZOmYmNkyJyvMsTnSkSotYxStFfRmCDtD9NBN03U54Vp7zEoBZBjKr+SQvDJWc8os8mlLFOsAYOXUhysht4jzETtwK/TgopSuW9kbMKQn3GzTcqVA10UWSHIEtAP6fshezJore9n0X7UqyTX4N96O+qV5b66CxHqOY5aJicWceXVCE06w0ZzzyYr1wz4LbkC0km6Yrs9pUxjNcryom95TCbO6BN3HROiYlozTshIVdvKIaxQTXtXFmpFLp5QkSTNO0p6cRMQuHaoW0JAF5h7lHS3+g0uJK+BMi9YyHRRnWnBF/FYKEoKeYPVq4sOj1DdK06jaxMp04oVYUXXcDMOj3aASWKd+o2zIUTjasDo6AcsyvarpzWiqu1Gy7CYxpDBnhMwicYQZeH4Xss6zeHHaBakAGog8Eu51m0Gq26ZgxhdKGKd9IfKGWVS3iSW4jBG2IU1GkACQvuO14BTbdzEWUENN0bywACQCkhNFEXGofbVQcGkVHK4TaCLkSpvO/iCGkOfY06wUORaPHJtILbI9aRaAKT1pdSpknk+Lhgg1+AfaDfWW9G4C9LRFSlmK1XmQiKYBOZ18qawJtgf9XVajVWNB+l5rSFrpQ394jhUWtjok33usEZFLOmtIHEUnlUyJo8BR1GiTaodBkJ7o1Gq8ItkFtIa9IPWSv/f0yUYRaA8dE7rb2C8i9lRCipDMZqQPKJUCylASGjL0uM8jF06jT6Qw8VilJQcbfiTV4xQp6JN6IkVM8eSjzhVSDHHj2gEdLzG6jM2h+YfDR6E5+QMaZgtqWjRolY1Vw4BgkRo8GgS+nGo2KqSFpZJWXCEQkGHSLOEZRCNpmyYvw3sLBAnToQhcZ7t/wQFSlGYhV2AVNWvUN9aQao5DXEAalTAOkRH4S0Pd2RT8tHIZUNhqEpfgBZKlZc2TqMydMuQG8hc4mL46HYR0IgTkq6nHRxqxWkBnV4FbBHFEbTZBhyhWJO1J8JsehRiKFhftQqCSA6nF1NTo0QtEeJr8b9ExRCR8oy057QDxjLxUtI4Oc30O5RolZgWOFpW5DorzKNyLjBor/FxoCIWmmhY1TSvGp7gWJ1Gp1ZfwEp1cMknCSbelxhihzToBnZIx4oOKf5AwFGKieIvOGYLFJK3lAj1d54aBQH6eQ+0GJq2JHIlGUIfVnLFvVS2ZE7iy5fCi+1solm65t2iRSJTBqjnfRctzSkXoBUxoWGJRhsI4DWYI3RTzlKme6fc1LW0KOqUHbQEciMCVWDSnx2TpjM9wLZV0KTSf4lotrZf2l06Urig9q/TcUonlJau9OqyUa6rfaa/SSdFK0i+Bu4fddspWBt1Sl6n+iD6qNRyXc4eNzRXJvSYz15TSFZxgk+5K6pAy7ztsNC6Nh6viZXLrUo/9FrM7Df4pLibfnLzghsk9k5/70E9K9gWa5gV8K5rMibfryTX+5ODkY3yZlSZfk/owl5Ovbf2S3N1wwnk7WnL5/si9nn1Bbr6NvWJy+6/cw/8T5+PJ7T7jN984+XtraXKf04psdtfkEWu//f6vT35kqaYm7508Itjmd/mXOb+Qb34VPek34s1vfMB/I/+FzS8i+vZt/RB7WC82V/8p0p/0+OaQXyLl1l/y+evGk5fwxa2vIRhvGvGHn8SHN5RuKd1Ruvdp+ZA8SBc/mg9m1Iw76brXwdhc+Niia2hn4NSPyMblfM45vnKqzPx7ffs3PHHbxevzoYpbt87CwXesnJL1A15rZVAV2m863uGLWyt2Szc7m8efur+fX7q7dF/plU/X34W701pKzm3R5Y19c5Fu4XE89OkyoJZFYT0L3/PsMju7tLnLXjyYLNR69jqPF8NK1uzoi9YWw+qcd+csIHh5dIpnA7feUNm+xYuD5QtcPpLhgqx7ZTeSq4vW/NzmBTtj4e+AxbMR+7eXXli6/6mjwdrDgcGDLr2qGRopLhIvyMRqjXNzZVXvECjvBw7D+27IgxUv9NDwQeXPe2JufS1+nVVbE16nEs0AgX9uBS++kL97HoJ2IRTxunb2Rvwd2UE7vORJHL9TDtyKLLin9ODTyYFu4XO6iizNRuYTb9NEMMlBHzcZdC1zif4Mwv9jPLPfZ2W3oI1byeYO8oXLw3Zrnsv9PFjy9wzKSxqK85ZZZMAu6wN62R1IHsr5S7NnzS3XHb4Wrl1g8Qxia/PlO2IQ7IDBsxD7d5VeBBRe83RwKKK/l5mPRSDedVrr08WjlnlhTM/pw5XdTpZqlATadgZ58AF74WRwPFXWoptUddjhcqF5KuTZVbp96X12x16VHc39NzlxRduRFf/bmSBTac7fcpnNV/hi185unbter76c23tGo6j7Fr88n23+wVPOj5Olq0rXlm5+mrj06QpmbSoAXR08o0Jgf1ZHR8K4pe2b5X2Vu2bh2Y+lrtKrnnvdSzr65rdZm85Ojtwpxq8oXX8+XEMRTleBT6stXa1PH+0cZqAYkH01G1nmsz698WAGsf3TcuGovG1lr5y7lr+Y71r6ifWNjfWO7g12OYOZ6MjKwL9kuSHmds9f4l+lkqwp5uaEt6hkzltS792/y+qtbr7uqWLwLMTxC6AvHyi9+ulrntMkP9gm+a6mT9aN6dJ5ujZ5xjTDGyd081qZ3SAbzTxo2tWavSGXa4tH75W5ZXdWXfsNM+WYByqn+NwbOw9EyzWXr8QHZCbnDhzdCPcPLvzL78ExO+FyELlxG5B5UellT4tnQPZEM0BBpL20XCgf+mzFIdNb0WdmW8gR+vBMZwaQ/Ev03Ad04/L8iqsgR+Y8odwNX64uBXb2eXfPHdx7yyxg0Guvf19r5Ua1wCyuJ/9g25+0y34wtyh23Vq57Y4oP7C5uiMOO2nQy84HhZTuVXBadLa6RVc7fiJADsxCh/5mxGUwF/JoYDG5r+Go7H9FgMNVwtsI5O4FO6i8exZA/DTX3059/bFKmq7Mce5PvkFYBJlemv/Od556H3AT6sMrSz9ceuj8ujJNn4mnZsCiDzEUbbD5tJEpxU+cJTMozRPdOBpnly7dbGWXzvn6VyOHnXiOvWi37HnevPbx6fLcWeBzsIUO/WK/tXQwsrnwm5pzd9DrtezuvspLz06dp4PX80uvLb2x9JbSO552VT+7iaaPsfVSc9+HookGNgY4TR+zfeaA441D5Vuau/T8ZTJzr9DrOlzdP7du77Nly44qjvKy258R+K5IrvKOu9k8b+ydO6ZqR2wr2KPaQRJU7Ijna+UVccf3DWKwI+/dez5Zt0PNmbYlYEWjgukOHGmVPibeMffCadFNOrL+eAZU+MnHI3PVXZXaXKAzW5djXnEFz8K71ev0vrK+0H5gRqR4JiZfWQne3G6+w7LnPV4NygldZbURvk1ftGA5mx99GnXqpaVXlV6PrPvBoUUf89peNUyzbaWXn6HzzB0crGcCrudplaRvLlt3ZqqZyvhSPnctvsNysGJvBCvL1f3PAGQfkXtvnPOb1kgGIrs8u06kB225Fqzb+7PND+5Mkzvm2LXIsVeWXld6c+nhp9vj9+m2MdN7H5jPI26DRJ/D3AnWDkk/kuWjWSi/cPXilWbD1U6cJnWdB1JmLZ5cKhsna/Xj58jBv+Hhwn5vKbLn3zkTSWjvWbusXF11+Cq/QlZ5/cjqVU5r62xcf6vSGameijf/9KnXusvOZ8V4R5akpZtilcB8vphutTOjhYJzEu36yqOxyHqVsr0iRFLtl+915TOQW80gsXMnO/yqNreTkxdfYW/u2xGM8Em0+otKLy+9Burjx57+GRMjParm1jBmPaG7YwNFn94lUWL16WYLOq394PNpwuX8gfCqqLVxt9s5sXvphnP7qZbev7bf7di9gT2ayQmWeHQqn+Nze57tq+zwBv6av/Zs8NprfFk5dXfxy/vbnl7rbX7zKeuNa0ovPJ8KVnChub+dWWbIzPLmsGuo8ckANNvNYn3oX+zl8auYtXj15VUuV92kIjZsvjxvRyfO4cD/aK9Y/qLOnZ+YBXwXQ1wc+eDywi2XObx1FedVXv3E49rjjXStd8Hmnqe6dvTs0q3ns0ZNt7owJGfu6VednpocTs9MdjNC1PRteWs8HLTSan8Wi0e7Vf3qu1pXV60HIud3JL/q1EYWK3uX9efW3MkH7cbJ+z90x0bvZ2YBzLXNU+71a0uDzErKnvQu6u9pr8ulXK8du+Hd/mL71FvWr73zvs2vfu+adO69U69CPj2HVqif7t1TFd04im5dCASK02SDXMzsjqqJqxsXMN1a5O5iaHdme3/VP+RZ6qkFHX9Uh3/V2lSPv9vqk/n1ZkT8naV7zsuvdD/I7R7XnIahm7zQPTPMnfRm6GV78YS97Lstvr56P/P/g2XdHdbv5PE1crb+/gM5f4UtD6oVO2seOu7ayzbXsnrh0A1Pfue75zh/Z9/fW3pJ6WW0Sv20fU93eaSQHoJ4qlaL7rAxPSdc3HTG1AK6QWBxY7bO7KBw7WoyshdiL+8sLMuDcjX0E193hFT140l9uc3bC7x2Ysa42M2+7XfsgRv7XkevJ6t+/Wiy1HaXUeEzN774CdB5rH6fi89zS3eYldIHzhMh5EV/vM07dLeYPrGPuV0ulYjRGMp4dsgcX/UbN0edtbrwGi63/bLnxidbId8fy3DGvLT+Cnc55OEeW69FImwIxefe/lP2Za5/JNz8d4+HYuc8+YGgYO5BOS3QeWsfy80rI7r/VItuJmSgmR0KN73TyhLOQ7eR9Nb9MI73qOeF1VOiPphb4smNkbhpxli8m+5twFN79x43bMiTPp+/ZPlYqHv28qZ3TlaEO2JxE955EB0JrYeeT82gs5nmMiIoWHM3wGFxbRcVD3T+5h5T5tx+a3rys2bOtM3sDuiNq5zGcV27ks9dtDInebiqncANl3VydMTX7XmH28ty9TfrDR3r8vtmXV7yF5Yby5fz+pX1S2paHnfrePi8v2zxff56gydaVXh9q/UEXLZzDj2rdB2we9755BBhhj5kWuN7dE/OEV1sNCtMbvtlO3kxd69WzrIrubNv+bYZp4jwqgn3rNddbbvJ7Sd2qdYTZMaT5cYpePj5ePfFdPb//PycmfvnET919tEVRhaqhmkd6G6F1NCjk6/MsJjftLirev3aMe4tLr99fb3jrq6jmdvf2z/jyI+GcTYnq3vDK3X9YLWeNRqXXsZX1Kpdh8Tau9F27M7G5iPngrIzJjeierwEtYNWJc+rfmTmtD/d+8vcadXciK5QVwCnuDIpf2a4iuurI1Y/njYl+MkPXX/Zzo7IdnPXe8BRuaPX8t96Znjq1rh6pCYXqoHn17R9uHHB0Z+8N9zTG71qR4raGadLTGW5p3Q/ast51xUI4oGyjCCmG+9nBVLlbp4V6/x4OW/NDqBbGyftxvF7Jn+k97Ts/Y4SXhZzvfLBddda3ruxMVtU/kkuvKCeta9857tcu1aNQ0fZP2vbzNLvSp7LwyvCW7dq5+bPzhr4CtSMO0p3I4fOh9HyVnW78R7R/YHpTuh0yuw0NIPuzODY/FKrtjexeyEL6zH/hLvUM5i4eKLfO1ss/nm0xssf0SxI/knzypynGrYBg3lsc/fjUQieRP++CnrrTbSOeH6dIsp3r+AqWqVK6e6K5g6Gp6+h73aeMG1mV2nujyLr5AKvOyt2U7fv467/SR3WjkVW43Zen/zj2Qn0ktmi9X/k3BWuP+jY9fkjxxzG9YLPufST0dBPjtpnJ9O58D0JfvdCK/9I6W109cD5rLIYtKbr+QRR38A4rUXbrX7R6Q+6EXtGcbypfjis+dxdthdVPQ93693zkSfWNG9cKReba2sLN3z5GcayObToJhSrVb/shi1/VdaWtV09nix29tT5XM096n5vSJ+kXv1Q6aVQFG8oPURnOs93daBYLqYGla5e61ORomSkG7zuUMe6xVW3M1xb+1d+yl6m7wxqnNtVzuNQ2zXNJ986G8b368OCezMW5t/03+0tuzzcQx9zi5NQhtxt2PrHEleeDeHPSudK95i/+ZXvn1vvLL2m9MPIzh87v5XlzFyLvi0NaeWtbxbezBP6LxiKvvYZZtf9car0WmW+a++2o7KbhLHNa1fPJYdlNpaVBSkbN2jhPcM0+0159y5d62244YKOj9vLF7aO+LKV6GVbfs+EfDKd/5LSq82VB289X/1obj1cANelhVX6P0XozFtnB0lZFFQ9S0V5V/3ZF1x0oydrF/PFTPOgG8ULscd4NvnG2dh9WHZkrnU7PzBrlbn8oD289u6FQ1UuTyIptfQvfJzg/JwcDHjvieTmk+Tjs34AXUBegJQVZ+Ky6ULFMy1tPvnBxH5hnI1svezanrvREJM/e2YTLYkjIZ3mrdfbnB+95ETTan0fKVaKdsTmmtILgMz5Z9n2CkdaXFlPKxw7wZPlnUFxN/hCo9ZSPbsse3Fy3eK6nL/MfT73F5fDyd+eDdcf8D0dN8/dttXbZ71txvolHoRZg9f3LF7oXlOr1Rvz8srH6ZUH1VGtmm794Y017eUbW42ntFZ1PVTpK4DlG0o/ep58SSAeYebTEOY/tajRfwmwY/9tPuFCy7ozXGqvneT1kV3LrXU/DN2WlvWLF72T57Tj9qLb1bnd6s2aKueP+OlRnsjL3bpMRsxqP/89j6PKW+093q4LNj/7/a+XHEe9e23p9UDvbed57rZmzkZtS9HTHWK1UKZjc41yvn0pQ3fw2BLKTEG8v3K1rl127+SL5aB8uM4bXtNd0ouvCO1f0nFyLLEbz+dXd113eYPvPjpr/CqvPfyct4fv4Hr+EmnbF641a5cck3Tr79BH9bOywSF96UP8du4f61xzbrljpTO+Lij9f4JLRUh42mNgZGBgYGRwXOR0ZFc8v81XBnkOBhA469qrgkyzLWE3BFIcDEwgHgAf6AjeAAB42mNgZGBgN/x/g4GBgwEE2JYwMDKgAn0ASyQC8wAAAHjaY3rD4MLBwMDA+AeC2dkZUthZGX4BcQpVMTt1MeMXBgYA83IXSgAAAAAsACwALAAsAL4bDhuwHGgdLh3qHqwfeiAeIOAhrCJwIzIkCiTsJcQmnieAKEYpJCn+Ksordiw0LQQtyC6OL2owHDDmMboyhjNINCg1EjX2Nto3vjiMOXI6Ujs0OzwAAQAAAC8UKQCgAAAAAAACAAAAAQABAAAAQAAuAAAAAHjalVHNTsJAGJwWNNHExHjw3It/B5sCiih6IDTGgwcCRs4FSiEUmrQF5SIv4dt48GBi9Im8Ovt1Qa626e58s/PNzm4B7OITBtSzPpoyZzgnKMN5HKzwJudDrhr5LVavONLYoOpNY5Mr7xrn1nCe7xJv4BkfGm/CNKoab+PFuNF4D9fG0vML+8aPxt9wzJ1FLU6TRhTOB34v9kJ32PXdomM1/WAaerHV9jv9aJIuUEOMlDETNBAhxBwD+OiR9Vi5GKLL2kURDiwco44TmVsYYUpFSO0UAV+fPXOuNTj79EuotFmrTgcVwTXpsNCkb8CdUqpUpfSqfyZ721jI9yhcQm2ECXUFssqrgCp3aZHJqj92QGXKxEo/W3XYuOBYxZhnGtFTafpkQzp3mM/GuXwVlFhdcucHOg0lW1+8UqIndiumK+fzyKmsFk+vEk54Hgu3Wl1faSIiS/zL4haTGRPd6Rs4xT2ZQO7ZluTjf/4TdXuB/AuPijarzlrq7AZakkXlU6uKLct4hiu6lDhmTFHusfQLhExwggAAAHjabctJcgEBAEbhr5uKAziCeQiNYGuhjTFPRyBVqVQ2Fk5Ps/Y2/1v8T+jFfaDtHU2CMEhJycrJKygqKauoqqn71Eg+kVbSd3zp6ukbio2MTUzNzH1bWFpZ29ja2Ts4OgXpj/Pv7f/Sylz/fqIoGj43TuQBiIUSLgABUR/cpAAA) format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
 /* top-level dialog */
 .ui-dialog {
   padding: 0px;
+  font-family: 'Proxima Nova', "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
 }
 
 .ui-dialog .charsheet {
@@ -200,12 +209,12 @@ input::placeholder {
 
 /* headings */
 .sheet-sd h1 {
-  line-height: 16px;
-  font-size: 14px;
+  line-height: 20px;
+  font-size: 13px;
   background-color: rgba(11, 11, 11, 0.25);
   color: #fafafa;
-  margin: 4px 8px 4px 0;
-  padding: 2px 8px;
+  margin: 4px 0;
+  padding: 4px 8px;
   text-transform: uppercase;
   background-image: linear-gradient(to right, rgba(11, 11, 11, 1), rgba(11, 11, 11, 0));
 }
@@ -231,11 +240,12 @@ input::placeholder {
 }
 
 .charsheet .sheet-sd .sheet-form-body button[type=roll] {
-  font-size: 16px;
   border-radius: 4px;
   border: 1px solid green;
   background-color: rgba(0, 50, 10, 0.5);
   padding: 2px 16px;
+  width: auto;
+  margin: 2px 8px;
 }
 
 .charsheet .sheet-sd .sheet-form-body button[type=roll]:hover,
@@ -323,13 +333,8 @@ span.sd-text {
 
 /* buttons */
 .charsheet .sheet-sd button[type=roll] {
-  padding: 2px 6px;
-  font-size: 10px;
-  text-transform: uppercase;
-  margin: 2px 0;
   text-align: left;
-  vertical-align: bottom;
-  background-color: transparent;
+  vertical-align: middle;
   background: none;
   color: #111;
   font-weight: bold;
@@ -337,9 +342,11 @@ span.sd-text {
   border-radius: 0;
   box-shadow: none;
   text-shadow: none;
-  padding: 0;
+  padding: 6px;
   margin: 0;
-  font-size: 12px;
+  font-size: 15px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .charsheet .sheet-sd .sd-core-stat button[type=roll] {
@@ -351,7 +358,7 @@ span.sd-text {
 }
 
 .charsheet .sheet-sd button[type=roll]:hover {
-  background-color: #fafafa;
+  background-color: rgba(0, 0, 0, 0.25);
   color: #000;
 }
 
@@ -428,7 +435,6 @@ span.sd-text {
   line-height: 11px;
   font-weight: bold;
   margin: 0;
-  white-space: nowrap;
   width: auto;
   text-transform: uppercase;
   color: #666;
@@ -658,8 +664,14 @@ label.sheet-form-checkbox {
   font-weight: normal;
 }
 
+.sheet-sd .sd-attacks {
+  white-space: nowrap;
+  margin-right: 46px;
+}
+
 .sheet-sd .sd-attacks button[type=roll] {
   width: auto;
+  white-space: wrap;
 }
 
 /* display multiple lines of test for feature desc */
@@ -716,12 +728,28 @@ label.sheet-form-checkbox {
   z-index: 9999;
 }
 
+.ui-dialog .charsheet .repcontainer .repitem .itemcontrol {
+  position: static;
+  height: auto;
+  min-height: 30px;
+}
+
+.ui-dialog .charsheet .repcontainer .repitem {
+  min-height: 30px;
+}
+
 .sheet-sd .sheet-checkbox-cog {
   display: inline-block;
   height: 20px;
   position: absolute;
   align-self: flex-end;
   width: 20px;
+}
+
+/* hide form edit buttons and feature details in Modify Mode (roll 20 uses .editmode class when repeater "Modify" is clicked) */
+.sheet-sd .repcontainer.editmode .repitem .sheet-fieldset-item .sheet-checkbox-cog,
+.sheet-sd .repcontainer.editmode .repitem .sheet-fieldset-item .sheet-feature-details {
+  display: none;
 }
 
 .sheet-sd h1 .sheet-checkbox-cog {
@@ -760,19 +788,15 @@ label.sheet-form-checkbox {
   opacity: 1;
 }
 
-.sheet-darkmode .sheet-sd .sheet-checkbox-cog span {
-  color: #666;
-}
-
 .sheet-sd .sheet-checkbox-cog span {
-  align-items: center;
+  align-items: normal;
   border-radius: 50%;
   box-sizing: border-box;
   display: flex;
   font-family: 'Pictos';
   font-size: 20px;
   height: 100%;
-  justify-content: center;
+  justify-content: flex-end;
   left: 0;
   opacity: 0.5;
   color: #333;
@@ -781,8 +805,12 @@ label.sheet-form-checkbox {
   width: 100%;
 }
 
+.sheet-darkmode .sheet-sd .sheet-checkbox-cog span {
+  color: #666;
+}
+
 .sheet-sd .sheet-checkbox-cog span::before {
-  content: 'y';
+  content: 'y'; /* y = Pictos font Gear icon */
 }
 
 .sheet-sd .sheet-field-toggle:not([value])+*,
@@ -925,7 +953,7 @@ label.sheet-form-checkbox {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1000;
+  z-index: 10000;
   height: calc(100vh - 50px);
   max-height: calc(100vh - 50px);
   overflow: auto;
@@ -1131,18 +1159,20 @@ label.sheet-radio {
 /* luck tokens */
 .luck-tokens {
   display: inline-block;
+  vertical-align: top;
 }
 
 .luck-tokens input[type=checkbox] {
   cursor: pointer;
   border-radius: 50%;
-  width: 0.85em;
-  height: 0.85em;
+  width: 1.2em;
+  height: 1.2em;
   background-color: #333;
-  vertical-align: baseline;
+  vertical-align: sub;
   border: 2px solid #aaa;
   appearance: none;
   outline: none;
+  margin: 0 2px;
 }
 
 .luck-tokens input[type=checkbox]:checked {
@@ -1195,7 +1225,11 @@ input[type=checkbox].atk-fixed:checked {
   color: #666;
 }
 
-.sheet-sd .legal .sd-credits {
+.sheet-sd ol {
+  margin: 4px 0;
+}
+
+.sheet-sd .legal ul.sd-credits {
   list-style: none;
   font-size: 11px;
   margin: 0;
@@ -1204,6 +1238,10 @@ input[type=checkbox].atk-fixed:checked {
 .sd-gear-slots span {
   display: inline-block;
   min-width: 2em;
+}
+
+.sheet-sd .sd-gear-slots label {
+  white-space: nowrap;
 }
 
 .sheet-sd .sd-gear-slots input[type=text].sd-text {
@@ -1240,11 +1278,21 @@ input[type=checkbox].atk-fixed:checked {
   width: 100%;
 }
 
+.sd-gear-noslots-screen textarea.sd-text {
+  min-height: 360px;
+  resize: none;
+}
+
 /* attempt to make sheet work on a phone */
 @media (max-width: 550px) {
   .sheet-section-npc-stats,
   .sheet-section-pc-stats {
     flex: 0 1 100%;
+  }
+
+  .sd-gear-noslots-screen textarea.sd-text {
+    min-height: 420px;
+    width: 100%;
   }
 }
 

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -616,9 +616,9 @@
 			<div class="sheet-form-group">
 				<label class="sheet-form-checkbox" title="@{show_counters}">
 					<input type="checkbox" name="attr_show_counters" value="1">
-					<span>Custom Resource Counters</span>
+					<span>Show Custom Resource Counters</span>
 				</label>
-			</div>			
+			</div>
 			<div class="sheet-form-group">
 				<label class="sheet-form-checkbox">
 					<input type="checkbox" name="attr_init_tiebreaker" value="1">
@@ -638,12 +638,12 @@
 					<li>Click the button to Import JSON or Monster Text. Warning: This will overwrite existing data but will not clear attacks and spells, features, or custom counters.</li>
 				</ol>
 				<label>JSON (Shadowdarklings format) or Monster Text (Core rules PDF format)</label>
-				<textarea name="attr_json" title="@{json}"></textarea>
+				<textarea class="sd-text" name="attr_json" title="@{json}"></textarea>
 			</div>
 			<div class="sheet-form-group">
 				<label class="sheet-form-checkbox" title="@{sheetwipe_confirm_flag}">
 					<input type="checkbox" name="attr_sheetwipe_confirm_flag" value="1">
-					<span>Confirm Import: "By checking this box, I officially swear that I want to replace my stats"</span>
+					<span>Confirm: Ackowledge that importing will replace stats</span>
 				</label>
 				<div>
 					<button type="action" name="act_importjson">Import Shadowdarklings JSON</button>
@@ -652,7 +652,7 @@
 			</div>
 			<div class="sheet-form-group">
 				<label>Version:</label>
-				<input type="text" name="attr_version" value="2025.8.31.0" hidden disabled>
+				<input type="text" name="attr_version" value="2025.9.3.0" hidden disabled>
 				<span name="attr_version"></span>
 			</div>
 			<div>
@@ -2193,7 +2193,3 @@
 		};		
 	</script>
 </div>
-
-
-
-

--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -643,7 +643,7 @@
 			<div class="sheet-form-group">
 				<label class="sheet-form-checkbox" title="@{sheetwipe_confirm_flag}">
 					<input type="checkbox" name="attr_sheetwipe_confirm_flag" value="1">
-					<span>Confirm: Ackowledge that importing will replace stats</span>
+					<span>Confirm: I acknowledge this import will replace stats</span>
 				</label>
 				<div>
 					<button type="action" name="act_importjson">Import Shadowdarklings JSON</button>


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

The phone app experience is now pretty decent - as long as "Auto Roll Damage" is checked!

- Version 2025.9.3.0
- Fixed mobile d20 dice font: the dice icons now show for rolling initiative and stats
- Fixed fonts and style for repeaters for Features/Traits and Spells/Attacks for better readability and to reduce overlap
- Fixed some wide elements which were causing mobile to overflow (the import options)
- Luck tokens now 50% bigger!
- **Includes previous patch fix for the "Modify" mode in Spells/Attacks/Features** - no conflicts expected
- The Gear/Treasure text area is now much taller, but can no longer be resized