### PR TITLE
[Draw Steel] Bugfix: adding magic/psionic damage to rolls

### DIFF
--- a/Draw Steel/translation.json
+++ b/Draw Steel/translation.json
@@ -555,5 +555,7 @@
 	"faction-malice": "Malice",
 	"malice-abilities": "Malice Abilities",
 	"villain-action": "Villain Actions",
-	"villain-toggle": "Has Villain Actions"
+	"villain-toggle": "Has Villain Actions",
+	"magic": "Magic",
+	"psionic": "Psionic"
 }


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## [Draw Steel] Bugfix: adding magic/psionic damage to rolls

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

__Issue:__ Magic/Psionic Damage (from Equipment and Modifiers/Kit menu) is not being automatically added to ability rolls, that have "Magic"/"Psionic" keywords

__Solution:__ 'magic' and 'psionic' enteries were added to translation.json. These were called from func getAbilityMaps() - line 5197, 5198 -> resulting in a unknown key and Magic and Psionic dmg not being added correctly


