### PR TITLE
[Dolmenwood] Bugfix: Repair the inability to create more than one rune.

### DIFF
--- a/Dolmenwood/dolmenwood.html
+++ b/Dolmenwood/dolmenwood.html
@@ -2021,7 +2021,6 @@
           .concat(["strMod", "dexMod", "bab"]);
         getAttrs(attributes, function (values) {
           const attackType = values[`repeating_weapons_${id}_attackType`];
-          console.log(values);
           setAttrs({ [`repeating_weapons_${id}_bab_copy`]: values.bab });
           if (!attackType) {
             if (


### PR DESCRIPTION
# Submission Checklist
## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

This removes a bug with the recently updated sheet where only one rune of a category can be created.
Also remove the BAB not updating when level changed.
