### PR TITLE
[Shadowdark-Unofficial] Fix: JSON Import for spells

### DIFF
--- a/Shadowdark-Unofficial/Shadowdark-Unofficial.html
+++ b/Shadowdark-Unofficial/Shadowdark-Unofficial.html
@@ -657,7 +657,7 @@
 					</div>
 					<div class="sheet-form-group">
 						<label>Version:</label>
-						<input type="text" name="attr_version" value="2025.9.9.0" hidden disabled>
+						<input type="text" name="attr_version" value="2025.12.11.0" hidden disabled>
 						<span name="attr_version"></span>
 					</div>
 					<div>
@@ -2337,7 +2337,7 @@ var set_level = function (level, oldLevel) {
     });
   });
 };
-const classCastingStat = { "wizard": "intelligence", "cleric": "wisdom", "seer": "wisdom" };
+const classCastingStat = { "wizard": "intelligence", "priest": "wisdom", "seer": "wisdom" };
 const compendium = {
   "version": "2025.9.7.0",
   "thirdPartyLicenseText": "The Shadowdark JSON Project is an independent product published under the Shadowdark RPG Third-Party License and is not affiliated with The Arcane Library, LLC. Shadowdark RPG © 2023 The Arcane Library, LLC.",


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description
- fixed typo to use wisdom for spells imported from "priest" instead of "cleric"
- version 2025.12.11.0
- thanks to Clay and Shannon in the Arcane Library server for finding the bug!