### PR TITLE
[Draw Steel] Bugfixes

### DIFF
--- a/Draw Steel/draw-steel.css
+++ b/Draw Steel/draw-steel.css
@@ -1704,6 +1704,7 @@ inventory-accordion {
 	gap: 0.25em;
 	white-space: nowrap;
 	min-width: 0;
+	text-wrap: auto;
 }
 
 .sheet-rolltemplate-powerrollability .sheet-powerroll-characteristic, 

--- a/Draw Steel/draw-steel.html
+++ b/Draw Steel/draw-steel.html
@@ -5878,6 +5878,7 @@
 		MALICE_ABILITY: 'Malice Ability',
 		CONDITION_IMMUNITY: 'Condition Immunity',
 		SUMMON_CHOICE: 'Summon Choice',
+		ABILITY_DAMAGE: 'Ability Damage',
 	};
 
 	/**
@@ -6474,6 +6475,16 @@
 				return { ...acc, ...processAbility(abilityData) };
 			}, {});
 		
+		const damageModifiers = allFeatures
+			.filter(f => f.type === FEATURE_TYPES.ABILITY_DAMAGE)
+			.reduce((acc, f) => {
+				const id = generateRowID();
+				acc[`repeating_damagemods_${id}_mod_name`] = f.name;
+				acc[`repeating_damagemods_${id}_mod_keywords`] = f.data?.keywords.join(', ');
+				acc[`repeating_damagemods_${id}_mod_value`] = f.data?.value;
+				return acc;
+			}, {});
+		
 		const immunity = [
 			getDamageModifiers(allFeatures, level, 'Immunity'),
 			getConditionImmunities(allFeatures),
@@ -6541,10 +6552,11 @@
 			...classFeatures,
 			...abilityFeatures,
 			...classAbilities,
+			...damageModifiers,
 		};
 
 		// Clear existing repeating sections before adding new data.
-		const sectionsToClear = ['modifiers', 'perks', 'ancestrytraits', 'classfeatures', 'abilities', 'noaction', 'maneuvers', 'triggered', 'moves', 'conditions'];
+		const sectionsToClear = ['modifiers', 'perks', 'ancestrytraits', 'classfeatures', 'abilities', 'noaction', 'maneuvers', 'triggered', 'moves', 'conditions', 'damagemods'];
 		await Promise.all(sectionsToClear.map(s => clearRepeatingSection(s)));
 		
 		// Set the new attributes on the character sheet.

--- a/Draw Steel/draw-steel.html
+++ b/Draw Steel/draw-steel.html
@@ -4890,7 +4890,16 @@
 		const damagePerSurge = parseInt(attrs.surge_damage) || 0;
 	
 		if (type === 'damage' && available > 0) {
-			const query = `?{${getTranslationByKey('how-many-surges')}|1|2|3}`;
+		
+			const maxSurges = Math.min(available, 3);
+			
+			const options = [];
+			for (let i = 1; i <= maxSurges; i++) {
+				options.push(i);
+			}
+			const queryOptions = options.length > 0 ? options.join('|') : '0';
+			
+			const query = (available > 1) ? `?{${getTranslationByKey('how-many-surges')}|${queryOptions}}}` : '1';
 			const template = `@{wtype}&{template:${ROLLTEMPLATES.SIMPLE}} {{charactername=@{character_name}}} {{name=^{surges}}} {{text=^{roll-surge-damage}}} {{rolltitle=[[${query}]] ^{surges}}} {{roll=[[([[${query}]]*${damagePerSurge})]] ^{surges-damage}}}`;
 	
 			startRoll(template, ({ rollId, results }) => {

--- a/Draw Steel/draw-steel.html
+++ b/Draw Steel/draw-steel.html
@@ -1246,8 +1246,8 @@
 				</div>
 			</fieldset>
 			<!-- Standard Abilities -->
-            <h5 class="panel-title" data-i18n="standard-main-actions"></h5>
 			<div class="standard-abilities">
+				<h5 class="panel-title" data-i18n="standard-main-actions"></h5>
 				<!-- Melee Free Strike Ability -->
 				<div class="standard-abilities-item">
 					<input class="toggle-button -edit" type="checkbox" />
@@ -1637,8 +1637,8 @@
 				</div>
 			</fieldset>
 			<!-- Standard Maneuvers -->
-            <h5 class="panel-title" data-i18n="standard-maneuvers"></h5>
 			<div class="standard-abilities">
+				<h5 class="panel-title" data-i18n="standard-maneuvers"></h5>
 				<!-- Knockback -->
 				<div class="standard-abilities-item">
 					<input type="hidden" name="attr_knockback_type" value="maneuver" />
@@ -2222,8 +2222,8 @@
 				</div>
 			</fieldset>
 			<!-- Standard Triggered Abilities -->
-            <h5 class="panel-title" data-i18n="standard-triggers"></h5>
 			<div class="standard-abilities">
+				<h5 class="panel-title" data-i18n="standard-triggers"></h5>
 				<!-- Opportunity Attack -->
 				<div class="standard-abilities-item">
 					<input class="toggle-button -edit" type="checkbox" />
@@ -2391,8 +2391,8 @@
 				</div>
 			</fieldset>
 			<!-- Standard Abilities -->
-            <h5 class="panel-title" data-i18n="standard-noaction-trait"></h5>
 			<div class="standard-abilities">
+				<h5 class="panel-title" data-i18n="standard-noaction-trait"></h5>
 				<!-- Jump Move -->
 				<div class="standard-abilities-item">
 					<input type="hidden" name="attr_jump_type" value="no-action" />
@@ -2648,8 +2648,8 @@
 				</div>
 			</fieldset>
 			<!-- Standard Moves -->
-            <h5 class="panel-title" data-i18n="standard-move-actions"></h5>
 			<div class="standard-abilities">
+				<h5 class="panel-title" data-i18n="standard-move-actions"></h5>
 				<!-- Advance Move Action -->
 				<div class="standard-abilities-item">
 					<input class="toggle-button -edit" type="checkbox" />


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [X] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description
- Fixed text wrap issue in roll template styling
- Surge roll now adjusts the query based on the number of available surges and no longer gives users the option to pick more surges than they have.