### PR TITLE
[Candela Obscura PT-BR] Bugfix: Fix logo image path

### DIFF
--- a/Candela-Obscura-PT-BR/candela-obscura-pt-br.html
+++ b/Candela-Obscura-PT-BR/candela-obscura-pt-br.html
@@ -2,7 +2,7 @@
 
   <div class="sheet-header-top">
     <div class="sheet-logo-placeholder">
-      <img src="logo.png" alt="Logo">
+      <img src="https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Candela-Obscura-PT-BR/logo.png" alt="Logo">
     </div>
     <div class="sheet-header-fields">
       <div class="sheet-header-field">Nome: <input type="text" name="attr_character_name"></div>


### PR DESCRIPTION
Fixed the logo image path to use the raw GitHub URL so it loads correctly in Roll20.

# Submission Checklist

## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

This PR fixes the Candela Obscura PT-BR sheet logo path by replacing the relative image source with the raw GitHub URL:

`https://raw.githubusercontent.com/Roll20/roll20-character-sheets/master/Candela-Obscura-PT-BR/logo.png`

This allows the logo to load correctly in Roll20.