### PR TITLE
[Monster of the Week Official] Bugfix: Two small mostly-cosmetic fixes to advanced basic moves

### DIFF
--- a/Monster of the Week Official/translation.json
+++ b/Monster of the Week Official/translation.json
@@ -1775,7 +1775,7 @@
 	"Pyrokinesis-advanced": "<b>Advanced:</b> When you advance <b>pyrokinesis</b>, add this:<ul><li>On a 12+, pick two normal options or one of these:<ul><li>A fire starts where normally impossible.<li>All nearby fires are extinguished.<li>One person is immune to fire and smoke for a few minutes.</ul></ul>",
 	"Summoner-advanced": "<b>Advanced:</b> When you advance <b>summoner</b>, add this:<ul><li>On a 12+, choose one: either the creature stays to complete an extra task, or it reveals a useful secret.</ul>",
 	"Tradecraft-advanced": "<b>Advanced:</b> When you advance <b>tradecraft</b>, add this:<ul><li>On a 12+, you also choose one of these:<ul><li>The goal works out better than expected.<li>Choose a second, extra, goal.</ul></ul>",
-	"Warding-advanced": "<b>Advanced Warding:</b> When you advance <b>warding</b>, add this:<ul><li>On a 12+, your ward has a secondary effect. Take the strong intended effect plus another standard effect.</ul>",
+	"Warding-advanced": "<b>Advanced:</b> When you advance <b>warding</b>, add this:<ul><li>On a 12+, your ward has a secondary effect. Take the strong intended effect plus another standard effect.</ul>",
 	"Custom Team Playbook": "Custom Team Playbook",
 	"The Loner": "The Loner",
 	"The Lore-Holder": "The Lore-Holder",


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description
- Phantom box showed up when marking the improvement to access the Advanced version of Manipulate Someone. Box now removed.
- Text display of "Warding Advanced" read "Warding Advanced Warding", inconsistent vs. all other advanced moves.
