### PR TITLE
[HollowEarthExpedition] Bugfix: Alter img src to reference github hex logo; tweaks to textarea font-size and height

### DIFF
--- a/HollowEarthExpedition/Hollow-Earth-Expedition.html
+++ b/HollowEarthExpedition/Hollow-Earth-Expedition.html
@@ -117,7 +117,7 @@
                     <span data-i18n="Motivation">Motivation</span>
                 </div>
                 <div class="sheet-img-logo">
-                    <img class="sheet-hexlogo" src="http://exilegames.com/images/hex_logo_r20.png" />
+                    <img class="sheet-hexlogo" src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/HollowEarthExpedition/hexlogo.png" />
                 </div>
             </div>
             <div class="sheet-stats">

--- a/HollowEarthExpedition/hex.css
+++ b/HollowEarthExpedition/hex.css
@@ -65,8 +65,8 @@
   border-bottom: 1px solid lightblue;
   box-shadow: none;
   box-sizing: border-box;
-  font-size: 0.9rem;
-  height: 2.8rem;
+  font-size: 1.4rem;
+  height: 5rem;
   max-width: 100%;
   min-width: 100%;
   width: 100%;
@@ -143,10 +143,10 @@
 }
 .sheet-hex .sheet-2colrow .sheet-col.sheet-languages-money textarea {
   border-top: none;
-  height: 4.6rem;
+  height: 5rem;
 }
 .sheet-hex .sheet-2colrow .sheet-col.sheet-languages-money textarea.sheet-money {
-  height: 3rem;
+  height: 5rem;
 }
 .sheet-hex .sheet-attr-input-label, .sheet-hex .sheet-side-input-label {
   border-bottom: 1px solid lightblue;
@@ -278,7 +278,7 @@
   font-size: 1.1rem;
   font-style: italic;
   position: absolute;
-  left: 1.6rem;
+  left: 2.5rem;
   top: -1.1rem;
 }
 .sheet-hex .sheet-weapon-isranged ~ .sheet-ranged-stats {

--- a/HollowEarthExpedition/hex.scss
+++ b/HollowEarthExpedition/hex.scss
@@ -97,8 +97,8 @@ $font-size-smallest: 1.05rem;
 		-moz-box-sizing: border-box;
 		-webkit-box-sizing: border-box;
 		box-sizing: border-box;
-		font-size: 0.9rem;
-		height: 2.8rem;
+		font-size: $font-size-medium;
+		height: 5rem;
 		max-width: 100%;
 		min-width: 100%;
 		width: 100%;
@@ -200,10 +200,10 @@ $font-size-smallest: 1.05rem;
 
 				textarea {
 					border-top: none;
-					height: 4.6rem;
+					height: 5rem;
 
 					&.sheet-money {
-						height: 3rem;
+						height: 5rem;
 					}
 				}
 			}
@@ -366,7 +366,7 @@ $font-size-smallest: 1.05rem;
 			font-size: $font-size-small;
 			font-style: italic;
 			position: absolute;
-			left: 1.6rem;
+			left: 2.5rem;
 			top: -1.1rem;
 		}
 


### PR DESCRIPTION
## [HollowEarthExpedition] Bugfix: Alter img src to reference github hex logo; tweaks to textarea font-size and height

- [ x ] The pull request title clearly contains the name of the sheet I am editing.
- [ x ] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content
- [ x ] The pull request makes changes to files in only one sub-folder.
- [ x ] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [ x ] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description
Completes work started on previous PR (heex-font-resize) to migrate image reference from defunct exilegames server. Text size accessibility improvements.