### PR TITLE
[Draw Steel] NPC Import Bugfix

### DIFF
--- a/Draw Steel/draw-steel.html
+++ b/Draw Steel/draw-steel.html
@@ -3205,6 +3205,15 @@
 							</div>
 							<textarea class="ability-malice" data-i18n-placeholder="malice" name="attr_ability_malice" spellcheck="false"></textarea>
 						</div>
+						<div class="ability-toggle-group">
+							<input type="checkbox" name="attr_has_spend" />
+							<label data-i18n="spend"></label>
+							<div class="grid-span-full">
+								<label data-i18n="ability-cost"></label>
+								<input type="text" name="attr_ability_spend_cost" />
+							</div>
+							<textarea class="ability-malice" data-i18n-placeholder="spend" name="attr_ability_spend" spellcheck="false"></textarea>
+						</div>
 					</div>			
 				</div>
 				<div class="ability-card -togglehide">
@@ -3280,7 +3289,11 @@
 						<label><span name="attr_ability_cost"></span>&nbsp;<span data-i18n="malice"></span>:</label>
 						<span class="ability-malice" name="attr_ability_malice"></span>
 					</div>
-				
+					<input type="hidden" name="attr_has_spend" />					
+					<div class="npc-ability-malice grid-span-full">
+						<label><span data-i18n="spend"></span>&nbsp;<span name="attr_ability_spend_cost"></span>:</label>
+						<span class="ability-malice" name="attr_ability_spend"></span>
+					</div>
 				</div>
 			</fieldset>
 		</div>
@@ -6227,7 +6240,7 @@
 				let queryString = `!{{template:default}}{{ask=![[?{${getTranslationByKey('import-monster')}|${getTranslationByKey('import-select-prompt')},-1`;
 				for (const [index, monster] of data.monsters.entries()) {
 					
-					queryString += '|' + monster.name + ', ' + index.toString();
+					queryString += '|' + monster.name + ' (' + getTranslationByKey('level') + ' ' + monster.level + '), ' + index.toString();
 				}
 				queryString += '}]]}}';
 				
@@ -6613,11 +6626,11 @@
 				}
 				return acc;
 			}, {});
-		
+
 		const abilityFeatures = data.features
 			.filter(f => f.type === FEATURE_TYPES.ABILITY)
 			.reduce((acc, f) => ({ ...acc, ...processMonsterAbility(f.data.ability) }), {});
-		
+
 		const maliceFeatures = malice ? importMalice(malice) : [];
 		
 		const minionTag = roleString.includes('Minion') ? getTranslationByKey('minion-text') : '';


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [X] The pull request title clearly contains the name of the sheet I am editing.
- [X] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [X] The pull request makes changes to files in only one sub-folder.
- [X] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [X] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

- Added Spend section to NPC ability card for use with Beastheart companion
- Updated Monster import to place spend elements in the new section
- Monster import now displays individual monster levels when importing a group.
