### PR TITLE
Dark Heresy (1e) BugFix: fix failure rolls coloured green for narrow misses

### DIFF
--- a/Dark_Heresy/DarkHeresy.html
+++ b/Dark_Heresy/DarkHeresy.html
@@ -102,7 +102,7 @@
                         <td><input name="attr_Awareness3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Awareness4" type="number" value="0"></td>
                         <td><button name="roll_Awareness" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollawareness}}} [[(@{Awareness}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Awareness}]]}} {{target=[[@{Awareness} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollawareness}}} [[(@{Awareness}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Awareness}]]}} {{target=[[@{Awareness} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Awareness" type="number"
                                     value="floor((@{Awareness1}+0.5)*@{Per}+@{Awareness2}+@{Awareness3}+@{Awareness4})">
                             </button></td>
@@ -114,7 +114,7 @@
                         <td><input name="attr_Barter3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Barter4" type="number" value="0"></td>
                         <td><button name="roll_Barter" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollbarter}}} [[(@{Barter}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Barter}]]}} {{target=[[@{Barter} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollbarter}}} [[(@{Barter}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Barter}]]}} {{target=[[@{Barter} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Barter" type="number"
                                     value="floor((@{Barter1}+0.5)*@{Fel}+@{Barter2}+@{Barter3}+@{Barter4})">
                             </button></td>
@@ -126,7 +126,7 @@
                         <td><input name="attr_Carouse3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Carouse4" type="number" value="0"></td>
                         <td><button name="roll_Carouse" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcarouse}}} [[(@{Carouse}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Carouse}]]}} {{target=[[@{Carouse} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcarouse}}} [[(@{Carouse}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Carouse}]]}} {{target=[[@{Carouse} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Carouse" type="number"
                                     value="floor((@{Carouse1}+0.5)*@{T}+@{Carouse2}+@{Carouse3}+@{Carouse4})">
                             </button></td>
@@ -138,7 +138,7 @@
                         <td><input name="attr_Charm3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Charm4" type="number" value="0"></td>
                         <td><button name="roll_Charm" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcharism}}} [[(@{Charm}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Charm}]]}} {{target=[[@{Charm} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcharism}}} [[(@{Charm}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Charm}]]}} {{target=[[@{Charm} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Charm" type="number"
                                     value="floor((@{Charm1}+0.5)*@{Fel}+@{Charm2}+@{Charm3}+@{Charm4})">
                             </button></td>
@@ -150,7 +150,7 @@
                         <td><input name="attr_Climb3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Climb4" type="number" value="0"></td>
                         <td><button name="roll_Climb" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollclimb}}} [[(@{Climb}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Climb}]]}} {{target=[[@{Climb} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollclimb}}} [[(@{Climb}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Climb}]]}} {{target=[[@{Climb} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Climb" type="number"
                                     value="floor((@{Climb1}+0.5)*@{S}+@{Climb2}+@{Climb3}+@{Climb4})">
                             </button></td>
@@ -162,7 +162,7 @@
                         <td><input name="attr_Command3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Command4" type="number" value="0"></td>
                         <td><button name="roll_Command" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcommand}}} [[(@{Command}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Command}]]}} {{target=[[@{Command} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcommand}}} [[(@{Command}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Command}]]}} {{target=[[@{Command} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Command" type="number"
                                     value="floor((@{Command1}+0.5)*@{Fel}+@{Command2}+@{Command3}+@{Command4})">
                             </button></td>
@@ -174,7 +174,7 @@
                         <td><input name="attr_Concealment3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Concealment4" type="number" value="0"></td>
                         <td><button name="roll_Concealment" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollconcealment}}} [[(@{Concealment}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Concealment}]]}} {{target=[[@{Concealment} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollconcealment}}} [[(@{Concealment}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Concealment}]]}} {{target=[[@{Concealment} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Concealment" type="number"
                                     value="floor((@{Concealment1}+0.5)*@{Ag}+@{Concealment2}+@{Concealment3}+@{Concealment4})">
                             </button></td>
@@ -186,7 +186,7 @@
                         <td><input name="attr_Contortionist3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Contortionist4" type="number" value="0"></td>
                         <td><button name="roll_Contortionist" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcontortionist}}} [[(@{Contortionist}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Contortionist}]]}} {{target=[[@{Contortionist} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollcontortionist}}} [[(@{Contortionist}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Contortionist}]]}} {{target=[[@{Contortionist} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Contortionist" type="number"
                                     value="floor((@{Contortionist1}+0.5)*@{Ag}+@{Contortionist2}+@{Contortionist3}+@{Contortionist4})">
                             </button></td>
@@ -198,7 +198,7 @@
                         <td><input name="attr_Deceive3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Deceive4" type="number" value="0"></td>
                         <td><button name="roll_Deceive" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolldeceive}}} [[(@{Deceive}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Deceive}]]}} {{target=[[@{Deceive} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolldeceive}}} [[(@{Deceive}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Deceive}]]}} {{target=[[@{Deceive} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Deceive" type="number"
                                     value="floor((@{Deceive1}+0.5)*@{Fel}+@{Deceive2}+@{Deceive3}+@{Deceive4})">
                             </button></td>
@@ -210,7 +210,7 @@
                         <td><input name="attr_Disguise3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Disguise4" type="number" value="0"></td>
                         <td><button name="roll_Disguise" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolldisguise}}} [[(@{Disguise}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Disguise}]]}} {{target=[[@{Disguise} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolldisguise}}} [[(@{Disguise}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Disguise}]]}} {{target=[[@{Disguise} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Disguise" type="number"
                                     value="floor((@{Disguise1}+0.5)*@{Fel}+@{Disguise2}+@{Disguise3}+@{Disguise4})">
                             </button></td>
@@ -222,7 +222,7 @@
                         <td><input name="attr_Dodge3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Dodge4" type="number" value="0"></td>
                         <td><button name="roll_Dodge" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolldodge}}} [[(@{Dodge}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Dodge}]]}} {{target=[[@{Dodge} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolldodge}}} [[(@{Dodge}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Dodge}]]}} {{target=[[@{Dodge} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Dodge" type="number"
                                     value="floor((@{Dodge1}+0.5)*@{Ag}+@{Dodge2}+@{Dodge3}+@{Dodge4})">
                             </button></td>
@@ -234,7 +234,7 @@
                         <td><input name="attr_Evaluate3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Evaluate4" type="number" value="0"></td>
                         <td><button name="roll_Evaluate" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollevaluate}}} [[(@{Evaluate}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Evaluate}]]}} {{target=[[@{Evaluate} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollevaluate}}} [[(@{Evaluate}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Evaluate}]]}} {{target=[[@{Evaluate} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Evaluate" type="number"
                                     value="floor((@{Evaluate1}+0.5)*@{Int}+@{Evaluate2}+@{Evaluate3}+@{Evaluate4})">
                             </button></td>
@@ -246,7 +246,7 @@
                         <td><input name="attr_Gamble3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Gamble4" type="number" value="0"></td>
                         <td><button name="roll_Gamble" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollgamble}}} [[(@{Gamble}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Gamble}]]}} {{target=[[@{Gamble} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollgamble}}} [[(@{Gamble}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Gamble}]]}} {{target=[[@{Gamble} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Gamble" type="number"
                                     value="floor((@{Gamble1}+0.5)*@{Int}+@{Gamble2}+@{Gamble3}+@{Gamble4})">
                             </button></td>
@@ -258,7 +258,7 @@
                         <td><input name="attr_Inquiry3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Inquiry4" type="number" value="0"></td>
                         <td><button name="roll_Inquiry" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollinquiry}}} [[(@{Inquiry}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Inquiry}]]}} {{target=[[@{Inquiry} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollinquiry}}} [[(@{Inquiry}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Inquiry}]]}} {{target=[[@{Inquiry} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Inquiry" type="number"
                                     value="floor((@{Inquiry1}+0.5)*@{Fel}+@{Inquiry2}+@{Inquiry3}+@{Inquiry4})">
                             </button></td>
@@ -270,7 +270,7 @@
                         <td><input name="attr_Intimidate3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Intimidate4" type="number" value="0"></td>
                         <td><button name="roll_Intimidate" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollintimidate}}} [[(@{Intimidate}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Intimidate}]]}} {{target=[[@{Intimidate} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollintimidate}}} [[(@{Intimidate}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Intimidate}]]}} {{target=[[@{Intimidate} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Intimidate" type="number"
                                     value="floor((@{Intimidate1}+0.5)*@{S}+@{Intimidate2}+@{Intimidate3}+@{Intimidate4})">
                             </button></td>
@@ -282,7 +282,7 @@
                         <td><input name="attr_Logic3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Logic4" type="number" value="0"></td>
                         <td><button name="roll_Logic" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} [[(@{Logic}+?{Modifier|0}-[[1d100]])/10]] {{rollname=^{rolllogic}}} {{roll=$[[1]]}} {{skill=[[@{Logic}]]}} {{target=[[@{Logic} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} [[(@{Logic}+?{Modifier|0}-[[1d100]])/10]] {{rollname=^{rolllogic}}} {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Logic}]]}} {{target=[[@{Logic} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Logic" type="number"
                                     value="floor((@{Logic1}+0.5)*@{Int}+@{Logic2}+@{Logic3}+@{Logic4})">
                             </button></td>
@@ -294,7 +294,7 @@
                         <td><input name="attr_Scrutiny3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Scrutiny4" type="number" value="0"></td>
                         <td><button name="roll_Scrutiny" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollscrutiny}}} [[(@{Scrutiny}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Scrutiny}]]}} {{target=[[@{Scrutiny} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollscrutiny}}} [[(@{Scrutiny}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Scrutiny}]]}} {{target=[[@{Scrutiny} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Scrutiny" type="number"
                                     value="floor((@{Scrutiny1}+0.5)*@{Per}+@{Scrutiny2}+@{Scrutiny3}+@{Scrutiny4})">
                             </button></td>
@@ -306,7 +306,7 @@
                         <td><input name="attr_Search3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Search4" type="number" value="0"></td>
                         <td><button name="roll_Search" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollsearch}}} [[(@{Search}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Search}]]}} {{target=[[@{Search} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollsearch}}} [[(@{Search}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Search}]]}} {{target=[[@{Search} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Search" type="number"
                                     value="floor((@{Search1}+0.5)*@{Per}+@{Search2}+@{Search3}+@{Search4})">
                             </button></td>
@@ -318,7 +318,7 @@
                         <td><input name="attr_SilentMove3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_SilentMove4" type="number" value="0"></td>
                         <td><button name="roll_SilentMove" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollsilentmove}}} [[(@{SilentMove}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{SilentMove}]]}} {{target=[[@{SilentMove} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollsilentmove}}} [[(@{SilentMove}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{SilentMove}]]}} {{target=[[@{SilentMove} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_SilentMove" type="number"
                                     value="floor((@{SilentMove1}+0.5)*@{Ag}+@{SilentMove2}+@{SilentMove3}+@{SilentMove4})">
                             </button></td>
@@ -330,7 +330,7 @@
                         <td><input name="attr_Swim3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_Swim4" type="number" value="0"></td>
                         <td><button name="roll_Swim" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollswim}}} [[(@{Swim}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{Swim}]]}} {{target=[[@{Swim} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollswim}}} [[(@{Swim}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{Swim}]]}} {{target=[[@{Swim} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_Swim" type="number"
                                     value="floor((@{Swim1}+0.5)*@{S}+@{Swim2}+@{Swim3}+@{Swim4})">
                             </button></td>
@@ -366,47 +366,47 @@
                 <h3 data-i18n="characteristics">Characteristics</h3>
 
                 <button name="roll_WS" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollws}}} [[(@{WS}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{WS}}} {{target=[[@{WS} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollws}}} [[(@{WS}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{WS}}} {{target=[[@{WS} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="weaponskillws">Weapon Skill (WS)</label></button>
                 <input name="attr_WS" type="text" value="0">
 
                 <button name="roll_BS" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollbs}}} [[(@{BS}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{BS}}} {{target=[[@{BS} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollbs}}} [[(@{BS}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{BS}}} {{target=[[@{BS} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="ballisticskillbs">Ballistic Skill (BS)</label></button>
                 <input name="attr_BS" type="text" value="0">
 
                 <button name="roll_S" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolls}}} [[(@{S}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{S}}} {{target=[[@{S} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rolls}}} [[(@{S}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{S}}} {{target=[[@{S} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="strengths">Strength (S)</label></button>
                 <input name="attr_S" type="text" value="0">
 
                 <button name="roll_T" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollt}}} [[(@{T}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{T}}} {{target=[[@{T} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollt}}} [[(@{T}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{T}}} {{target=[[@{T} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="toughnesst">Toughness (T)</label></button>
                 <input name="attr_T" type="text" value="0">
 
                 <button name="roll_Ag" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollag}}} [[(@{Ag}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{Ag}}} {{target=[[@{Ag} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollag}}} [[(@{Ag}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{Ag}}} {{target=[[@{Ag} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="agilityag">Agility (Ag)</label></button>
 				<input name="attr_Ag" type="text" value="0">
 
                 <button name="roll_Int" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollint}}} [[(@{Int}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{Int}}} {{target=[[@{Int} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollint}}} [[(@{Int}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{Int}}} {{target=[[@{Int} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="intelligenceint">Intelligence (Int)</label></button>
 				<input name="attr_Int" type="text" value="0">
 
                 <button name="roll_Per" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollper}}} [[(@{Per}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{Per}}} {{target=[[@{Per} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollper}}} [[(@{Per}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{Per}}} {{target=[[@{Per} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="perceptionper">Perception (Per)</label></button>
 				<input name="attr_Per" type="text" value="0">
 
                 <button name="roll_Wp" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollwp}}} [[(@{Wp}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{Wp}}} {{target=[[@{Wp} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollwp}}} [[(@{Wp}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{Wp}}} {{target=[[@{Wp} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="willpowerwp">Willpower (Wp)</label></button>
 				<input name="attr_Wp" type="text" value="0">
 
                 <button name="roll_Fel" type="roll"
-                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollfel}}} [[(@{Fel}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=@{Fel}}} {{target=[[@{Fel} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                    value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollfel}}} [[(@{Fel}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{Fel}}} {{target=[[@{Fel} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                     <label data-i18n="fellowshi`fel">Fellowship (Fel)</label></button>
 				<input name="attr_Fel" type="text" value="0">
 				
@@ -433,7 +433,7 @@
                         <td><input name="attr_speaklow3" type="checkbox" value="10"></td>
                         <td style="width:60px"><input name="attr_speaklow4" type="number" value="0"></td>
                         <td><button name="roll_speaklow" type="roll"
-                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollspeaklow}}} [[(@{speaklow}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{speaklow}]]}} {{target=[[@{speaklow} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                value="@{abilityroll} &{template:dh1ed} {{rollname=^{rollspeaklow}}} [[(@{speaklow}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{speaklow}]]}} {{target=[[@{speaklow} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                 <input disabled name="attr_speaklow" type="number"
                                     value="floor((@{speaklow1}+0.5)*@{Int}+@{speaklow2}+@{speaklow3}+@{speaklow4})">
                             </button></td>
@@ -465,7 +465,7 @@
                             <td><input name="attr_advancedskillbox3" type="checkbox" value="10"></td>
                             <td style="width:60px"><input name="attr_advancedskillbox4" type="number" value="0"></td>
                             <td><button name="roll_advanceskill" type="roll"
-                                    value="@{abilityroll} &{template:dh1ed} {{rollname=@{advancedskillname}}} [[(@{advancedskill}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{skill=[[@{advancedskill}]]}} {{target=[[@{advancedskill} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
+                                    value="@{abilityroll} &{template:dh1ed} {{rollname=@{advancedskillname}}} [[(@{advancedskill}+?{Modifier|0}-[[1d100]])/10]] {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=[[@{advancedskill}]]}} {{target=[[@{advancedskill} + ?{Modifier|0}]]}} {{modifier=?{Modifier|0}}} {{diceroll=$[[0]]}}">
                                     <input disabled name="attr_advancedskill" type="number"
                                         value="floor((@{advancedskillbox1}+0.5)*@{advancedskillcharacteristic}+@{advancedskillbox2}+@{advancedskillbox3}+@{advancedskillbox4})">
                                 </button></td>
@@ -590,7 +590,7 @@
                             </div>
                             <div class="sheet-item" style="width:10%; float: right;">
                                 <button name="roll_meleehit" type="roll"
-                                    value="@{abilityroll} &{template:dh1ed} {{rollname=@{meleeweaponname} ^{tohit}}} [[(@{WS} ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} ?{Attack Type | Standard (+0),+0 | Charge (+10),+10 | All out (+20),+20 | Lighting (-10),-10} + ?{Modifier|0}-[[1d100]])/10]] {{weapondiceroll=$[[0]]}} {{roll=$[[1]]}} {{skill=@{WS}}} {{target=[[@{WS} ?{Aim | } ?{Attack Type | } + ?{Modifier|0}]]}} {{aim=?{Aim | }}} {{attacktype=?{Attack Type | }}} {{modifier=?{Modifier|0}}}">
+                                    value="@{abilityroll} &{template:dh1ed} {{rollname=@{meleeweaponname} ^{tohit}}} [[(@{WS} ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} ?{Attack Type | Standard (+0),+0 | Charge (+10),+10 | All out (+20),+20 | Lighting (-10),-10} + ?{Modifier|0}-[[1d100]])/10]] {{weapondiceroll=$[[0]]}} {{roll=$[[1]]}} {{hit=$[[0]]}} {{skill=@{WS}}} {{target=[[@{WS} ?{Aim | } ?{Attack Type | } + ?{Modifier|0}]]}} {{aim=?{Aim | }}} {{attacktype=?{Attack Type | }}} {{modifier=?{Modifier|0}}}">
                                     <label data-i18n="hit">Hit</label>
                                 </button>
                             </div>
@@ -762,7 +762,7 @@
                             <div class="sheet-rangehide" data-i18n="range_description:">The input fields always show the maximum value for the distance category and the minimum value is always the previous category +1</div>
                             <div class="sheet-item" style="width: 10%; float: right;">
                                 <button name="roll_rangedhit" type="roll"
-                                    value="@{abilityroll} &{template:dh1ed} {{rollname=@{rangedweaponname} ^{tohit}}} [[(@{BS} ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} ?{Range | Point Blank (+30),+30 | Short (+10),+10 | Middle (+0),+0 | Long (-10),-10 | Extreme (-30),-30} ?{Rate of Fire/Attack Type | Standard (+0),+0 | Semi auto (+10),+10 | Full Auto (+20),+20 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0}-[[1d100]])/10]] {{weapondiceroll=$[[0]]}} {{roll=$[[1]]}} {{reliable=[[1d10]]}} {{skill=@{BS}}} {{target=[[@{BS} ?{Aim | } ?{Range | } ?{Rate of Fire/Attack Type | } + ?{Modifier|0}]]}} {{aim=?{Aim | }}} {{range=?{Range | }}} {{attacktype=?{Rate of Fire/Attack Type | }}} {{modifier=?{Modifier|0}}}">
+                                    value="@{abilityroll} &{template:dh1ed} {{rollname=@{rangedweaponname} ^{tohit}}} [[(@{BS} ?{Aim | Half aim (+10),+10| No aim (+0),+0 | Full aim (+20),+20} ?{Range | Point Blank (+30),+30 | Short (+10),+10 | Middle (+0),+0 | Long (-10),-10 | Extreme (-30),-30} ?{Rate of Fire/Attack Type | Standard (+0),+0 | Semi auto (+10),+10 | Full Auto (+20),+20 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + ?{Modifier|0}-[[1d100]])/10]] {{weapondiceroll=$[[0]]}} {{roll=$[[1]]}} {{hit=$[[0]]}} {{reliable=[[1d10]]}} {{skill=@{BS}}} {{target=[[@{BS} ?{Aim | } ?{Range | } ?{Rate of Fire/Attack Type | } + ?{Modifier|0}]]}} {{aim=?{Aim | }}} {{range=?{Range | }}} {{attacktype=?{Rate of Fire/Attack Type | }}} {{modifier=?{Modifier|0}}}">
                                     <label data-i18n="hit">Hit</label>
                                 </button>
                             </div>
@@ -1287,22 +1287,22 @@
             <td><span class="sheet-inlinerollresult">{{weapondiceroll}}</span></td>
         </tr>
         {{/rollLess() weapondiceroll 97}}
-        {{#^rollLess() roll 0}}
+        {{#^rollGreater() hit target}}
         <tr class="sheet-success">
             <th colspan="2">
                 <span data-i18n="success">Success</span> <span data-i18n="with">with</span> {{roll}} <span
                     data-i18n="degrees">degrees</span>
             </th>
         </tr>
-        {{/^rollLess() roll 0}}
-        {{#rollLess() roll 0}}
+        {{/^rollGreater() hit target}}
+        {{#rollGreater() hit target}}
         <tr class="sheet-failure">
             <th colspan="2">
                 <span data-i18n="failure">Failure</span> <span data-i18n="with">with</span> {{roll}} <span
                     data-i18n="degrees">degrees</span>
             </th>
         </tr>
-        {{/rollLess() roll 0}}
+        {{/rollGreater() hit target}}
         {{#psy}}
         <tr>
             <td><span class="sheet-tcat" data-i18n="resultpsy:">Result Psy: </span></td>


### PR DESCRIPTION
# Submission Checklist

## Pull Request Title

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

**Bug:** On the Dark Heresy (1st Edition) sheet, a failed roll that missed the target by only 1–9 was coloured green (success) instead of red (failure).

<img width="304" height="191" alt="image" src="https://github.com/user-attachments/assets/006528a4-88c9-4baa-824c-248e9c87c7b7" />

Smoke test:
<img width="382" height="250" alt="image" src="https://github.com/user-attachments/assets/02d40bba-3daf-46aa-b745-5df26227d83e" />


**Cause:**
The roll template decided success/failure with `{{#rollLess() roll 0}}`, where `roll` is the *float* degrees value `(target + modifier − 1d100) / 10`. Roll20's `rollLess()` / `rollGreater()` helpers round the value before comparing, so a narrow miss such as `−0.5` rounded to `0` and was treated as "not less than 0", sending the result down the success (green) branch.
