### PR TITLE
[Draw Steel] NPC sheet updates

### DIFF
--- a/Draw Steel/draw-steel.css
+++ b/Draw Steel/draw-steel.css
@@ -635,7 +635,7 @@ label.sublabel {
 
 .sheet-rolltemplate-powerroll,
 .sheet-rolltemplate-ability,
-.sheet-rolltemplate-simplepowerroll {
+.sheet-rolltemplate-abilitypowerroll {
   background-color: #f5f5f5; /* eggshell */
   font-family: 'Georgia', serif;
   padding: 16px;
@@ -646,22 +646,22 @@ label.sublabel {
 }
 .sheet-rolltemplate-powerroll.sheet-rolltemplate-darkmode,
 .sheet-rolltemplate-ability.sheet-rolltemplate-darkmode,
-.sheet-rolltemplate-simplepowerroll.sheet-rolltemplate-darkmode {
+.sheet-rolltemplate-abilitypowerroll.sheet-rolltemplate-darkmode {
 	background-color: #333333;
 	color: #ddd;
 }
 
 .sheet-rolltemplate-powerroll .sheet-header,
 .sheet-rolltemplate-ability .sheet-header,
-.sheet-rolltemplate-simplepowerroll .sheet-header {
+.sheet-rolltemplate-abilitypowerroll .sheet-header {
 	grid-column-start: 1;
 	grid-column-end: -1;
-  font-size: 2em;
-  font-weight: bold;
+	font-size: 1.2em;
+	font-weight: bold;
 }
 
-.sheet-rolltemplate-powerroll, 
-.sheet-rolltemplate-simplepowerroll {
+.sheet-rolltemplate-powerroll,
+.sheet-rolltemplate-abilitypowerroll {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 }
@@ -679,7 +679,7 @@ label.sublabel {
         line-height: 1.4;
 }
 .sheet-rolltemplate-powerroll label,
-.sheet-rolltemplate-simplepowerroll label,
+.sheet-rolltemplate-abilitypowerroll label,
 .sheet-rolltemplate-powerroll .sheet-powerroll-edge-bane {
 	display: unset;
 	margin: unset;
@@ -822,12 +822,12 @@ label.sublabel {
   line-height: 1.4;
 }
 
-.sheet-rolltemplate-simplepowerroll .sheet-header {
+.sheet-rolltemplate-abilitypowerroll .sheet-header {
 	border-bottom:1px solid #aaa;
 	margin-bottom: 6px;
 }
 
-.sheet-rolltemplate-simplepowerroll .sheet-powerroll-tier {
+.sheet-rolltemplate-abilitypowerroll .sheet-powerroll-tier {
 	justify-self: right;
 }
 
@@ -869,16 +869,9 @@ label.sublabel {
 	font-weight: 800;
 }
 
+
 .npc-stats-panel {
 	grid-template-columns: repeat(5, 1fr);
-}
-
-.npc-characteristic-input-group > label {
-	cursor: pointer;
-}
-
-.npc-characteristic-input-group > input {
-	text-align: center;
 }
 
 .npc-stats-panel div {
@@ -887,13 +880,16 @@ label.sublabel {
 	align-items: center;
 }
 
+.npc-characteristic-input-group > label {
+	cursor: pointer;
+}
+
 .npc-stat {
 	font-size: 1.5em;
 }
 
 .npc-skills-panel {
 	grid-template-columns: 1fr auto;
-	justify-items: start;
 	border-bottom: none;
 }
 
@@ -919,15 +915,19 @@ label.sublabel {
 .npc-conditions > .repcontainer[data-groupname="repeating_conditions"] > .repitem {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr ;
-  gap: 0.25em;
+  gap: 0.5em;
   align-items: start;
 }
 
 /* NPC Ability Card Styling */
 
+.npc-abilities-panel {
+	padding-top: 5px;
+}
+
 .repcontainer[data-groupname="repeating_npcabilities"] {
 	display: grid;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: 1fr 1fr;
 	grid-gap: 0.5em;
 }
 
@@ -948,8 +948,8 @@ input.npc-ability-edit-toggle {
 	position: absolute;
 }
 
-.charsheet input.npc-ability-edit-toggle:not(:checked) ~ div.npc-ability-card-edit, 
-.charsheet input.npc-ability-edit-toggle:checked ~ div.npc-ability-card-display {
+input.npc-ability-edit-toggle:not(:checked) ~ div.npc-ability-card-edit, 
+input.npc-ability-edit-toggle:checked ~ div.npc-ability-card-display {
     display: none;
 }
 
@@ -984,28 +984,12 @@ input.npc-ability-edit-toggle {
 }
 
 .npc-ability-card-edit textarea {
-	grid-column: 1/ -1;
 	height: 50px;
 }
 
 .npc-ability-type:has(> option[value*="triggered"]:checked) ~ .triggered-hide,
 .npc-ability-type:not(:has(> option[value*="triggered"]:checked)) ~ .triggered-show {
 	display: none;
-}
-
-.npc-ability-card input[name="attr_has_power_roll"]:not([value="on"]) ~ .npc-power-roll,
-.npc-ability-card input[name="attr_has_effect"]:not([value="on"]) ~ .npc-ability-effect,
-.npc-ability-card input[name="attr_has_special"]:not([value="on"]) ~ .npc-ability-special,
-.npc-ability-card input[name="attr_has_trait"]:not([value="on"]) ~ .npc-ability-trait,
-.npc-ability-card input[name="attr_has_malice"]:not([value="on"]) ~ .npc-ability-malice {
-	display:none;
-}
-
-.npc-ability-card input[name="attr_has_effect"][value="on"] ~ .npc-ability-effect,
-.npc-ability-card input[name="attr_has_special"][value="on"] ~ .npc-ability-special,
-.npc-ability-card input[name="attr_has_trait"][value="on"] ~ .npc-ability-trait,
-.npc-ability-card input[name="attr_has_malice"][value="on"] ~ .npc-ability-malice {
-	display:block;
 }
 
 .npc-power-roll {
@@ -1024,8 +1008,12 @@ input.npc-ability-edit-toggle {
 	margin: 4PX 0px 0px 0px;
 }
 
+.npc-power-roll-mods {
+	grid-column: 1 / -1;
+}
+
 .npc-power-roll-tier-effect {
-	font-size: 1em;
+	font-size: 0.8em;
 }
 
 .npc-ability-details:has([name="attr_has_power_roll"]:not(:checked)) > .npc-power-roll > .npc-power-roll-mods > :not(input[type="checkbox"]):not(label),
@@ -1033,43 +1021,19 @@ input.npc-ability-edit-toggle {
 	display: none;
 }
 
-.npc-abilities-panel {
-	padding-top: 5px;
-}
-
-.npc-abilities-panel .ability-distance,
-.npc-abilities-panel .ability-target {
-	font-size: 0.9em;
-}
-
-
-#npc-ability-subtype-selector:not([value*="villain"]):not([value*="signature"]) ~ .subtype-hide {
-	display: none;
-}
-
-#npc-ability-subtype-selector:not([value*="malice"]) ~ .malice-show {
-	display: none;
-}
-
-#npc-ability-subtype-selector:not([value="trait"]) ~ .trait-show,
-#npc-ability-subtype-selector[value="trait"] ~ .details-hide {
-	display: none;
-}
-
+#npc-ability-subtype-selector:not([value*="villain"]):not([value*="signature"]) ~ .subtype-hide,
+#npc-ability-subtype-selector:not([value*="malice"]) ~ .malice-show,
+#npc-ability-subtype-selector:not([value*="trait"]) ~ .trait-show,
+#npc-ability-subtype-selector[value*="trait"] ~ .details-hide,
 #npc-ability-subtype-selector:not([value="solo-monster"]) ~ .solo-monster-show,
 #npc-ability-subtype-selector[value="solo-monster"] ~ .details-hide {
 	display: none;
 }
 
-
-.npc-ability-subtype.malice-show {
-	grid-column-start: 4;
-	grid-column-end: span 2;
-}
-
 .npc-ability-card-display input[name*="attr_has"]:not([value="on"]) + div {
 	display: none;
 }
+
 .npc-ability-card-display .npc-ability-effect, .npc-ability-card-display .npc-ability-trigger {
 	height: auto;
 }
@@ -1080,11 +1044,7 @@ input.npc-ability-edit-toggle {
   font-size: 0.9em;
 }
 
-.npc-ability-keywords {
-
-}
-
-.npc-ability-type {
+.npc-ability-type, .npc-ability-target {
 	text-align: end;
 }
 
@@ -1092,17 +1052,9 @@ input.npc-ability-edit-toggle {
 	grid-column-start: 1;
 }
 
-.npc-ability-target {
-	text-align: end;
-}
-
 .npc-ability-card-display input:not([value*="triggered"]) ~ .npc-ability-trigger,
 .npc-ability-card-display input[value="no-action"] ~ .npc-ability-type {
 	display: none;
-}
-
-.npc-ability-trigger {
-
 }
 
 .npc-ability-button {
@@ -1115,11 +1067,8 @@ input.npc-ability-edit-toggle {
   border-radius: 5px;
 }
 
-
-
-.npc-ability-card-display > .ability-effect {
-	grid-column-start: 1;
-	grid-column-end: -1;
+.npc-ability-button:hover {
+	background-color: #ccc;
 }
 
 .npc-ability-card-display .npc-power-roll .npc-power-roll-mods button[type="roll"]::before {
@@ -1141,7 +1090,6 @@ input.npc-ability-edit-toggle {
 
 .ability-toggle-group textarea {
 	width: 100%;
-	height: 50px;
 }
 
 .ability-toggle-group input:not(:checked) ~ textarea,
@@ -1172,18 +1120,22 @@ input.npc-edit-toggle {
 	display: none;
 }
 
+input.npc-edit-toggle:not(:checked) ~ div.npc-edit {
+    display: none;
+} 
+
 .npc-edit {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
 	gap: 1em;
 	align-items: baseline;
 	justify-items: start;
-	font-size: .8em;
-	width: 350px;
+	font-size: 0.8em;
+	width: 400px;
 	margin-bottom: 10px;
 }
 
-.npc-edit-grid {
+.npc-edit-group {
 	display: grid;
 	gap: 3px;
 }
@@ -1192,8 +1144,8 @@ input.npc-edit-toggle {
 	grid-template-columns: 1fr 1fr;
 }
 
-.charsheet .npc-edit-stats > input[type="text"],
-.charsheet .npc-edit-stats > input[type="number"] {
+.npc-edit-stats > input[type="text"],
+.npc-edit-stats > input[type="number"] {
 	width: 4.5em;
 }
 
@@ -1202,9 +1154,7 @@ input.npc-edit-toggle {
 	grid-column-gap: 1em;
 }
 
-.charsheet input.npc-edit-toggle:not(:checked) ~ div.npc-edit {
-    display: none;
-} 
+
 
 
 /* Dark Mode */
@@ -1212,3 +1162,123 @@ input.npc-edit-toggle {
 	color: #333;
 }
 
+/* Monster Ability Roll Template */
+.sheet-rolltemplate-monsterability {
+  background-color: #f5f5f5; /* eggshell */
+  font-family: 'Georgia', serif;
+  padding: 16px;
+  border-radius: 10px;
+  border: 1px solid #ccc;
+  max-width: 264px;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+}
+
+.sheet-rolltemplate-monsterability.sheet-rolltemplate-darkmode {
+	background-color: #333333;
+	color: #ddd;
+}
+
+.sheet-rolltemplate-monsterability .sheet-header {
+  font-size: 1.2em;
+  font-weight: bold;
+}
+
+.sheet-rolltemplate-monsterability .sheet-character-name,
+.sheet-rolltemplate-abilitypowerroll .sheet-character-name {
+  font-size: 0.8em;
+  font-style: italic;
+}
+
+.sheet-rolltemplate-monsterability .sheet-subtype {
+  font-size: 0.9em;
+  font-style: italic;
+  margin-bottom: 10px;
+  border-bottom: 2px solid #aaa;
+  padding-bottom: 6px;
+  font-weight: bold;
+}
+
+.sheet-rolltemplate-monsterability .sheet-meta-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  font-size: 0.8em;
+  font-weight: bold;
+}
+
+.sheet-rolltemplate-monsterability .sheet-action-type, .sheet-rolltemplate-monsterability .sheet-target {
+  justify-self: right;
+  text-align: right;
+}
+
+.sheet-rolltemplate-monsterability .sheet-action-row {
+  font-size: 0.8em;
+  display: grid;
+  grid-template-columns: 1fr auto;
+}
+
+.sheet-rolltemplate-monsterability .sheet-effect-block .sheet-effect-label {
+  font-weight: bold;
+  font-size: 0.8em;
+}
+
+.sheet-rolltemplate-monsterability .sheet-effect-block {
+  margin-top: 14px;
+  padding: 10px;
+  background-color: #f0f0f0;
+  border: 1px solid #aaa;
+  border-radius: 6px;
+}
+
+.sheet-rolltemplate-monsterability.sheet-rolltemplate-darkmode .sheet-effect-block {
+	background-color: #0f0f0f;
+	color: #aaa
+}
+
+.sheet-rolltemplate-monsterability .sheet-effect-text {
+  font-size: .9em;
+}
+
+.sheet-rolltemplate-monsterability .sheet-stat-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  margin-bottom: 10px;
+  border-bottom: 1px solid #aaa;
+}
+
+.sheet-rolltemplate-monsterability .sheet-roll-label {
+  font-weight: bold;
+  font-size: 1em;
+}
+
+.sheet-rolltemplate-monsterability .sheet-roll-formula {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-weight: bold;
+  font-family: monospace;
+  box-shadow: inset 0 0 2px #aaa;
+}
+
+.sheet-rolltemplate-monsterability .sheet-tiers {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	gap: 8px;
+}
+
+.sheet-rolltemplate-monsterability .sheet-range {
+	background-color: #e0dbce;
+	padding: 2px 6px;
+	border-radius: 4px;
+	font-weight: bold;
+	font-size: .8em;
+	height: 20px;
+	text-align: center;
+}
+.sheet-rolltemplate-monsterability.sheet-rolltemplate-darkmode .sheet-range {
+  background-color: #5f5d58;
+}
+
+.sheet-rolltemplate-monsterability .sheet-damage {
+  font-size: 0.95em;
+}

--- a/Draw Steel/draw-steel.html
+++ b/Draw Steel/draw-steel.html
@@ -567,58 +567,65 @@
 <div class="npc-sheet-body">
 	<label class="npc-edit-icon" for="npc-edit-toggle">p</label><input class="npc-edit-toggle" type="checkbox" id="npc-edit-toggle" />
 	<div class="npc-edit">
-		<div class="npc-edit-grid npc-edit-text">
+		<div class="npc-edit-group npc-edit-text">
 			<label data-i18n="character-name" for="attr_character_name"></label>
-			<input type="text" name="attr_character_name" />
+			<input type="text" id="attr_character_name" name="attr_character_name" />
 			<label data-i18n="level" for="attr_level"></label>
-			<input type="text" name="attr_level" />
+			<input type="text" id="attr_level" name="attr_level" />
 			<label data-i18n="npc-role" for="attr_npc_role"></label>
-			<input type="text" name="attr_npc_role" />
+			<input type="text" id="attr_npc_role" name="attr_npc_role" />
 			<label data-i18n="keywords" for="attr_npc_keywords"></label>
-			<input type="text" name="attr_npc_keywords" />
+			<input type="text" id="attr_npc_keywords" name="attr_npc_keywords" />
 			<label data-i18n="encounter-value-abbr" for="attr_npc_EV"></label>
-			<input type="text" name="attr_npc_EV" />
+			<input type="text" id="attr_npc_EV" name="attr_npc_EV" />
 		</div>
-		<div class="npc-edit-grid npc-edit-stats">
+		<div class="npc-edit-group npc-edit-stats">
 			<label data-i18n="size" for="attr_size"></label>
-			<input type="text" name="attr_size" />
+			<input type="text" id="attr_size" name="attr_size" />
 			<label data-i18n="speed" for="attr_speed"></label>
-			<input type="number" name="attr_speed" />
+			<input type="number" id="attr_speed" name="attr_speed" />
 			<label data-i18n="stamina" for="attr_stamina"></label>
-			<input type="number" name="attr_stamina" />
+			<input type="number" id="attr_stamina" name="attr_stamina" />
 			<label data-i18n="stability" for="attr_stability"></label>
-			<input type="number" name="attr_stability" />
+			<input type="number" id="attr_stability" name="attr_stability" />
 			<label data-i18n="free-strike" for="attr_npc_freestrike"></label>
-			<input type="number" name="attr_npc_freestrike" />
+			<input type="number" id="attr_npc_freestrike" name="attr_npc_freestrike" />
 		</div>
-		<div class="npc-edit-grid npc-edit-text">
+		<div class="npc-edit-group npc-edit-text">
 			<label data-i18n="immunity" for="attr_immunity"></label>
-			<input type="text" name="attr_immunity" />
+			<input type="text" id="attr_immunity" name="attr_immunity" />
 			<label data-i18n="weakness" for="attr_weakness"></label>
-			<input type="text" name="attr_weakness" />
+			<input type="text" id="attr_weakness" name="attr_weakness" />
 			<label data-i18n="movement" for="attr_npc_movement"></label>
-			<input type="text" name="attr_npc_movement" />
+			<input type="text" id="attr_npc_movement" name="attr_npc_movement" />
 			<label data-i18n="with-captain" for="attr_npc_with_captain"></label>
-			<input type="text" name="attr_npc_with_captain" />
+			<input type="text" id="attr_npc_with_captain" name="attr_npc_with_captain" />
 		</div>
-		<div class="npc-edit-grid npc-edit-stats">
+		<div class="npc-edit-group npc-edit-stats">
 			<label data-i18n="might" for="attr_might"></label>
-			<input type="number" name="attr_might" />
+			<input type="number" id="attr_might" name="attr_might" />
 			<label data-i18n="agility" for="attr_agility"></label>
-			<input type="number" name="attr_agility" />
+			<input type="number" id="attr_agility" name="attr_agility" />
 			<label data-i18n="reason" for="attr_reason"></label>
-			<input type="number" name="attr_reason" />
+			<input type="number" id="attr_reason" name="attr_reason" />
 			<label data-i18n="intuition" for="attr_intuition"></label>
-			<input type="number" name="attr_intuition" />
+			<input type="number" id="attr_intuition" name="attr_intuition" />
 			<label data-i18n="presence" for="attr_presence"></label>
-			<input type="number" name="attr_presence" />
+			<input type="number" id="attr_presence" name="attr_presence" />
 		</div>
-			
+		<div>
+			<span data-i18n="whisper-gm"></span>
+			<select name="attr_wtype">
+				<option value="" data-i18n="never-whisper-roll" selected></option>
+				<option value="?{Whisper?|Public Roll,|Whisper Roll,/w gm }" data-i18n="query-whisper-roll"></option>
+				<option value="/w gm " data-i18n="always-whisper-roll"></option>
+            </select>	
+		</div>
 	</div>
 	<div class="npc-display">
 		<div class="npc-header-panel npc-panel">
 			<div class="npc-name"><span name="attr_character_name"></span></div>
-			<div class="npc-level"><span data-i18n="level"></span>&nbsp;<span name="attr_level"></span>&nbsp;<span name="attr_npc_role"></div>
+			<div class="npc-level"><span data-i18n="level"></span>&nbsp;<span name="attr_level"></span>&nbsp;<span name="attr_npc_role"></span></div>
 			<div><span name="attr_npc_keywords"></span></div>
 			<div><span data-i18n="encounter-value-abbr"></span>&nbsp;<span name="attr_npc_EV"></span></div>
 		</div>
@@ -707,7 +714,7 @@
 				<select class="npc-ability-subtype-selector" name="attr_ability_subtype">
 					<option value="normal-ability" selected data-i18n="normal-ability"></option>
 					<option value="signature-ability" data-i18n="signature-ability"></option>
-					<option value="villain-ability" data-i18n="villain-action"></option>
+					<option value="villain-ability" data-i18n="villain-ability"></option>
 					<option value="solo-monster" data-i18n="solo-monster"></option>
 					<option value="trait" data-i18n="trait"></option>
 					<option value="malice-ability" data-i18n="malice-ability"></option>
@@ -728,7 +735,7 @@
 					<input type="number" placeholder="3" name="attr_ability_malice_cost" />
 				</div>
 
-				<textarea class="npc-ability-trait" data-i18n-placeholder="trait" name="attr_ability_trait"></textarea>
+				<textarea class="npc-ability-trait grid-span-full" data-i18n-placeholder="trait" name="attr_ability_trait"></textarea>
 				
 				<div class="npc-ability-details grid-span-full">
 					<input type="text" class="npc-ability-keywords" data-i18n-placeholder="keywords" name="attr_ability_keywords" />
@@ -745,7 +752,7 @@
 					<input type="text" class="npc-ability-target" data-i18n-placeholder="target" name="attr_ability_target" />
 					<textarea class="npc-ability-trigger triggered-show grid-span-full" data-i18n-placeholder="trigger" name="attr_ability_trigger" spellcheck="false"></textarea>
 					<div class="npc-power-roll">
-						<div class="npc-power-roll-mods grid-span-full">
+						<div class="npc-power-roll-mods">
 							<input type="checkbox" name="attr_has_power_roll" />
 							<label data-i18n="power-roll"></label>
 							<span>+</span>
@@ -815,18 +822,18 @@
 				</div>
 				<input type="hidden" name="attr_has_power_roll" />
 				<div class="npc-power-roll">
-					<div class="power-roll-mods">
-						<button type="roll" data-i18n-title="power-roll-button-tooltip" value="&{template:simplepowerroll} {{roll=[[ [[2d10cs>11cf<0]][2d10]  + [[@{ability_characteristic}]] ]]}} {{name=@{ability_name}}}"></button>
+					<div class="npc-power-roll-mods">
+						<button type="roll" data-i18n-title="power-roll-button-tooltip" value="@{wtype} &{template:abilitypowerroll} {{roll=[[ [[2d10cs>11cf<0]][2d10]  + [[@{ability_characteristic}]] ]]}} {{name=@{ability_name}}} {{charactername=@{character_name}}}"></button>
 						<label>2d10</label>
 						<span>+</span>
 						<span class="power-roll-characteristic" name="attr_ability_characteristic" ></span>
 					</div>
 					<label class="sublabel">≤ 11</label>
-					<span class="power-roll-tier-effect" name="attr_ability_tier_1" ></span>
+					<span class="npc-power-roll-tier-effect" name="attr_ability_tier_1" ></span>
 					<label class="sublabel">12-16</label>
-					<span type="text" class="power-roll-tier-effect" name="attr_ability_tier_2" ></span>
+					<span class="npc-power-roll-tier-effect" name="attr_ability_tier_2" ></span>
 					<label class="sublabel">17+</label>
-					<span type="text" class="power-roll-tier-effect" name="attr_ability_tier_3" ></span>
+					<span class="npc-power-roll-tier-effect" name="attr_ability_tier_3" ></span>
 				</div>
 				<input type="hidden" name="attr_has_special" />
 				<div class="npc-ability-special grid-span-full">
@@ -853,7 +860,7 @@
 </div>
 <rolltemplate class="sheet-rolltemplate-powerroll">
 	<div class="header">
-		<span data-i18n="{{characteristic}}"></span> <span data-i18n="power-roll"></span>
+		{{name}}
 	</div>
 	<div class="powerroll-2d10">
 		<label>2d10:</label> {{2d10}}
@@ -943,7 +950,88 @@
 	</div>
 	{{/rollTotal() hasEffect 1}}
 </rolltemplate>
-<rolltemplate class="sheet-rolltemplate-simplepowerroll">
+<rolltemplate class="sheet-rolltemplate-monsterability">
+	<div class="character-name">{{charactername}}</div>
+	<div class="header">{{name}}</div>
+	<div class="subtype">
+		{{subtype}}
+	</div>
+	<div class="section">
+		{{#rollTotal() hasTrait 1}}
+		<div class="trait">
+			{{trait}}
+		</div>
+		{{/rollTotal() hasTrait 1}}
+		{{#rollTotal() hasSolo 1}}
+		<div class="effect-block">
+			<div class="effect-label">{{solo1name}}</span>:</div>
+			<div class="effect-text">{{solo1text}}</div>
+		</div>
+		<div class="effect-block">
+			<div class="effect-label">{{solo2name}}</span>:</div>
+			<div class="effect-text">{{solo2text}}</div>
+		</div>
+		{{/rollTotal() hasSolo 1}}
+	</div>
+	<div class="meta-row">
+		<div class="keywords">{{keywords}}</div>
+		<div class="action-type">{{type}}</div>
+	</div>
+	<div class="action-row">
+		<div class="distance">
+		{{#distance}}
+			<!-- triangle-ruler -->
+			&#128208;{{distance}}
+			{{/distance}}
+		</div>
+		<div class="target">
+			{{#target}}
+			<!-- bullseye -->
+				&#127919;{{target}}
+			{{/target}}
+		</div>
+	</div>
+	{{#rollTotal() hasTrigger 1}}
+	<div class="effect-block">
+		<div class="effect-label"><span data-i18n="trigger"></span>:</div>
+		<div class="effect-text">{{trigger}}</div>
+	</div>
+	{{/rollTotal() hasTrigger 1}}
+	{{#rollTotal() hasPowerRoll 1}}
+	<div class="stat-row">
+		<div class="roll-label">{{powerRoll}}:</div>
+		<span class="roll-formula">2d10 + {{characteristic}}</span>
+	</div>
+	<div class="tiers">
+		<span class="range">≤ 11</span>
+		<span class="damage">{{tier1}}</span>
+		<span class="range">12–16</span>
+		<span class="damage">{{tier2}}</span>
+		<span class="range">17+</span>
+		<span class="damage">{{tier3}}</span>
+	</div>
+	{{/rollTotal() hasPowerRoll 1}}
+	{{#rollTotal() hasSpecial 1}}
+	<div class="effect-block">
+		<div class="effect-label"><span data-i18n="special"></span>:</div>
+		<div class="effect-text">{{special}}</div>
+	</div>
+	{{/rollTotal() hasSpecial 1}}
+	{{#rollTotal() hasEffect 1}}
+	<div class="effect-block">
+		<div class="effect-label"><span data-i18n="effect"></span>:</div>
+		<div class="effect-text">{{effect}}</div>
+	</div>
+	{{/rollTotal() hasEffect 1}}
+	{{#rollTotal() hasMalprop 1}}
+	<div class="effect-block">
+		<div class="effect-label">{{malpropcost}}&nbsp;<span data-i18n="malice"></span>:</div>
+		<div class="effect-text">{{malprop}}</div>
+	</div>
+	{{/rollTotal() hasMalprop 1}}
+</rolltemplate>
+<rolltemplate class="sheet-rolltemplate-abilitypowerroll">
+	<div class="character-name">{{charactername}}</div>
 	<div class="header">
 		{{name}}
 	</div>
@@ -1031,11 +1119,12 @@
 /**
 **Characteristic Roll
 **/
-$20('.characteristic-input-group > label').on('click', async (e) => {
-		const characteristic = e.htmlAttributes['data-characteristic'];
+
+	async function rollPower(characteristic) {
 		const attrs = await getAttrsAsync([characteristic]);
 		const characteristicValue = attrs[characteristic];
 		const characteristicTranslation = getTranslationByKey(characteristic) || characteristic;
+		const powerRollTranslation = getTranslationByKey('power-roll') || 'Power Roll';
 		const edgeOrBaneTranslation = getTranslationByKey('edge-or-bane') || 'edge-or-bane';
 		const noEdgeOrBaneTranslation = getTranslationByKey('no-edge-or-bane') || 'no-edge-or-bane';
 		const doubleEdgeTranslation = getTranslationByKey('double-edge') || 'double-edge';
@@ -1053,18 +1142,19 @@ $20('.characteristic-input-group > label').on('click', async (e) => {
 				`|${edgeTranslation},2[${edgeTranslation}]` +
 				`|${baneTranslation},-2[${baneTranslation}]` +
 				`|${doubleBaneTranslation},0[${doubleBaneTranslation}]` +
-			`}]][${edgeOrBaneTranslation}] ` +
-			` + [[?{${bonusOrPenaltyTranslation}|0}]][${bonusOrPenaltyTranslation}] ` +
+				`}]][${edgeOrBaneTranslation}] ` +
+				` + [[?{${bonusOrPenaltyTranslation}|0}]][${bonusOrPenaltyTranslation}] ` +
 			']] ' +
 			'{{2d10=$[[0]]}} ' +
 			'{{characteristicValue=$[[1]]}} ' +
 			'{{edgeBane=$[[2]]}} ' +
 			'{{bonus=$[[3]]}} ' +
 			'{{total=$[[4]]}} ' +
+			`{{name=` + characteristicTranslation + ` ` + powerRollTranslation + `}} ` +
 			`{{characteristic=${characteristic}}} ` +
-			`{{isDoubleEdge=[[0]]}} ` + // placeholder for computed value
-			`{{isDoubleBane=[[0]]}} ` + // placeholder for computed value
-			'{{tier=[[0]]}} '; // placeholder for computed value
+			`{{isDoubleEdge=[[0]]}} ` +
+			`{{isDoubleBane=[[0]]}} ` +
+			'{{tier=[[0]]}} ';
 		console.log('roll', roll);
 		startRoll(roll, ({ rollId, results }) => {
 			console.log('roll results', results);
@@ -1093,6 +1183,16 @@ $20('.characteristic-input-group > label').on('click', async (e) => {
 			const tier = Math.max(1, Math.min(3, tierBase + tierMod));
 			finishRoll(rollId, { isDoubleEdge, isDoubleBane, tier });
 		});
+	}
+
+	$20('.npc-characteristic-input-group > label').on('click', (e) => {
+		const characteristic = e.htmlAttributes['data-characteristic'];
+		rollPower(characteristic);
+	});
+	
+	$20('.characteristic-input-group > label').on('click', (e) => {
+		const characteristic = e.htmlAttributes['data-characteristic'];
+		rollPower(characteristic);
 	});
 
 /**
@@ -1228,224 +1328,311 @@ $20('.characteristic-input-group > label').on('click', async (e) => {
   startRoll(roll, ({ rollId }) => finishRoll(rollId));
 	});
 
-/**
-**Melee Free Strike Display
-**/
-on('clicked:melee_share', async (event) => {
-  const attributeNames = [
-    'melee_free_strike_name',
-    'melee_free_strike_keywords',
-    'melee_free_strike_distance',
-    'melee_free_strike_target',
-    'melee_free_strike_characteristic',
-    'melee_free_strike_tier_1',
-    'melee_free_strike_tier_2',
-    'melee_free_strike_tier_3'
-  ];
+	/**
+	**Melee Free Strike Display
+	**/
+	on('clicked:melee_share', async (event) => {
+	  const attributeNames = [
+		'melee_free_strike_name',
+		'melee_free_strike_keywords',
+		'melee_free_strike_distance',
+		'melee_free_strike_target',
+		'melee_free_strike_characteristic',
+		'melee_free_strike_tier_1',
+		'melee_free_strike_tier_2',
+		'melee_free_strike_tier_3'
+	  ];
 
-  const attrs = await getAttrsAsync(attributeNames);
+	  const attrs = await getAttrsAsync(attributeNames);
 
-  const directMap = {
-    name: attrs.melee_free_strike_name,
-    keywords: attrs.melee_free_strike_keywords,
-    distance: attrs.melee_free_strike_distance,
-    target: attrs.melee_free_strike_target,
-    characteristic: attrs.melee_free_strike_characteristic,
-    tier1: attrs.melee_free_strike_tier_1,
-    tier2: attrs.melee_free_strike_tier_2,
-    tier3: attrs.melee_free_strike_tier_3
-  };
+	  const directMap = {
+		name: attrs.melee_free_strike_name,
+		keywords: attrs.melee_free_strike_keywords,
+		distance: attrs.melee_free_strike_distance,
+		target: attrs.melee_free_strike_target,
+		characteristic: attrs.melee_free_strike_characteristic,
+		tier1: attrs.melee_free_strike_tier_1,
+		tier2: attrs.melee_free_strike_tier_2,
+		tier3: attrs.melee_free_strike_tier_3
+	  };
 
-const rollValueMap = {
-  hasPowerRoll: '1'
-};
+	const rollValueMap = {
+	  hasPowerRoll: '1'
+	};
 
-  const roll = `&{template:ability} `
-    + '{{powerRoll=^{power-roll}}} '
-    + '{{type=^{main-action}}} '
-    + Object.entries(directMap)
-        .map(([key, value]) => `{{${key}=${value}}} `)
-  + Object.entries(rollValueMap)
-   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
+	  const roll = `&{template:ability} `
+		+ '{{powerRoll=^{power-roll}}} '
+		+ '{{type=^{main-action}}} '
+		+ Object.entries(directMap)
+			.map(([key, value]) => `{{${key}=${value}}} `)
+	  + Object.entries(rollValueMap)
+	   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
 
-  console.log('Melee Free Strike roll:', roll);
-  startRoll(roll, ({ rollId }) => finishRoll(rollId));
-});
+	  console.log('Melee Free Strike roll:', roll);
+	  startRoll(roll, ({ rollId }) => finishRoll(rollId));
+	});
 
-/**
-**Melee Free Strike Power Roll
-**/
-on('clicked:melee_power_roll_share', async (event) => {
-  const attributeNames = [
-    'melee_free_strike_name',
-    'melee_free_strike_keywords',
-    'melee_free_strike_distance',
-    'melee_free_strike_target',
-    'melee_free_strike_characteristic',
-    'melee_free_strike_tier_1',
-    'melee_free_strike_tier_2',
-    'melee_free_strike_tier_3'
-  ];
+	/**
+	**Melee Free Strike Power Roll
+	**/
+	on('clicked:melee_power_roll_share', async (event) => {
+	  const attributeNames = [
+		'melee_free_strike_name',
+		'melee_free_strike_keywords',
+		'melee_free_strike_distance',
+		'melee_free_strike_target',
+		'melee_free_strike_characteristic',
+		'melee_free_strike_tier_1',
+		'melee_free_strike_tier_2',
+		'melee_free_strike_tier_3'
+	  ];
 
-  const attrs = await getAttrsAsync(attributeNames);
-  const characteristicValue = attrs['melee_free_strike_characteristic'];
-  const characteristicTranslation = getTranslationByKey(characteristicValue) || characteristicValue;
-  const edgeOrBaneTranslation = getTranslationByKey('edge-or-bane') || 'edge-or-bane';
-  const noEdgeOrBaneTranslation = getTranslationByKey('no-edge-or-bane') || 'no-edge-or-bane';
-  const doubleEdgeTranslation = getTranslationByKey('double-edge') || 'double-edge';
-  const edgeTranslation = getTranslationByKey('edge') || 'edge';
-  const baneTranslation = getTranslationByKey('bane') || 'bane';
-  const doubleBaneTranslation = getTranslationByKey('double-bane') || 'double-bane';
-  const bonusOrPenaltyTranslation = getTranslationByKey('bonus-or-penalty') || 'bonus-or-penalty';
+	  const attrs = await getAttrsAsync(attributeNames);
+	  const characteristicValue = attrs['melee_free_strike_characteristic'];
+	  const characteristicTranslation = getTranslationByKey(characteristicValue) || characteristicValue;
+	  const edgeOrBaneTranslation = getTranslationByKey('edge-or-bane') || 'edge-or-bane';
+	  const noEdgeOrBaneTranslation = getTranslationByKey('no-edge-or-bane') || 'no-edge-or-bane';
+	  const doubleEdgeTranslation = getTranslationByKey('double-edge') || 'double-edge';
+	  const edgeTranslation = getTranslationByKey('edge') || 'edge';
+	  const baneTranslation = getTranslationByKey('bane') || 'bane';
+	  const doubleBaneTranslation = getTranslationByKey('double-bane') || 'double-bane';
+	  const bonusOrPenaltyTranslation = getTranslationByKey('bonus-or-penalty') || 'bonus-or-penalty';
 
-  const directMap = {
-    name: attrs.melee_free_strike_name,
-    keywords: attrs.melee_free_strike_keywords,
-    distance: attrs.melee_free_strike_distance,
-    target: attrs.melee_free_strike_target,
-    characteristic: attrs.melee_free_strike_characteristic,
-    tier1: attrs.melee_free_strike_tier_1,
-    tier2: attrs.melee_free_strike_tier_2,
-    tier3: attrs.melee_free_strike_tier_3
-  };
+	  const directMap = {
+		name: attrs.melee_free_strike_name,
+		keywords: attrs.melee_free_strike_keywords,
+		distance: attrs.melee_free_strike_distance,
+		target: attrs.melee_free_strike_target,
+		characteristic: attrs.melee_free_strike_characteristic,
+		tier1: attrs.melee_free_strike_tier_1,
+		tier2: attrs.melee_free_strike_tier_2,
+		tier3: attrs.melee_free_strike_tier_3
+	  };
 
-const rollValueMap = {
-  hasPowerRoll: '1'
-};
+	const rollValueMap = {
+	  hasPowerRoll: '1'
+	};
 
-  const roll = '&{template:ability} ' +
-			'[[ [[2d10cs>11cf<0]][2d10] ' +
-			` + [[${characteristicValue}]] ` +
-			' + [[?{' +
-				edgeOrBaneTranslation +
-				`|${noEdgeOrBaneTranslation},0` +
-				`|${doubleEdgeTranslation},0[${doubleEdgeTranslation}]` +
-				`|${edgeTranslation},2[${edgeTranslation}]` +
-				`|${baneTranslation},-2[${baneTranslation}]` +
-				`|${doubleBaneTranslation},0[${doubleBaneTranslation}]` +
-			`}]][${edgeOrBaneTranslation}] ` +
-			` + [[?{${bonusOrPenaltyTranslation}|0}]][${bonusOrPenaltyTranslation}] ` +
-			']] ' 
-    + '{{powerRoll=^{power-roll}:&nbsp;$[[4]]}} '
-    + '{{type=^{main-action}}} '
-    + Object.entries(directMap)
-        .map(([key, value]) => `{{${key}=${value}}} `)
-  + Object.entries(rollValueMap)
-   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
+	  const roll = '&{template:ability} ' +
+				'[[ [[2d10cs>11cf<0]][2d10] ' +
+				` + [[${characteristicValue}]] ` +
+				' + [[?{' +
+					edgeOrBaneTranslation +
+					`|${noEdgeOrBaneTranslation},0` +
+					`|${doubleEdgeTranslation},0[${doubleEdgeTranslation}]` +
+					`|${edgeTranslation},2[${edgeTranslation}]` +
+					`|${baneTranslation},-2[${baneTranslation}]` +
+					`|${doubleBaneTranslation},0[${doubleBaneTranslation}]` +
+				`}]][${edgeOrBaneTranslation}] ` +
+				` + [[?{${bonusOrPenaltyTranslation}|0}]][${bonusOrPenaltyTranslation}] ` +
+				']] ' 
+		+ '{{powerRoll=^{power-roll}:&nbsp;$[[4]]}} '
+		+ '{{type=^{main-action}}} '
+		+ Object.entries(directMap)
+			.map(([key, value]) => `{{${key}=${value}}} `)
+	  + Object.entries(rollValueMap)
+	   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
 
-  console.log('Melee Free Strike power roll:', roll);
-  startRoll(roll, ({ rollId }) => finishRoll(rollId));
-});
+	  console.log('Melee Free Strike power roll:', roll);
+	  startRoll(roll, ({ rollId }) => finishRoll(rollId));
+	});
 
-/**
-**Ranged Free Strike Display
-**/
-on('clicked:ranged_share', async (event) => {
-  const attributeNames = [
-    'ranged_free_strike_name',
-    'ranged_free_strike_keywords',
-    'ranged_free_strike_distance',
-    'ranged_free_strike_target',
-    'ranged_free_strike_characteristic',
-    'ranged_free_strike_tier_1',
-    'ranged_free_strike_tier_2',
-    'ranged_free_strike_tier_3'
-  ];
+	/**
+	**Ranged Free Strike Display
+	**/
+	on('clicked:ranged_share', async (event) => {
+	  const attributeNames = [
+		'ranged_free_strike_name',
+		'ranged_free_strike_keywords',
+		'ranged_free_strike_distance',
+		'ranged_free_strike_target',
+		'ranged_free_strike_characteristic',
+		'ranged_free_strike_tier_1',
+		'ranged_free_strike_tier_2',
+		'ranged_free_strike_tier_3'
+	  ];
 
-  const attrs = await getAttrsAsync(attributeNames);
+	  const attrs = await getAttrsAsync(attributeNames);
 
-  const directMap = {
-    name: attrs.ranged_free_strike_name,
-    keywords: attrs.ranged_free_strike_keywords,
-    distance: attrs.ranged_free_strike_distance,
-    target: attrs.ranged_free_strike_target,
-    characteristic: attrs.ranged_free_strike_characteristic,
-    tier1: attrs.ranged_free_strike_tier_1,
-    tier2: attrs.ranged_free_strike_tier_2,
-    tier3: attrs.ranged_free_strike_tier_3
-  };
+	  const directMap = {
+		name: attrs.ranged_free_strike_name,
+		keywords: attrs.ranged_free_strike_keywords,
+		distance: attrs.ranged_free_strike_distance,
+		target: attrs.ranged_free_strike_target,
+		characteristic: attrs.ranged_free_strike_characteristic,
+		tier1: attrs.ranged_free_strike_tier_1,
+		tier2: attrs.ranged_free_strike_tier_2,
+		tier3: attrs.ranged_free_strike_tier_3
+	  };
 
-const rollValueMap = {
-  hasPowerRoll: '1'
-};
+	const rollValueMap = {
+	  hasPowerRoll: '1'
+	};
 
-  const roll = `&{template:ability} `
-    + '{{powerRoll=^{power-roll}}} '
-    + '{{type=^{main-action}}} '
-    + Object.entries(directMap)
-        .map(([key, value]) => `{{${key}=${value}}} `)
-  + Object.entries(rollValueMap)
-   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
+	  const roll = `&{template:ability} `
+		+ '{{powerRoll=^{power-roll}}} '
+		+ '{{type=^{main-action}}} '
+		+ Object.entries(directMap)
+			.map(([key, value]) => `{{${key}=${value}}} `)
+	  + Object.entries(rollValueMap)
+	   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
 
-  console.log('Ranged Free Strike roll:', roll);
-  startRoll(roll, ({ rollId }) => finishRoll(rollId));
-});
+	  console.log('Ranged Free Strike roll:', roll);
+	  startRoll(roll, ({ rollId }) => finishRoll(rollId));
+	});
 
-/**
-**Ranged Free Strike Power Roll
-**/
-on('clicked:ranged_power_roll_share', async (event) => {
-  const attributeNames = [
-    'ranged_free_strike_name',
-    'ranged_free_strike_keywords',
-    'ranged_free_strike_distance',
-    'ranged_free_strike_target',
-    'ranged_free_strike_characteristic',
-    'ranged_free_strike_tier_1',
-    'ranged_free_strike_tier_2',
-    'ranged_free_strike_tier_3'
-  ];
+	/**
+	**Ranged Free Strike Power Roll
+	**/
+	on('clicked:ranged_power_roll_share', async (event) => {
+	  const attributeNames = [
+		'ranged_free_strike_name',
+		'ranged_free_strike_keywords',
+		'ranged_free_strike_distance',
+		'ranged_free_strike_target',
+		'ranged_free_strike_characteristic',
+		'ranged_free_strike_tier_1',
+		'ranged_free_strike_tier_2',
+		'ranged_free_strike_tier_3'
+	  ];
 
-  const attrs = await getAttrsAsync(attributeNames);
-  const characteristicValue = attrs['ranged_free_strike_characteristic'];
-  const characteristicTranslation = getTranslationByKey(characteristicValue) || characteristicValue;
-  const edgeOrBaneTranslation = getTranslationByKey('edge-or-bane') || 'edge-or-bane';
-  const noEdgeOrBaneTranslation = getTranslationByKey('no-edge-or-bane') || 'no-edge-or-bane';
-  const doubleEdgeTranslation = getTranslationByKey('double-edge') || 'double-edge';
-  const edgeTranslation = getTranslationByKey('edge') || 'edge';
-  const baneTranslation = getTranslationByKey('bane') || 'bane';
-  const doubleBaneTranslation = getTranslationByKey('double-bane') || 'double-bane';
-  const bonusOrPenaltyTranslation = getTranslationByKey('bonus-or-penalty') || 'bonus-or-penalty';
+	  const attrs = await getAttrsAsync(attributeNames);
+	  const characteristicValue = attrs['ranged_free_strike_characteristic'];
+	  const characteristicTranslation = getTranslationByKey(characteristicValue) || characteristicValue;
+	  const edgeOrBaneTranslation = getTranslationByKey('edge-or-bane') || 'edge-or-bane';
+	  const noEdgeOrBaneTranslation = getTranslationByKey('no-edge-or-bane') || 'no-edge-or-bane';
+	  const doubleEdgeTranslation = getTranslationByKey('double-edge') || 'double-edge';
+	  const edgeTranslation = getTranslationByKey('edge') || 'edge';
+	  const baneTranslation = getTranslationByKey('bane') || 'bane';
+	  const doubleBaneTranslation = getTranslationByKey('double-bane') || 'double-bane';
+	  const bonusOrPenaltyTranslation = getTranslationByKey('bonus-or-penalty') || 'bonus-or-penalty';
 
-  const directMap = {
-    name: attrs.ranged_free_strike_name,
-    keywords: attrs.ranged_free_strike_keywords,
-    distance: attrs.ranged_free_strike_distance,
-    target: attrs.ranged_free_strike_target,
-    characteristic: attrs.ranged_free_strike_characteristic,
-    tier1: attrs.ranged_free_strike_tier_1,
-    tier2: attrs.ranged_free_strike_tier_2,
-    tier3: attrs.ranged_free_strike_tier_3
-  };
+	  const directMap = {
+		name: attrs.ranged_free_strike_name,
+		keywords: attrs.ranged_free_strike_keywords,
+		distance: attrs.ranged_free_strike_distance,
+		target: attrs.ranged_free_strike_target,
+		characteristic: attrs.ranged_free_strike_characteristic,
+		tier1: attrs.ranged_free_strike_tier_1,
+		tier2: attrs.ranged_free_strike_tier_2,
+		tier3: attrs.ranged_free_strike_tier_3
+	  };
 
-const rollValueMap = {
-  hasPowerRoll: '1'
-};
+	const rollValueMap = {
+	  hasPowerRoll: '1'
+	};
 
-  const roll = '&{template:ability} ' +
-			'[[ [[2d10cs>11cf<0]][2d10] ' +
-			` + [[${characteristicValue}]] ` +
-			' + [[?{' +
-				edgeOrBaneTranslation +
-				`|${noEdgeOrBaneTranslation},0` +
-				`|${doubleEdgeTranslation},0[${doubleEdgeTranslation}]` +
-				`|${edgeTranslation},2[${edgeTranslation}]` +
-				`|${baneTranslation},-2[${baneTranslation}]` +
-				`|${doubleBaneTranslation},0[${doubleBaneTranslation}]` +
-			`}]][${edgeOrBaneTranslation}] ` +
-			` + [[?{${bonusOrPenaltyTranslation}|0}]][${bonusOrPenaltyTranslation}] ` +
-			']] ' 
-    + '{{powerRoll=^{power-roll}:&nbsp;$[[4]]}} '
-    + '{{type=^{main-action}}} '
-    + Object.entries(directMap)
-        .map(([key, value]) => `{{${key}=${value}}} `)
-  + Object.entries(rollValueMap)
-   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
+	  const roll = '&{template:ability} ' +
+				'[[ [[2d10cs>11cf<0]][2d10] ' +
+				` + [[${characteristicValue}]] ` +
+				' + [[?{' +
+					edgeOrBaneTranslation +
+					`|${noEdgeOrBaneTranslation},0` +
+					`|${doubleEdgeTranslation},0[${doubleEdgeTranslation}]` +
+					`|${edgeTranslation},2[${edgeTranslation}]` +
+					`|${baneTranslation},-2[${baneTranslation}]` +
+					`|${doubleBaneTranslation},0[${doubleBaneTranslation}]` +
+				`}]][${edgeOrBaneTranslation}] ` +
+				` + [[?{${bonusOrPenaltyTranslation}|0}]][${bonusOrPenaltyTranslation}] ` +
+				']] ' 
+		+ '{{powerRoll=^{power-roll}:&nbsp;$[[4]]}} '
+		+ '{{type=^{main-action}}} '
+		+ Object.entries(directMap)
+			.map(([key, value]) => `{{${key}=${value}}} `)
+	  + Object.entries(rollValueMap)
+	   .map(([key, value]) => `{{${key}=[[${value}]]}} `);
 
-  console.log('Ranged Free Strike power roll:', roll);
-  startRoll(roll, ({ rollId }) => finishRoll(rollId));
-});
+	  console.log('Ranged Free Strike power roll:', roll);
+	  startRoll(roll, ({ rollId }) => finishRoll(rollId));
+	});
 
+	/**
+	** Monster Abilities Share
+	**/
+	
+	on('clicked:repeating_npcabilities:share', async (event) => {
+		const abilityAttributeNames = [
+			'ability_name', 'ability_subtype', 'ability_malice_cost', 'ability_description', 'ability_keywords',
+			'ability_trait', 'ability_solo_1_name', 'ability_solo_1_text', 'ability_solo_2_name', 'ability_solo_2_text',
+			'ability_type', 'ability_distance', 'ability_target', 'ability_trigger',
+			'has_power_roll', 'ability_characteristic',	'ability_tier_1', 'ability_tier_2', 'ability_tier_3', 
+			'ability_effect', 'has_effect', 'ability_special', 'has_special', 'has_malice', 'ability_cost', 'ability_malice',
+		];
+		const attrs = await getAttrsAsync([
+			'character_name',
+			'wtype',
+			...abilityAttributeNames.map(x => `repeating_abilities_${x}`),
+		]);
+		
+		const characterName = attrs.character_name;
+		const wtype = attrs.wtype;
+		let subtype = '';
+		
+		switch(attrs.repeating_abilities_ability_subtype) {
+			case 'signature-ability':
+			case 'villain-ability':
+				subtype = getTranslationByKey(attrs.repeating_abilities_ability_subtype) || '';
+				break;
+			case 'malice-ability':
+			case 'malice-trait':
+				subtype = attrs.repeating_abilities_ability_malice_cost + ' ' + getTranslationByKey('malice');
+				break;
+		}
+		const type = attrs.repeating_abilities_ability_type === 'no-action' ? '' : getTranslationByKey(attrs.repeating_abilities_ability_type);
+		
+		const directMap = {
+			name: attrs.repeating_abilities_ability_name,
+			subtype: subtype,
+			trait: attrs.repeating_abilities_ability_trait || '',
+			type: type,
+			keywords: attrs.repeating_abilities_ability_keywords || '',
+			distance: attrs.repeating_abilities_ability_distance || '',
+			target: attrs.repeating_abilities_ability_target || '',
+			trigger: attrs.repeating_abilities_ability_trigger || '',
+			characteristic: attrs.repeating_abilities_ability_characteristic || '',
+			tier1: attrs.repeating_abilities_ability_tier_1 || '',
+			tier2: attrs.repeating_abilities_ability_tier_2 || '',
+			tier3: attrs.repeating_abilities_ability_tier_3 || '',
+			special: attrs.repeating_abilities_ability_special || '',
+			effect: attrs.repeating_abilities_ability_effect || '',
+			malprop: attrs.repeating_abilities_ability_malice || '',
+			malpropcost: attrs.repeating_abilities_ability_cost || '',
+			solo1name: attrs.repeating_abilities_ability_solo_1_name || '',
+			solo1text: attrs.repeating_abilities_ability_solo_1_text || '',
+			solo2name: attrs.repeating_abilities_ability_solo_2_name || '',
+			solo2text: attrs.repeating_abilities_ability_solo_2_text || '',
+		};
+		
+		const rollValueMap = {
+		    hasTrait: attrs.repeating_abilities_ability_subtype.includes('trait')
+				&& attrs.repeating_abilities_ability_trait
+				? 1 : 0,
+			hasSolo: attrs.repeating_abilities_ability_subtype.includes('solo')
+				? 1 : 0,
+			hasTrigger: attrs.repeating_abilities_ability_type.includes('triggered')
+				&& attrs.repeating_abilities_ability_trigger
+				? 1 : 0,
+			hasPowerRoll: attrs.repeating_abilities_has_power_roll === 'on'
+				? 1 : 0,
+			hasSpecial: attrs.repeating_abilities_has_special === 'on'
+				? 1 : 0,
+			hasEffect: attrs.repeating_abilities_has_effect === 'on'
+				? 1 : 0,
+			hasMalprop: attrs.repeating_abilities_has_malice === 'on'
+				? 1 : 0,
+		};
+		const roll = wtype + ` &{template:monsterability} `
+			+ '{{charactername=' + characterName + '}} '
+			+ '{{powerRoll=^{power-roll}}} '
+			+ Object.entries(directMap)
+				.map(([key, value]) => `{{${key}=${value}}} `)
+			+ Object.entries(rollValueMap)
+				.map(([key, value]) => `{{${key}=[[${value}]]}} `);
+		console.log('ability values', roll);
+		startRoll(roll, ({ rollId }) => finishRoll(rollId));
+	});
+	
+	
 	/**
 	** import start
 	**/

--- a/Draw Steel/translation.json
+++ b/Draw Steel/translation.json
@@ -143,5 +143,9 @@
 	"malice": "Malice",
 	"malice-cost": "Malice Cost",
 	"malice-trait": "Malice Trait",
-	"malice-ability": "Malice Ability"
+	"malice-ability": "Malice Ability",
+	"whisper-gm": "Whisper rolls to GM?",
+	"never-whisper-roll": "Never Whisper Rolls",
+	"query-whisper-roll": "Query Whisper",
+	"always-whisper-roll": "Always Whisper Rolls"
 }


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## [Draw Steel] NPC sheet updates

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [X] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description
Overall:
- Changed a few existing text values to use localization.
- Changed ability type values for move and no-action.
- Added two new roll templates designed for use with the NPC sheet
- Adjusted roll template darkmode colors for readability
- Refactored and formatted some sheet worker code
- Added new sheet worker to handle displaying monster abilities in chat

NPC Sheet:
- Fixed a bug where Stability was showing for Free Strike
- Fixed empty box showing on NPC ability card when "No Action" type was selected.
- Rewrote the NPC ability cards to come closer in line with the official statblocks
- Added a power roll button to NPC ability cards
- Cleaned up NPC sheet styling code
- Added whisper options for roll buttons along with their localization entries

Localization:
- Changed wording of npc-view and npc-role values to better clarify information presented
- Added power roll tooltip text and prefill text for npc ability description.