### PR TITLE
[Shadowrun Sixth World] Bugfix: Hide what's still visibile of act_fad…

### DIFF
--- a/Shadowrun Sixth World/Shadowrun6thEdition.html
+++ b/Shadowrun Sixth World/Shadowrun6thEdition.html
@@ -2844,7 +2844,7 @@
 
           <div class="complex-forms-rolls submersion">
             <input class="techno-toggle" name="attr_techno_toggle" type="hidden" value="submersion"/>
-            <button style="display: none;" name="act_fade_registering" type="action" value=""></button>
+            <button style="display: none !important;" name="act_fade_registering" type="action" value=""></button>
             <div class="pc-row submersion-headers">
               <button data-i18n="resistfade" name="act_fade_compiling" type="action" value="@{gm_toggle} &{template:rolls-computed}{{mod=[[@{modifiers_toggle}]]}}{{edge=[[@{edge_toggle}]]}}{{header=@{character_name}}}{{base=^{resistfade} ^{compiling}}}{{dice=[[(@{willpower}+@{charisma}+@{modifiers_toggle}+@{edge_toggle})d6>5@{explode_toggle}]]}}{{wilddie=[[@{wild_die}]]}}{{wilddie_dice=[[0]]}}{{desc=Willpower + Charisma}}"></button>
               <span>&nbsp;</span>


### PR DESCRIPTION
…e_registering button

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

There is a stray, empty button on the Submersion tab, above Resist Fade. This button already has "display: none" but also needs "!important" to fully hide it.