### PR TITLE
[CyberpunkRED_raycw] New Feature: optionally apply head and body armor penalty

### DIFF
--- a/CyberpunkRED_raycw/cyberpunkred-raycw.html
+++ b/CyberpunkRED_raycw/cyberpunkred-raycw.html
@@ -1675,8 +1675,8 @@
 					<div class="settings-title">APPLY TO REF</div>
 					<div class="settings-value">
 						<div class="settings-checkbox">
-							<input type="hidden" class="settings-toggle" name="attr_armor_penaly_ref_flag" value="1" />
-							<button type="action" name="act_armor_penaly_ref" class="settings-toggle">
+							<input type="hidden" class="settings-toggle" name="attr_armor_penalty_ref_flag" value="1" />
+							<button type="action" name="act_armor_penalty_ref" class="settings-toggle">
 								<span class="checked">✓</span>
 							</button>
 						</div>
@@ -1686,8 +1686,8 @@
 					<div class="settings-title">APPLY TO DEX</div>
 					<div class="settings-value">
 						<div class="settings-checkbox">
-							<input type="hidden" class="settings-toggle" name="attr_armor_penaly_dex_flag" value="1" />
-							<button type="action" name="act_armor_penaly_dex" class="settings-toggle">
+							<input type="hidden" class="settings-toggle" name="attr_armor_penalty_dex_flag" value="1" />
+							<button type="action" name="act_armor_penalty_dex" class="settings-toggle">
 								<span class="checked">✓</span>
 							</button>
 						</div>
@@ -1697,8 +1697,8 @@
 					<div class="settings-title">APPLY TO MOVE</div>
 					<div class="settings-value">
 						<div class="settings-checkbox">
-							<input type="hidden" class="settings-toggle" name="attr_armor_penaly_move_flag" value="1" />
-							<button type="action" name="act_armor_penaly_move" class="settings-toggle">
+							<input type="hidden" class="settings-toggle" name="attr_armor_penalty_move_flag" value="1" />
+							<button type="action" name="act_armor_penalty_move" class="settings-toggle">
 								<span class="checked">✓</span>
 							</button>
 						</div>
@@ -2760,9 +2760,9 @@
 	const armor_penalty_triggers = [
 		"HeadPenalty",
 		"BodyPenalty",
-		"armor_penaly_ref_flag",
-		"armor_penaly_dex_flag",
-		"armor_penaly_move_flag"
+		"armor_penalty_ref_flag",
+		"armor_penalty_dex_flag",
+		"armor_penalty_move_flag"
 	];
 	armor_penalty_triggers.forEach(function(trigger) {
 		on(`change:${trigger}`, function() {
@@ -2772,9 +2772,9 @@
 				"Reflex_max",
 				"Dexterity_max",
 				"Movement_max",
-				"armor_penaly_ref_flag",
-				"armor_penaly_dex_flag",
-				"armor_penaly_move_flag"
+				"armor_penalty_ref_flag",
+				"armor_penalty_dex_flag",
+				"armor_penalty_move_flag"
 				], function(values) {
 
 					const headpen = Math.abs(parseInt(values.HeadPenalty))||0;
@@ -2787,15 +2787,15 @@
 
 					let update_attrs = {};
 
-					if (values.armor_penaly_ref_flag == 1) {
+					if (values.armor_penalty_ref_flag == 1) {
 						update_attrs.Reflex = REF - maxpenalty;
 					}
 
-					if (values.armor_penaly_dex_flag == 1) {
+					if (values.armor_penalty_dex_flag == 1) {
 						update_attrs.Dexterity = DEX - maxpenalty;
 					}
 
-					if (values.armor_penaly_move_flag == 1) {
+					if (values.armor_penalty_move_flag == 1) {
 						update_attrs.Movement = MOVE - maxpenalty;
 						if (update_attrs.Movement < 0)
 						{
@@ -3340,7 +3340,7 @@
 
 	const toggleList = [
 		"cbaudio","lefteye","righteye","rightarm","leftarm","neurallink","rightleg","leftleg","mooksheet",
-		"initiative_modifier", "armor_penaly_ref", "armor_penaly_dex", "armor_penaly_move"
+		"initiative_modifier", "armor_penalty_ref", "armor_penalty_dex", "armor_penalty_move"
 	];
 	toggleList.forEach(function(button) {
 		on(`clicked:${button}`, function() {


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

* Optionally apply head and armor penalties to stats using settings.
* By default, enable all new settings to retain default behaviour of appling armor penalty to all relevant stats (REF, DEX and MOVE).
* When applying the armor penalty, REF and DEX stats can go below zero, but MOVE cannot.
* Fixed buggy behavior where armor penalty would be applied after focusing on the `Dexterity` or `Dexterity_max` attributes.

Tested in custom sheet sandbox #20415307.

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->
