### PR TITLE
[Imperium Maledictum] Feature: Replace global difficulty/circumstance selects with roll queries

### DIFF
--- a/ImperiumMaledictum/sheet_new.html
+++ b/ImperiumMaledictum/sheet_new.html
@@ -16,15 +16,6 @@
         name="act_settings">Settings</button></div>
 
     <div class="roller">
-        <select class="input character" name="attr_difficulty">
-          <option value="60">Very Easy (+60)</option>
-          <option value="40">Easy (+40)</option>
-          <option value="20">Routine (+20)</option>
-          <option value="0" selected>Challenging (+0)</option>
-          <option value="-10">Difficult (-10)</option>
-          <option value="-20">Hard (-20)</option>
-          <option value="-30">Very Hard (-30)</option>
-        </select>
         <select class="input character" name="attr_superiority">
           <option value="0">No Superiority</option>
           <option value="1">+1 Superiority</option>
@@ -33,15 +24,6 @@
           <option value="4">+4 Superiority</option>
           <option value="5">+5 Superiority</option>
           <option value="6">+6 Superiority</option>
-        </select>
-        <select class="input character" name="attr_circumstances">
-            <option value="3">Advantage (+20)</option>
-            <option value="2">Advantage (+10)</option>
-            <option value="1">Advantage</option>
-            <option value="0" selected>No Advantage</option>
-            <option value="-1">Disadvantage</option>
-            <option value="-2">Disadvantage (-10)</option>
-            <option value="-3">Disadvantage (-20)</option>
         </select>
     </div>
 </div>
@@ -1787,7 +1769,7 @@
         });
     });
 
-const test_list = ["difficulty","circumstances","superiority","psychic_focus","roll_visibility"];
+const test_list = ["superiority","psychic_focus","roll_visibility"];
     const button_list = chars_list.concat(skill_list).concat(npc_chars_list);
     button_list.forEach(trigger => {
         on(`clicked:${trigger}`, function(eventInfo) {
@@ -1802,11 +1784,9 @@ const test_list = ["difficulty","circumstances","superiority","psychic_focus","r
 
             getAttrs(test_list.concat(button_list), function(values) {
                 let skill_total = parseInt(values[`${field}`])||0;
-                let diff_roll = parseInt(values["difficulty"])||0;
-                let circ = parseInt(values["circumstances"])||0;
                 let superiority = parseInt(values["superiority"])||0;
 
-                rollTest(reroll, skill_name, skill_total, diff_roll, circ, superiority);
+                rollTest(reroll, skill_name, skill_total, superiority);
             });
         });
     });
@@ -1828,50 +1808,29 @@ const test_list = ["difficulty","circumstances","superiority","psychic_focus","r
                     `${trigger}_${key}_name`,
                     `${trigger}_${key}_total`,
                     `${trigger}_${key}_damage_total`,
-                    `${trigger}_${key}_damage_info`,
-                    `${trigger}_${key}_difficulty`
+                    `${trigger}_${key}_damage_info`
                 ]), function(values) {
                 let skill_name = values[`${trigger}_${key}_name`];
                 let skill_total = parseInt(values[`${trigger}_${key}_total`])||0;
-                let diff_roll = parseInt(values["difficulty"])||0;
-                if (`${trigger}_${key}_difficulty` in values) {
-                    diff_roll = parseInt(values[`${trigger}_${key}_difficulty`])||0;
-                }
-                let circ = parseInt(values["circumstances"])||0;
                 let superiority = parseInt(values["superiority"])||0;
                 let slmod = trigger == "repeating_powers" ? (parseInt(values["psychic_focus"])||0) : 0;
                 let dmg = parseInt(values[`${trigger}_${key}_damage_total`])||-1;
                 let dmg_info = values[`${trigger}_${key}_damage_info`];
                 let critfum = trigger == "repeating_weapons";
 
-                rollTest(reroll, skill_name, skill_total, diff_roll, circ, superiority, dmg, dmg_info, slmod, critfum);
+                rollTest(reroll, skill_name, skill_total, superiority, dmg, dmg_info, slmod, critfum);
             });
         });
     });
 
-    const rollTest = function(reroll, skill_name, skill_total, diff_roll, circ, superiority, dmg=-1, dmgi="", slmod=0, critfum=false) {
-        let circ_bonus = 0;
-        let circ_roll = "";
-        let adv_roll = "";
-        let disadv_roll = "";
+    const rollTest = function(reroll, skill_name, skill_total, superiority, dmg=-1, dmgi="", slmod=0, critfum=false) {
+        const diff_query = "?{Difficulty|Challenging (+0),0|Very Easy (+60),60|Easy (+40),40|Routine (+20),20|Difficult (-10),-10|Hard (-20),-20|Very Hard (-30),-30}";
+        const circ_query = "?{Circumstances|No Advantage,0|Advantage,1|Disadvantage,-1}";
         let dmg_roll = "";
         let dmg_info = dmgi ? ` {{damage_info=${dmgi}}}` : "";
         let hitloc = "";
         let adjustedsl = slmod > 0 ? ` {{adjustedsl=+${slmod}}}` :
             slmod < 0 ? ` {{adjustedsl=${slmod}}}` : "";
-        if (circ > 0) {
-            circ_bonus = (circ - 1) * 10;
-            adv_roll = " {{advantage=[[0]]}}";
-            circ_roll = " {{circumstances=Advantage";
-            circ_roll += circ_bonus > 0 ? ` (+${circ_bonus})` : "";
-            circ_roll += "}}";
-        } else if (circ < 0) {
-            circ_bonus = (circ + 1) * 10;
-            disadv_roll = " {{disadvantage=[[0]]}}";;
-            circ_roll = " {{circumstances=Disadvantage";
-            circ_roll += circ_bonus < 0 ? ` (${circ_bonus})` : "";
-            circ_roll += "}}";
-        }
         if (dmg > -1) {
             dmg_roll = ` {{damage=[[${dmg}]]}}`;
         }
@@ -1884,8 +1843,8 @@ const test_list = ["difficulty","circumstances","superiority","psychic_focus","r
 
             startRoll(`${rollPrefix}&{template:imtest} {{reroll=[Reroll](~${reroll})}} `
                 .concat(`{{name=@{character_name}}} {{skill_name=${skill_name}}} `)
-                .concat(`{{skill_total=[[${skill_total}]]}} {{difficulty=[[${diff_roll}]]}} `)
-                .concat(`{{result=[[1d100]]}}${adv_roll}${disadv_roll}${circ_roll}${dmg_roll}${dmg_info}${hitloc} `)
+                .concat(`{{skill_total=[[${skill_total}]]}} {{difficulty=[[${diff_query}]]}} `)
+                .concat(`{{result=[[1d100]]}} {{circ_value=[[${circ_query}]]}} {{circumstances=[[0]]}}${dmg_roll}${dmg_info}${hitloc} `)
                 .concat(`{{sl=[[0]]}} {{sl_info=[[0]]}} {{critical=[[0]]}} {{fumble=[[0]]}}${adjustedsl}`)
                 .concat(`{{superiority=${superiority}}}`), (results) => {
                 const result = results.results.result.result;
@@ -1895,6 +1854,19 @@ const test_list = ["difficulty","circumstances","superiority","psychic_focus","r
                 }
                 const difficulty = results.results.difficulty.result;
                 const diff_name = diff_data[`${difficulty}`]["name"];
+                const circ = results.results.circ_value.result;
+
+                let circ_bonus = 0;
+                let circ_text = "";
+                if (circ > 0) {
+                    circ_bonus = (circ - 1) * 10;
+                    circ_text = "Advantage";
+                    circ_text += circ_bonus > 0 ? ` (+${circ_bonus})` : "";
+                } else if (circ < 0) {
+                    circ_bonus = (circ + 1) * 10;
+                    circ_text = "Disadvantage";
+                    circ_text += circ_bonus < 0 ? ` (${circ_bonus})` : "";
+                }
 
                 let final_result = result;
                 let final_total = skill_total + difficulty;
@@ -1929,6 +1901,7 @@ const test_list = ["difficulty","circumstances","superiority","psychic_focus","r
                 finishRoll(
                     results.rollId,
                     {
+                        "circ_value": circ,
                         "result": final_result,
                         "difficulty": diff_name,
                         "skill_total": final_total,
@@ -1936,7 +1909,8 @@ const test_list = ["difficulty","circumstances","superiority","psychic_focus","r
                         "sl_info": final_sl_info,
                         "critical": crit,
                         "fumble": fumb,
-                        "hitlocation": hitlocation
+                        "hitlocation": hitlocation,
+                        "circumstances": circ_text
                     }
                 );
             });
@@ -2050,13 +2024,19 @@ const test_list = ["difficulty","circumstances","superiority","psychic_focus","r
         {{#adjustedsl}}
             <p>//Adjusted SL: {{adjustedsl}}</p>
         {{/adjustedsl}}
-        {{#circumstances}}
-            <p>//{{circumstances}}</p>
-        {{/circumstances}}
+        {{#rollGreater() computed::circ_value 0}}
+            <p>//{{computed::circumstances}}</p>
+        {{/rollGreater() computed::circ_value 0}}
+        {{#rollLess() computed::circ_value 0}}
+            <p>//{{computed::circumstances}}</p>
+        {{/rollLess() computed::circ_value 0}}
         <p>Test adjusted to {{computed::skill_total}}%</p>
-        {{#circumstances}}
+        {{#rollGreater() computed::circ_value 0}}
             <p>//Unmodified roll: {{result}}</p>
-        {{/circumstances}}
+        {{/rollGreater() computed::circ_value 0}}
+        {{#rollLess() computed::circ_value 0}}
+            <p>//Unmodified roll: {{result}}</p>
+        {{/rollLess() computed::circ_value 0}}
         {{#rollLess() superiority 1 }}
         {{#superiority}}
             <p>//Superiority: {{superiority}}</p>


### PR DESCRIPTION
Remove attr_difficulty and attr_circumstances from the sheet header and prompt players via ?{...} roll queries before every roll instead. This prevents players from forgetting to reset global modifiers between actions.
- Drop difficulty/circumstance selects from header .roller div
- Inject ?{Difficulty|...} and ?{Circumstances|...} directly into startRoll() for characteristics, skills, and repeating sections
- Reduce circumstances options to Advantage / No Advantage / Disadvantage
- Update imtest roll template to use computed::circ_value conditionals

<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

Removes the global `attr_difficulty` and `attr_circumstances` dropdowns from the sheet header and replaces them with `?{...}` roll queries that prompt the player before every roll. This prevents players from forgetting to reset modifiers between actions, which was a recurring issue during sessions.
**Changes to `ImperiumMaledictum/sheet_new.html`:**
- Removed difficulty and circumstance selects from the header `.roller` div (kept `attr_superiority` as a global select)
- Characteristic, skill and repeating section roll handlers no longer read these values from `getAttrs`; instead, `rollTest` embeds `?{Difficulty|...}` and `?{Circumstances|...}` directly in the `startRoll` string
- Simplified circumstances query to three options: No Advantage / Advantage / Disadvantage
- Updated the `imtest` roll template to use `computed::circ_value` conditionals and `computed::circumstances` for display, since the circumstance value is now resolved at roll time
