### PR TITLE
[olddragon2e] Bugfix: Fix monster morale check

### DIFF
--- a/olddragon2e/olddragon2e.html
+++ b/olddragon2e/olddragon2e.html
@@ -762,7 +762,7 @@
       </div>
       <div class="stat">
         <div class="stat-value">
-          <button type="roll" value="&{template:basicroll} {{character=@{character_name}}} {{rollname=Teste de Moral}} {{rollformula= **Resultado:** [[1d20]] comparado a @{monster_mo} (JP) }} {{stat=[[@{monster_mo}]]}}" name="roll_Monster_Mo" title="Rolar Teste de Moral"><span class="font-bold">MO</span></button>
+          <button type="roll" value="&{template:basicroll} {{character=@{character_name}}} {{rollname=Teste de Moral}} {{rollformula= **Resultado:** [[2d6]] comparado a @{monster_mo} (MO) }} {{stat=[[@{monster_mo}]]}}" name="roll_Monster_Mo" title="Rolar Teste de Moral"><span class="font-bold">MO</span></button>
           <input type="number" name="attr_monster_mo" value="">
         </div>
       </div>


### PR DESCRIPTION
# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

The monster morale check (MO) has been corrected. Previously, the check rolled 1d20. Now it's corrected to roll 2d6.

## Brazilian Portuguese 🇧🇷

O teste de moral (MO) de monstros foi corrigido. Anteriormente o teste rolava 1d20. Agora corrigido para rolar 2d6.
