### PR TITLE
[Blades in the Dark Official] New Feature: 5-level Wanted track support

### DIFF
--- a/Blades in the Dark/blades.html
+++ b/Blades in the Dark/blades.html
@@ -257,6 +257,11 @@
     </div>
     <div class="setting-crew">
       <label>
+        <input class="checkbox squarebox" type="checkbox" name="attr_setting_wanted_5th" value="1"/><span></span><span data-i18n="wanted_5th"></span>
+      </label>
+    </div>
+    <div class="setting-crew">
+      <label>
         <input class="checkbox squarebox" type="checkbox" name="attr_setting_show_origin" value="1"/><span></span><span data-i18n="show_origin"></span>
       </label>
     </div>
@@ -2838,12 +2843,22 @@
               </button>
               <input type="hidden" name="attr_wanted_formula" value=" {{?{@{bonusdice}|0,zerodice=[[d6]]&amp;#44; [[d6]]|1,dice=[[d6]]|2,dice=[[d6]]&amp;#44; [[d6]]|3,dice=[[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]|4,dice=[[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]|5,dice=[[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]|6,dice=[[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]&amp;#44; [[d6]]|-1,zerodice=[[d6]]&amp;#44; [[d6]]|-2,zerodice=[[d6]]&amp;#44; [[d6]]|-3,zerodice=[[d6]]&amp;#44; [[d6]]}}}"/>
             </div>
+            <input class="hider-inverted" type="hidden" name="attr_setting_wanted_5th" value="0"/>
             <div class="wantedholder flex">
               <input class="tooth zero" type="radio" name="attr_wanted" value="0" checked="checked"/><span></span>
               <input class="tooth regulartooth" type="radio" name="attr_wanted" value="1"/><span></span>
               <input class="tooth regulartooth" type="radio" name="attr_wanted" value="2"/><span></span>
               <input class="tooth regulartooth" type="radio" name="attr_wanted" value="3"/><span></span>
               <input class="tooth regulartooth" type="radio" name="attr_wanted" value="4"/><span></span>
+            </div>
+            <input class="hider" type="hidden" name="attr_setting_wanted_5th" value="0"/>
+            <div class="wantedholder flex">
+              <input class="tooth zero" type="radio" name="attr_wantedDC" value="0" checked="checked"/><span></span>
+              <input class="tooth regulartooth" type="radio" name="attr_wantedDC" value="1"/><span></span>
+              <input class="tooth regulartooth" type="radio" name="attr_wantedDC" value="2"/><span></span>
+              <input class="tooth regulartooth" type="radio" name="attr_wantedDC" value="3"/><span></span>
+              <input class="tooth regulartooth" type="radio" name="attr_wantedDC" value="4"/><span></span>
+              <input class="tooth regulartooth" type="radio" name="attr_wantedDC" value="5"/><span></span>
             </div>
           </div>
         </div>

--- a/Blades in the Dark/translation.json
+++ b/Blades in the Dark/translation.json
@@ -1481,6 +1481,7 @@
     "vigilantes": "Vigilantes",
     "vizier": "Vizier",
     "wanted_label": "Label to use for Wanted",
+    "wanted_5th": "Use 5-level Wanted Track",
     "wanted": "Wanted",
     "wantedroll1": "(who currently have ",
     "wantedroll2": ") roll for",


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

Added a "Use 5-Level Wanted Track" entry to translations.json

Added a "Use 5-Level Wanted Track" toggle to the Crew settings dialog

When the setting is toggled on, a 5-level Wanted track (which is tracked separately from the default 4-level track) displays, and the 4-level track hides. When it's off, vice-versa.

If a Crew has the Shadows ability "Slippery" as implemented in Deep Cuts, they would want to also toggle this option on. If they want the benefit of the "roll as if your Wanted is one level lower" part, they'll need to select Bonus Dice = -1 when prompted to while rolling their Wanted level.