### PR TITLE
Fix Unnatural Characteristic Degrees of Success in Dark Heresy 2e

### DIFF
--- a/Dark_Heresy_2ed/DarkHeresy2ed.html
+++ b/Dark_Heresy_2ed/DarkHeresy2ed.html
@@ -137,7 +137,7 @@
 						<!-- WeaponSkill (WS) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_WS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{WeaponSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Weapon Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{WeaponSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{WeaponSkill} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_WS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{WeaponSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Weapon Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnWS}/2)]]}}{{skill=[[@{WeaponSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{WeaponSkill} + [[?{Modifier|+0}]]]]}}">
 									<label>Weapon Skill (WS)</label>
 								</button>
 							</div>
@@ -165,7 +165,7 @@
 						<!-- BallisticSkill (BS) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_BS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{BallisticSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Ballistic Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{BallisticSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{BallisticSkill} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_BS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{BallisticSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Ballistic Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnBS}/2)]]}}{{skill=[[@{BallisticSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{BallisticSkill} + [[?{Modifier|+0}]]]]}}">
 									<label>Ballistic Skill (BS)</label>
 								</button>
 							</div>
@@ -221,7 +221,7 @@
 						<!-- Toughness (T) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_T" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Toughness} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Toughness}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Toughness}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Toughness} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_T" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Toughness} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Toughness}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnT}/2)]]}}{{skill=[[@{Toughness}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Toughness} + [[?{Modifier|+0}]]]]}}">
 									<label>Toughness (T)</label>
 								</button>
 							</div>
@@ -249,7 +249,7 @@
 						<!-- Agility (Ag) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Ag" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Agility} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Agility}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Agility}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Agility} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Ag" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Agility} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Agility}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnAg}/2)]]}}{{skill=[[@{Agility}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Agility} + [[?{Modifier|+0}]]]]}}">
 									<label>Agility (Ag)</label>
 								</button>
 							</div>
@@ -281,7 +281,7 @@
 						<!-- Intelligence (Int) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Int" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Intelligence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Intelligence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Intelligence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Intelligence} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Int" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Intelligence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Intelligence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnInt}/2)]]}}{{skill=[[@{Intelligence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Intelligence} + [[?{Modifier|+0}]]]]}}">
 									<label>Intelligence (Int)</label>
 								</button>
 							</div>
@@ -309,7 +309,7 @@
 						<!-- Perception (Per) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Per" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Perception} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Perception}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Perception}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Perception} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Per" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Perception} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Perception}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnPer}/2)]]}}{{skill=[[@{Perception}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Perception} + [[?{Modifier|+0}]]]]}}">
 									<label>Perception (Per)</label>
 								</button>
 							</div>
@@ -337,7 +337,7 @@
 						<!-- Willpower (WP) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_WP" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Willpower} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Willpower}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Willpower}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Willpower} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_WP" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Willpower} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Willpower}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnWP}/2)]]}}{{skill=[[@{Willpower}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Willpower} + [[?{Modifier|+0}]]]]}}">
 									<label>Willpower (WP)</label>
 								</button>
 							</div>
@@ -365,7 +365,7 @@
 						<!-- Fellowship (Fel) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Fel" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Fellowship} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Fellowship}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Fellowship}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Fellowship} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Fel" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Fellowship} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Fellowship}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnFel}/2)]]}}{{skill=[[@{Fellowship}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Fellowship} + [[?{Modifier|+0}]]]]}}">
 									<label>Fellowship (Fel)</label>
 								</button>
 							</div>
@@ -393,7 +393,7 @@
 						<!-- Influence (Ifl) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Inf" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Influence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Influence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Influence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Influence} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Inf" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Influence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Influence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnInf}/2)]]}}{{skill=[[@{Influence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Influence} + [[?{Modifier|+0}]]]]}}">
 									<label>Influence (Inf)</label>
 								</button>
 							</div>

--- a/Dark_Heresy_2ed/DarkHeresy2ed.html
+++ b/Dark_Heresy_2ed/DarkHeresy2ed.html
@@ -193,7 +193,7 @@
 						<!-- Strength (S) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_S" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Strength} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Strength}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{Strength}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Strength} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_S" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Strength} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Strength}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnS}/2)]]}}{{skill=[[@{Strength}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Strength} + [[?{Modifier|+0}]]]]}}">
 									<label>Strength (S)</label>
 								</button>
 							</div>
@@ -3071,7 +3071,10 @@
 		{{#rollGreater() degrees 0}}
 		<tr class="sheet-success">
 			<th colspan="2">
-				<span>Success</span> <span>with </span> {{degrees}} <span> additional degrees</span>
+				<span>Success</span> <span>with </span>
+				{{#successdegrees}}{{successdegrees}}{{/successdegrees}}
+				{{^successdegrees}}{{degrees}}{{/successdegrees}}
+				<span> additional degrees</span>
 			</th>
 		</tr>
 		{{/rollGreater() degrees 0}}
@@ -3080,7 +3083,15 @@
 		{{#^rollLess() target roll}}
 		<tr class="sheet-success">
 			<th colspan="2">
-				<span>Success</span> <span> </span>  <span></span>
+				{{#successdegrees}}
+				<span>Success</span> <span>with </span>
+				{{successdegrees}}
+				<span> additional degrees</span>
+				{{/successdegrees}}
+
+				{{^successdegrees}}
+				<span>Success</span>
+				{{/successdegrees}}
 			</th>
 		</tr>
 		{{/^rollLess() target roll}}


### PR DESCRIPTION
## Summary

Fixes #14138 for the Dark Heresy 2nd Edition character sheet.

This change updates successful characteristic tests so the displayed Degrees of Success include half of the appropriate Unnatural Characteristic value, rounded up.

## Changes

* Added adjusted successful Degrees of Success for all ten characteristics:

  * Weapon Skill
  * Ballistic Skill
  * Strength
  * Toughness
  * Agility
  * Intelligence
  * Perception
  * Willpower
  * Fellowship
  * Influence
* Preserved the original `degrees` value for failed tests.
* Added a separate `successdegrees` value for successful-test display.

## Validation

* Ran `git diff --check` successfully.
* Reviewed the complete diff.
* Confirmed all ten characteristic rolls use the correct Unnatural Characteristic attribute.
* Confirmed only `Dark_Heresy_2ed/DarkHeresy2ed.html` was modified.

## Testing limitation

Live Roll20 custom-sheet testing was not available with my current account access, so validation was limited to static review and Git checks.
