### PR TITLE
[Monster of the Week Official] Bugfix: Other Moves default, Show HJ Options toggles

### DIFF
--- a/Monster of the Week Official/MotWHTML.html
+++ b/Monster of the Week Official/MotWHTML.html
@@ -12153,7 +12153,7 @@ on("change:repeating_hunterstory:story", function(e) {
               <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_Toggle-Monstrous-Breed-All" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="all">All</span></span>
               <div class="sheet-Expander">
                 <div class="sheet-isolator">
-                  <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Monstrous-Enable" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
+                  <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Monstrous-Enable" value="1"/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
                 </div>
                 <div><span data-i18n="breed-description">You&apos;re half-human, half-monster. Were you always this way, or were you originally human and were transformed somehow? Were you always fighting for good, or were you once evil and then changed sides?</span></div>
                 <textarea name="attr_Breed-Monstrous" rows="3" cols="40"></textarea>
@@ -13813,7 +13813,7 @@ on("change:repeating_hunterstory:story", function(e) {
                 <input class="sheet-SkinCheck" type="hidden" name="attr_SkinCheck" value="0"/> 
                 <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_Toggle-Expert-Haven-Unused" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="unused">Unused</span></span>
                 <div class="sheet-isolator">
-                  <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Haven-Enable" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
+                  <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Haven-Enable" value="1"/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
                 </div>
                 <div><span data-i18n="haven-description">You have set up a haven, a safe place to work</span><span class="sheet-Snoop sheet-Actionscientist">.</span><span class="sheet-Expert"><i>&nbsp;(<span data-i18n="pick-three">pick three</span>)</i>:</span><span class="sheet-Gumshoe sheet-Hex sheet-Flake sheet-Monstrous sheet-Wronged sheet-Luchador"><i>&nbsp;(<span data-i18n="pick-two">pick two</span>)</i>:</span><span class="sheet-Snoop"><i><span data-i18n="1-fixed-move">You get this</span>:</i></span><span class="sheet-Actionscientist"><i><span data-i18n="as-haven-instruct">Pick one in addition to a Workshop</span>:</i></span></div>
                 <div class="sheet-move sheet-Snoop">
@@ -29500,7 +29500,7 @@ on("change:repeating_hunterstory:story", function(e) {
                 <div class="sheet-OPBHead sheet-MinorHead sheet-space-above" data-i18n="the-monstrous">The Monstrous</div>
                 <div class="sheet-Monstrous">
                   <div class="sheet-isolator">
-                    <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Monstrous-Enable" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
+                    <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Monstrous-Enable" value="1"/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
                   </div><i><span data-i18n="2-moves">Pick two of these</span>:</i>
                 </div>
                 <div class="sheet-Monstrous sheet-OPB">
@@ -32732,7 +32732,7 @@ on("change:repeating_hunterstory:story", function(e) {
               <div class="sheet-Expander">
                 <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_Toggle-Monstrous-NatWeap-Unused" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="unused">Unused</span></span>
                 <div class="sheet-isolator">
-                  <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Monstrous-Enable" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
+                  <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Monstrous-Enable" value="1"/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
                 </div>
                 <div><i>(<span data-i18n="monstrous-attacks-pick">pick one base and one extra, or pick two bases</span>)</i>:</div>
                 <div class="sheet-move">
@@ -33133,7 +33133,7 @@ on("change:repeating_hunterstory:story", function(e) {
                   </div>
                   <div class="sheet-MinorHead"><span data-i18n="chosen-gear2">Special Weapon</span></div>
                   <div class="sheet-isolator">
-                    <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Chosen-Enable" value="1" checked=""/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
+                    <input class="sheet-checkbox sheet-ExpToggle" type="checkbox" name="attr_HJ-Chosen-Enable" value="1"/><span class="sheet-anglebox"></span><span class="sheet-ExpHeader"><span data-i18n="Hunter's Journal Options"></span> </span>
                   </div><span data-i18n="chosen-special-descrip">Design your weapon by choosing a Form, three Business-end options (which are added to the base tags), and a material that the business-end is made from.</span>
                   <input class="sheet-SettingCheck" type="hidden" name="attr_Game-World" value="0"/><span class="sheet-Setting-Bone"><span data-i18n="Your special weapon has unlimited wear."></span> </span><br/><br/><b><span data-i18n="form">Form</span></b> <i>&nbsp;(<span data-i18n="pick-one">pick one</span>)</i>:<br/>
                   <input class="sheet-SettingCheck" type="hidden" name="attr_Game-World" value="0"/>

--- a/Monster of the Week Official/MotWHTML.html
+++ b/Monster of the Week Official/MotWHTML.html
@@ -88,7 +88,7 @@ on("sheet:opened change:harm1 change:harm2 change:harm3 change:harm4 change:harm
 });
 
 // Needed for SkinMoves because that call to +custommoves has the rollable flag set to true; you'll need to add any other repeating_XXXes where that flag is set to true for it to work right.
-on("change:repeating_skinmoves:rollable", function(e) {
+on("change:repeating_skinmoves:rollable change:repeating_othermoves:rollable", function(e) {
 	var rollable = e.sourceAttribute;
 	var rowid = (e.sourceAttribute).slice(0,-8); // strips off 'rollable'
 	var atts = {};


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

## Other Moves
The "Other Moves" section did not properly trigger the sheetworker to store the value of the selected rollable stat when configured. 

The sheetworker addresses this now for any newly-created Other Moves. 

It won't fix existing custom moves, but if you go to "edit" an Other Move and select the rollable stat as "None", then re-select the intended stat, that'll fix the existing move.

## Show Hunter's Journal Options
"Show Hunter's Journal Options" toggles defaulted to displaying as on, even though they were disabled. Now they default to displaying as off, to match their actual initial state.