### PR TITLE
[Les Chroniques d'Enyllion] Bugfix: Fix roll template rendering and unify sheet styling

### DIFF
--- a/Les Chroniques d'Enyllion/chroniques_enyllion.css
+++ b/Les Chroniques d'Enyllion/chroniques_enyllion.css
@@ -42,37 +42,8 @@
         width: 99%;
         max-width: 822px;
         margin-bottom: 10px;
-        /* background: 
-            radial-gradient(ellipse 250px 180px at 50% 50%, rgba(235, 220, 185, 0.4), transparent),
-            radial-gradient(ellipse 180px 120px at 15% 25%, rgba(110, 74, 45, 0.3), transparent),
-            radial-gradient(ellipse 220px 150px at 85% 70%, rgba(122, 82, 49, 0.35), transparent),
-            radial-gradient(ellipse 160px 100px at 45% 80%, rgba(117, 80, 40, 0.25), transparent),
-            radial-gradient(ellipse 140px 90px at 75% 20%, rgba(138, 93, 54, 0.28), transparent),
-            radial-gradient(ellipse 200px 130px at 25% 60%, rgba(106, 70, 42, 0.32), transparent),
-            radial-gradient(circle 80px at 92% 35%, rgba(125, 85, 48, 0.22), transparent),
-            radial-gradient(circle 70px at 8% 75%, rgba(115, 78, 45, 0.26), transparent),
-            radial-gradient(ellipse 190px 110px at 55% 15%, rgba(130, 88, 52, 0.24), transparent),
-            radial-gradient(circle 95px at 35% 45%, rgba(108, 72, 44, 0.29), transparent),
-            radial-gradient(ellipse 400px 300px at 50% 50%, #d4b896, transparent 70%),
-            linear-gradient(to bottom, rgba(90, 60, 35, 0.15) 0%, transparent 8%, transparent 92%, rgba(90, 60, 35, 0.15) 100%),
-            linear-gradient(to right, rgba(90, 60, 35, 0.18) 0%, transparent 5%, transparent 95%, rgba(90, 60, 35, 0.18) 100%),
-            linear-gradient(135deg, #9d7a56 0%, #b8936a 15%, #8a6642 25%, #a17d55 40%, #7d5e3f 55%, #b0895f 70%, #8c6846 85%, #9d7a56 100%); */
         background-color: #d4a574;
-        background-image: 
-            /* Grain principal visible mais pas agressif */
-            url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><filter id="g"><feTurbulence type="fractalNoise" baseFrequency="0.7" numOctaves="4" seed="2"/></filter><rect width="100" height="100" fill="%23000000" filter="url(%23g)" opacity="0.08"/></svg>'),
-            /* Variations de teinte */
-            url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="250" height="250"><filter id="v"><feTurbulence type="fractalNoise" baseFrequency="0.4" numOctaves="2"/></filter><rect width="250" height="250" fill="%23ffffff" filter="url(%23v)" opacity="0.04"/></svg>');
-        
-        background-size: 100px 100px, 250px 250px;
-        background-position: 0 0, 0 0;
-        
-        /* IMPORTANT : répéter le grain sur toute la surface */
-        background-repeat: repeat;
-        background-attachment: scroll;
-        
-        /* Effet de profondeur */
-        box-shadow: 
+        box-shadow:
             inset 0 0 40px rgba(0, 0, 0, 0.2),
             inset 20px 20px 40px rgba(0, 0, 0, 0.08);
         border: 2px solid #000;
@@ -474,7 +445,7 @@
         color: #000;
     }
 
-/*Jauge de santé*/
+/*Jauge de sante*/
     .jauge-sante
     {
         height: 20px;
@@ -511,10 +482,12 @@
 
     input[type="checkbox"].sante-check:checked + span::before
     {
-        content: "▼";
+        content: "";
+        display: inline-block;
+        background-color: #000;
     }
 
-/*Jauge d'affinité divine*/
+/*Jauge d'affinite divine*/
     .jauge-affDiv
     {
         height: 20px;
@@ -546,7 +519,9 @@
 
     input[type="checkbox"].affDiv-check:checked + span::before
     {
-        content: "▼";
+        content: "";
+        display: inline-block;
+        background-color: #000;
     }
 
 /*Jauge d'honneur*/
@@ -582,8 +557,9 @@
     
     input[type="checkbox"].honneur-check:checked + span::before
     {
-        content: "▼";
-        color: rgb(158, 0, 0);
+        content: "";
+        display: inline-block;
+        background-color: rgb(158, 0, 0);
     }
 
 /* Flexbox styling */
@@ -1029,7 +1005,7 @@
     .sheet-rolltemplate-monster div.sheet-rollTmpt-container,
     .sheet-rolltemplate-degatsFamilier div.sheet-rollTmpt-container {
         width: 100%;
-        background-color: #785130;
+        background-color: #d4a574;
         border: 1px solid #202020;
         border-radius: 5px;
         padding: 0px;

--- a/Les Chroniques d'Enyllion/chroniques_enyllion.html
+++ b/Les Chroniques d'Enyllion/chroniques_enyllion.html
@@ -5,7 +5,7 @@
             <span class="title-sheet">Les Chroniques d'Enyllion</span>
         </div>
         <div class="logo">
-            <img src="https://i.ibb.co/gMzcSHr1/logo-enyllion.png" style="width: 105px; height: auto;"/>
+            <img src="https://i.ibb.co/ccwn25gR/logo-enyllion.png" style="width: 105px; height: auto;"/>
         </div>
     </div>
     <!-- Choix fiche -->
@@ -3417,32 +3417,32 @@
 </rolltemplate>
 
 <rolltemplate class="sheet-rolltemplate-degats">
-    <div class="rollTmpt-container">
-        <div class="rollTmpt-header">
+    <div class="sheet-rollTmpt-container">
+        <div class="sheet-rollTmpt-header">
             {{#perso}}
-                <div class="roll-header-persoTitle">{{perso}}</div>
+                <div class="sheet-roll-header-persoTitle">{{perso}}</div>
             {{/perso}}
             {{#name}}
-                <div class="roll-header-subtitle">{{name}}</div>
+                <div class="sheet-roll-header-subtitle">{{name}}</div>
             {{/name}}
         </div>
         <hr align="center" width="50%">
-        <div class="rollTmpt-content">
+        <div class="sheet-rollTmpt-content">
             {{#effet}}
-                <div class="roll-content-effet">Effet : {{effet}}</div>
+                <div class="sheet-roll-content-effet">Effet : {{effet}}</div>
                 {{#rollGreater() Roll pourcentage}}
-                    <div class="roll-content-effet-fail">Non déclenché</div>
+                    <div class="sheet-roll-content-effet-fail">Non déclenché</div>
                     {{#RollDegats}}
-                        <div class="roll-content-roll">Dégats : {{RollDegats}}</div>
+                        <div class="sheet-roll-content-roll">Dégats : {{RollDegats}}</div>
                     {{/RollDegats}}
                 {{/rollGreater() Roll pourcentage}}
                 {{#rollLess() Roll pourcentage}}
-                    <div class="roll-content-effet-success">Déclenché</div>
+                    <div class="sheet-roll-content-effet-success">Déclenché</div>
                     {{#RollTour}}
-                        <div class="roll-content-effet-turns">Nombre de tours : {{RollTour}}</div>
+                        <div class="sheet-roll-content-effet-turns">Nombre de tours : {{RollTour}}</div>
                     {{/RollTour}}
                     {{#TotalDegats}}
-                        <div class="roll-content-roll">Dégats : {{TotalDegats}}</div>
+                        <div class="sheet-roll-content-roll">Dégats : {{TotalDegats}}</div>
                     {{/TotalDegats}}
                 {{/rollLess() Roll pourcentage}}
             {{/effet}}
@@ -3451,40 +3451,40 @@
 </rolltemplate>
 
 <rolltemplate class="sheet-rolltemplate-degatsFamilier">
-    <div class="rollTmpt-container">
-        <div class="rollTmpt-header">
+    <div class="sheet-rollTmpt-container">
+        <div class="sheet-rollTmpt-header">
             {{#perso}}
-                <div class="roll-header-persoTitle">{{perso}}</div>
+                <div class="sheet-roll-header-persoTitle">{{perso}}</div>
             {{/perso}}
             {{#familier}}
                 <div class="sheet-roll-header-famTitle">{{familier}}</div>
             {{/familier}}
             {{#name}}
-                <div class="roll-header-subtitle">{{name}}</div>
+                <div class="sheet-roll-header-subtitle">{{name}}</div>
             {{/name}}
         </div>
         <hr align="center" width="50%">
-        <div class="rollTmpt-content">
+        <div class="sheet-rollTmpt-content">
             {{#description}}
-                <div class="roll-content-description">Description : {{description}}</div>
+                <div class="sheet-roll-content-description">Description : {{description}}</div>
             {{/description}}
             {{#RollDegats}}
-                <div class="roll-content-roll">Dégats : {{RollDegats}}</div>
+                <div class="sheet-roll-content-roll">Dégats : {{RollDegats}}</div>
             {{/RollDegats}}
         </div>
     </div>
 </rolltemplate>
 
 <rolltemplate class="sheet-rolltemplate-monster">
-    <div class="rollTmpt-container">
-        <div class="rollTmpt-header">
+    <div class="sheet-rollTmpt-container">
+        <div class="sheet-rollTmpt-header">
             {{#monster}}
-                <div class="roll-header-persoTitle">{{monster}}</div>
+                <div class="sheet-roll-header-persoTitle">{{monster}}</div>
             {{/monster}}
         </div>
-        <div class="rollTmpt-content">
+        <div class="sheet-rollTmpt-content">
             {{#description}}
-                <div class="roll-header-subtitle">{{description}}</div>
+                <div class="sheet-roll-header-subtitle">{{description}}</div>
             {{/description}}
             {{#image}}
                 {{image}}


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

**Title:** `[Les Chroniques d'Enyllion] Bugfix: Fix roll template rendering and unify sheet styling`

This PR fixes the roll templates, which were broken or rendered unstyled in Roll20, and harmonizes the visual styling between the character sheet and the roll output.

### CSS (`chroniques_enyllion.css`)
- Removed an inline SVG (`data:image/svg+xml`) `background-image` from `.sheet-tabs-wrapper`. Roll20 rejects inline `<svg>`/`data:` URIs in sheet CSS, which was silently breaking the roll templates. Only `background-color`, `box-shadow` and `border` are kept.
- Removed a dead multi-line comment (old gradient `background` block), which also breaks roll template CSS.
- Replaced the three `content: "▼"` markers on the checked health, divine affinity and honor gauges with CSS-drawn blocks (`content: ""; display: inline-block; background-color`). The high Unicode glyph broke the checkbox styling. Honor uses `rgb(158, 0, 0)`; the redundant `color` rule was dropped.
- Matched the roll template container background (`#785130` → `#d4a574`) to the character sheet background so both surfaces share the same tone.

### HTML (`chroniques_enyllion.html`)
- Prefixed all roll template inner element classes with `sheet-`. Roll20 auto-prepends `sheet-` on the HTML side of roll templates, so the `degats`, `degatsFamilier` and `monster` templates (which used bare classes like `rollTmpt-container`, `roll-header-persoTitle`, `roll-content-roll`) never matched the `.sheet-*` selectors and rendered unstyled. They are now consistent with the already-correct `enyllion` template.
