### PR TITLE
[Star Wars D6] Bugfix: v2.48 - prevent sheet streching too wide

### DIFF
--- a/D6StarWars/CHANGELOG.md
+++ b/D6StarWars/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 2.48 (2026-02)
+- by Anduh: stops the sheet stretching too wide (started happening after 2.47 update)
+- minor code cleanup
+
 ### Version 2.47 (2026-01)
 - by Anduh: Update CSS so Settings Menu(cogwheel) text is readable in Roll20 Light Mode (was white on white)
 

--- a/D6StarWars/D6StarWars.css
+++ b/D6StarWars/D6StarWars.css
@@ -1,3 +1,6 @@
+.ui-dialog .charsheet label{
+  width: unset;
+}
 /*-------------------------------------------*/
 /*------------- SWD6 Main CSS----------------*/
 /*-------------------------------------------*/
@@ -32,6 +35,7 @@
     border-top: 5px dotted white;
     padding:10px;
     width: 100%;
+    max-width: 860px;
 }
 
 
@@ -170,7 +174,7 @@
     margin:0;
 }
 
-.charsheet input[type="text"].60p{
+.charsheet input[type="text"].w60p{
     width: 60%;
 }
 
@@ -803,8 +807,8 @@
 .charsheet .repcontainer[data-groupname="repeating_armors"] > .repitem input[type="text"].name{
     width: 150px;
 }
-.charsheet .repcontainer[data-groupname="repeating_weapons"] > .repitem input[type="number"].40px,
-.charsheet .repcontainer[data-groupname="repeating_armors"] > .repitem input[type="number"].40px{
+.charsheet .repcontainer[data-groupname="repeating_weapons"] > .repitem input[type="number"].w40px,
+.charsheet .repcontainer[data-groupname="repeating_armors"] > .repitem input[type="number"].w40px{
     width: 150px;
 }
 
@@ -1144,7 +1148,6 @@
 .charsheet .repcontainer[data-groupname="repeating_shipweapon"] > .repitem .weapon-info label{
     width: unset;
     margin: 5px 0px 0px 5px;
-    grid
 }
 
 .charsheet .repcontainer[data-groupname="repeating_shipweapon"] > .repitem .weapon-grid{
@@ -1476,7 +1479,6 @@
 .charsheet .repcontainer[data-groupname="repeating_shipweapon"] > .repitem .weapon-info label{
     width: unset;
     margin: 5px 0px 0px 5px;
-    grid
 }
 
 .charsheet .repcontainer[data-groupname="repeating_shipweapon"] > .repitem .weapon-grid{
@@ -1805,7 +1807,6 @@
 .charsheet .repcontainer[data-groupname="repeating_vehicleweapon"] > .repitem .weapon-info label{
     width: unset;
     margin: 5px 0px 0px 5px;
-    grid
 }
 
 .charsheet .repcontainer[data-groupname="repeating_vehicleweapon"] > .repitem .weapon-grid{
@@ -2084,18 +2085,3 @@
 .sheet-rolltemplate-black tr:nth-child(even) {
  background-color:#eee;
 }
-
-    © 2022 GitHub, Inc.
-
-    Terms
-    Privacy
-    Security
-    Status
-    Docs
-    Contact GitHub
-    Pricing
-    API
-    Training
-    Blog
-    About
-

--- a/D6StarWars/D6StarWars.html
+++ b/D6StarWars/D6StarWars.html
@@ -1,4 +1,4 @@
-<input  name="attr_version" type="hidden" value="2.47">
+<input  name="attr_version" type="hidden" value="2.48">
 
 <input class="toggle" name="attr_sheettype" type="hidden" value="0">
 
@@ -130,10 +130,10 @@
     <div class="section pc">
       <div class="sheet-2colrow">
         <div class="sheet-col lineblock">
-          <label class="toppad">Character Name <input class="right reduce-padd 60p" name="attr_charactername"
+          <label class="toppad">Character Name <input class="right reduce-padd w60p" name="attr_charactername"
                                                       type="text"/></label>
-          <label class="toppad">Type <input class="right reduce-padd 60p" name="attr_type" type="text"/></label>
-          <label class="toppad">Species <input class="right reduce-padd 60p" list="species" name="attr_species" type="text"/></label>
+          <label class="toppad">Type <input class="right reduce-padd w60p" name="attr_type" type="text"/></label>
+          <label class="toppad">Species <input class="right reduce-padd w60p" list="species" name="attr_species" type="text"/></label>
 
           <div class="physical-params">
             <label class="toppad">Age <input class="smalltext reduce-padd" name="attr_age" type="text"/></label>
@@ -952,7 +952,7 @@
                     </div>
                   
                     
-                    <input class="40px" name="attr_ship_space" type="number">
+                    <input class=" w40px" name="attr_ship_space" type="number">
                     <input class="mediumnumber" name="attr_ship_ground" type="number">
                     <input class="mediumnumber" name="attr_ship_athmosphere" type="number">
                 </div>
@@ -1000,7 +1000,7 @@
             </span>
             <span>Search</span>
             <span>
-                <input class="40px" name="attr_sensor_search_range" type="number"/>
+                <input class=" w40px" name="attr_sensor_search_range" type="number"/>
             </span>
             <span>
                 <input type="number" name="attr_sensor_search" value="0" min="0" required="required" class="unified-dice unified-dice-input"/>


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

## New Sheet Details

Please complete this section if you are adding a new sheet to the repository.

If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by [  ].

- The name of this game is: [   ]  
  > _(e.g. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: [   ]  
  > _(e.g. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: [   ]  
  > _(e.g. Dungeons & Dragons, FATE)_
- The rules for this game can be found at the following location: [   ]
  > _(e.g. a link to purchase, ISBN, Half-Price Books)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.
- [ ] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] (Official Sheets Only) The game's publisher has reached out to [licensing@roll20.net](mailto:licensing@roll20.net) to confirm they are aware of and supporting this sheet as an official sheet with their name attached.

Select EXACTLY One:
- [ ] This game is a traditionally published game.
- [ ] This game is not a traditionally published game.
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system. [  ADD DETAILS HERE  ]

# Changes / Description

This should restore the sheet width to what it was before #14666 , by setting the `.charsheet .section` max-with to 860px, which until v.2.46 had been determined by the `.charsheet .master-container` set to `width: 860px;`.

The issue have been discussed in [STAR WARS D6 sheet is misbehaving](https://app.roll20.net/forum/permalink/12661915/)-thread

It's unclear how the v.2.47 update managed to cause the change in sheet width, as it only adjusted the background color in a small part. Suspicion is that they update triggered some reprocessing of the sheet CSS that lead it to change how it displayed.

Also included some minor code cleanup.
