### PR TITLE
[Bug Fix] [Dark Heresy 2nd Edition] Fixed unnatural characteristic outputs

### DIFF
--- a/Dark_Heresy_2ed/DarkHeresy2ed.html
+++ b/Dark_Heresy_2ed/DarkHeresy2ed.html
@@ -137,7 +137,7 @@
 						<!-- WeaponSkill (WS) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_WS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{WeaponSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Weapon Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnWS}/2)]]}}{{skill=[[@{WeaponSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{WeaponSkill} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_WS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{WeaponSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Weapon Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnWS}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnWS}/2)]]}}{{skill=[[@{WeaponSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{WeaponSkill} + [[?{Modifier|+0}]]]]}}">
 									<label>Weapon Skill (WS)</label>
 								</button>
 							</div>
@@ -165,7 +165,7 @@
 						<!-- BallisticSkill (BS) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_BS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{BallisticSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Ballistic Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnBS}/2)]]}}{{skill=[[@{BallisticSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{BallisticSkill} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_BS" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{BallisticSkill} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Ballistic Skill}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnBS}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnBS}/2)]]}}{{skill=[[@{BallisticSkill}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{BallisticSkill} + [[?{Modifier|+0}]]]]}}">
 									<label>Ballistic Skill (BS)</label>
 								</button>
 							</div>
@@ -193,7 +193,7 @@
 						<!-- Strength (S) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_S" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Strength} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Strength}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnS}/2)]]}}{{skill=[[@{Strength}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Strength} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_S" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Strength} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Strength}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnS}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnS}/2)]]}}{{skill=[[@{Strength}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Strength} + [[?{Modifier|+0}]]]]}}">
 									<label>Strength (S)</label>
 								</button>
 							</div>
@@ -221,7 +221,7 @@
 						<!-- Toughness (T) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_T" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Toughness} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Toughness}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnT}/2)]]}}{{skill=[[@{Toughness}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Toughness} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_T" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Toughness} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Toughness}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnT}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnT}/2)]]}}{{skill=[[@{Toughness}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Toughness} + [[?{Modifier|+0}]]]]}}">
 									<label>Toughness (T)</label>
 								</button>
 							</div>
@@ -249,7 +249,7 @@
 						<!-- Agility (Ag) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Ag" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Agility} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Agility}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnAg}/2)]]}}{{skill=[[@{Agility}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Agility} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Ag" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Agility} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Agility}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnAg}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnAg}/2)]]}}{{skill=[[@{Agility}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Agility} + [[?{Modifier|+0}]]]]}}">
 									<label>Agility (Ag)</label>
 								</button>
 							</div>
@@ -281,7 +281,7 @@
 						<!-- Intelligence (Int) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Int" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Intelligence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Intelligence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnInt}/2)]]}}{{skill=[[@{Intelligence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Intelligence} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Int" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Intelligence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Intelligence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnInt}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnInt}/2)]]}}{{skill=[[@{Intelligence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Intelligence} + [[?{Modifier|+0}]]]]}}">
 									<label>Intelligence (Int)</label>
 								</button>
 							</div>
@@ -309,7 +309,7 @@
 						<!-- Perception (Per) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Per" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Perception} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Perception}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnPer}/2)]]}}{{skill=[[@{Perception}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Perception} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Per" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Perception} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Perception}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnPer}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnPer}/2)]]}}{{skill=[[@{Perception}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Perception} + [[?{Modifier|+0}]]]]}}">
 									<label>Perception (Per)</label>
 								</button>
 							</div>
@@ -337,7 +337,7 @@
 						<!-- Willpower (WP) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_WP" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Willpower} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Willpower}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnWP}/2)]]}}{{skill=[[@{Willpower}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Willpower} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_WP" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Willpower} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Willpower}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnWP}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnWP}/2)]]}}{{skill=[[@{Willpower}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Willpower} + [[?{Modifier|+0}]]]]}}">
 									<label>Willpower (WP)</label>
 								</button>
 							</div>
@@ -365,7 +365,7 @@
 						<!-- Fellowship (Fel) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Fel" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Fellowship} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Fellowship}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnFel}/2)]]}}{{skill=[[@{Fellowship}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Fellowship} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Fel" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Fellowship} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Fellowship}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnFel}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnFel}/2)]]}}{{skill=[[@{Fellowship}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Fellowship} + [[?{Modifier|+0}]]]]}}">
 									<label>Fellowship (Fel)</label>
 								</button>
 							</div>
@@ -393,7 +393,7 @@
 						<!-- Influence (Ifl) -->
 						<div class="sheet-2colrow">
 							<div class="sheet-col">
-								<button name="roll_Inf" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Influence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Influence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{successdegrees=[[$[[4]] + ceil(@{UnInf}/2)]]}}{{skill=[[@{Influence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Influence} + [[?{Modifier|+0}]]]]}}">
+								<button name="roll_Inf" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{Influence} +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Influence}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[ceil(@{UnInf}/2)]]}}{{successdegrees=[[$[[4]] + ceil(@{UnInf}/2)]]}}{{skill=[[@{Influence}]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{Influence} + [[?{Modifier|+0}]]]]}}">
 									<label>Influence (Inf)</label>
 								</button>
 							</div>
@@ -589,7 +589,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Acrobatics" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{AcrobaticsCharacteristic} + (-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Acrobatics}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{AcrobaticsCharacteristic} + (-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{AcrobaticsCharacteristic} + (-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{AcrobaticsCharacteristic} + (-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Acrobatics}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{AcrobaticsCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{AcrobaticsCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{AcrobaticsCharacteristic} + (-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{AcrobaticsCharacteristic} + (-20 + @{Acrobatics1} + @{Acrobatics2} + @{Acrobatics3} + @{Acrobatics4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Acrobatics</label>
 										</button>
 									</div>
@@ -612,7 +612,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Athletics" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{AthleticsCharacteristic} + (-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Athletics}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{AthleticsCharacteristic} + (-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{AthleticsCharacteristic} + (-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{AthleticsCharacteristic} + (-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Athletics}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{AthleticsCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{AthleticsCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{AthleticsCharacteristic} + (-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{AthleticsCharacteristic} + (-20 + @{Athletics1} + @{Athletics2} + @{Athletics3} + @{Athletics4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Athletics</label>
 										</button>
 									</div>
@@ -635,7 +635,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Awareness" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{AwarenessCharacteristic} + (-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Awareness}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{AwarenessCharacteristic} + (-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{AwarenessCharacteristic} + (-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{AwarenessCharacteristic} + (-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Awareness}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{AwarenessCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{AwarenessCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{AwarenessCharacteristic} + (-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{AwarenessCharacteristic} + (-20 + @{Awareness1} + @{Awareness2} + @{Awareness3} + @{Awareness4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Awareness</label>
 										</button>
 									</div>
@@ -659,7 +659,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Charm" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{CharmCharacteristic} + (-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Charm}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{CharmCharacteristic} + (-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CharmCharacteristic} + (-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{CharmCharacteristic} + (-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Charm}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{CharmCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{CharmCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{CharmCharacteristic} + (-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CharmCharacteristic} + (-20 + @{Charm1} + @{Charm2} + @{Charm3} + @{Charm4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Charm</label>
 										</button>
 									</div>
@@ -682,7 +682,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Command" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommandCharacteristic} + (-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Command}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{CommandCharacteristic} + (-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommandCharacteristic} + (-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommandCharacteristic} + (-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Command}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{CommandCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{CommandCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{CommandCharacteristic} + (-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommandCharacteristic} + (-20 + @{Command1} + @{Command2} + @{Command3} + @{Command4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Command</label>
 										</button>
 									</div>
@@ -707,7 +707,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Commerce" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommerceCharacteristic} + (-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Commerce}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{CommerceCharacteristic} + (-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommerceCharacteristic} + (-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommerceCharacteristic} + (-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Commerce}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{CommerceCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{CommerceCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{CommerceCharacteristic} + (-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommerceCharacteristic} + (-20 + @{Commerce1} + @{Commerce2} + @{Commerce3} + @{Commerce4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Commerce</label>
 										</button>
 									</div>
@@ -730,7 +730,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Deceive" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{DeceiveCharacteristic} + (-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Deceive}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{DeceiveCharacteristic} + (-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{DeceiveCharacteristic} + (-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{DeceiveCharacteristic} + (-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Deceive}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{DeceiveCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{DeceiveCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{DeceiveCharacteristic} + (-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{DeceiveCharacteristic} + (-20 + @{Deceive1} + @{Deceive2} + @{Deceive3} + @{Deceive4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Deceive</label>
 										</button>
 									</div>
@@ -753,7 +753,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Dodge" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{DodgeCharacteristic} + (-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Dodge}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{DodgeCharacteristic} + (-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{DodgeCharacteristic} + (-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{DodgeCharacteristic} + (-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Dodge}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{DodgeCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{DodgeCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{DodgeCharacteristic} + (-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{DodgeCharacteristic} + (-20 + @{Dodge1} + @{Dodge2} + @{Dodge3} + @{Dodge4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Dodge</label>
 										</button>
 									</div>
@@ -775,7 +775,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Inquiry" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{InquiryCharacteristic} + (-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Inquiry}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{InquiryCharacteristic} + (-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{InquiryCharacteristic} + (-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{InquiryCharacteristic} + (-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Inquiry}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{InquiryCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{InquiryCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{InquiryCharacteristic} + (-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{InquiryCharacteristic} + (-20 + @{Inquiry1} + @{Inquiry2} + @{Inquiry3} + @{Inquiry4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Inquiry</label>
 										</button>
 									</div>
@@ -799,7 +799,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Interrogation" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{InterrogationCharacteristic} + (-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Interrogation}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{InterrogationCharacteristic} + (-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{InterrogationCharacteristic} + (-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{InterrogationCharacteristic} + (-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Interrogation}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{InterrogationCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{InterrogationCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{InterrogationCharacteristic} + (-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{InterrogationCharacteristic} + (-20 + @{Interrogation1} + @{Interrogation2} + @{Interrogation3} + @{Interrogation4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Interrogation</label>
 										</button>
 									</div>
@@ -822,7 +822,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Intimidate" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{IntimidateCharacteristic} + (-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Intimidate}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{IntimidateCharacteristic} + (-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{IntimidateCharacteristic} + (-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{IntimidateCharacteristic} + (-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Intimidate}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{IntimidateCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{IntimidateCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{IntimidateCharacteristic} + (-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{IntimidateCharacteristic} + (-20 + @{Intimidate1} + @{Intimidate2} + @{Intimidate3} + @{Intimidate4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Intimidate</label>
 										</button>
 									</div>
@@ -845,7 +845,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Logic" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{LogicCharacteristic} + (-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Logic}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{LogicCharacteristic} + (-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LogicCharacteristic} + (-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{LogicCharacteristic} + (-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Logic}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{LogicCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{LogicCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{LogicCharacteristic} + (-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LogicCharacteristic} + (-20 + @{Logic1} + @{Logic2} + @{Logic3} + @{Logic4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Logic</label>
 										</button>
 									</div>
@@ -868,7 +868,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Medicae" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{MedicaeCharacteristic} + (-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Medicae}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{MedicaeCharacteristic} + (-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{MedicaeCharacteristic} + (-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{MedicaeCharacteristic} + (-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Medicae}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{MedicaeCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{MedicaeCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{MedicaeCharacteristic} + (-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{MedicaeCharacteristic} + (-20 + @{Medicae1} + @{Medicae2} + @{Medicae3} + @{Medicae4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Medicae</label>
 										</button>
 									</div>
@@ -906,7 +906,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:100%">
 										<button name="roll_Surface" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{NavigateCharacteristic} + (-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Navigate (Surface)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{NavigateCharacteristic} + (-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{NavigateCharacteristic} + (-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{NavigateCharacteristic} + (-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Navigate (Surface)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{NavigateCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{NavigateCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{NavigateCharacteristic} + (-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{NavigateCharacteristic} + (-20 + @{Surface1} + @{Surface2} + @{Surface3} + @{Surface4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Surface</label>
 										</button>
 									</div>
@@ -923,7 +923,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:100%">
 										<button name="roll_Stellar" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{NavigateCharacteristic} + (-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Navigate (Stellar)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{NavigateCharacteristic} + (-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{NavigateCharacteristic} + (-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{NavigateCharacteristic} + (-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Navigate (Stellar)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{NavigateCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{NavigateCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{NavigateCharacteristic} + (-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{NavigateCharacteristic} + (-20 + @{Stellar1} + @{Stellar2} + @{Stellar3} + @{Stellar4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Stellar</label>
 										</button>
 									</div>
@@ -940,7 +940,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:100%">
 										<button name="roll_Warp" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{NavigateCharacteristic} + (-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Navigate (Warp)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{NavigateCharacteristic} + (-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{NavigateCharacteristic} + (-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{NavigateCharacteristic} + (-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Navigate (Warp)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{NavigateCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{NavigateCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{NavigateCharacteristic} + (-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{NavigateCharacteristic} + (-20 + @{Warp1} + @{Warp2} + @{Warp3} + @{Warp4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Warp</label>
 										</button>
 									</div>
@@ -971,7 +971,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:100%">
 										<button name="roll_Aeronautica" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{OperateCharacteristic} + (-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Operate (Aeronautica)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{OperateCharacteristic} + (-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{OperateCharacteristic} + (-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{OperateCharacteristic} + (-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Operate (Aeronautica)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{OperateCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{OperateCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{OperateCharacteristic} + (-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{OperateCharacteristic} + (-20 + @{Aeronautica1} + @{Aeronautica2} + @{Aeronautica3} + @{Aeronautica4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Aeronautica</label>
 										</button>
 									</div>
@@ -988,7 +988,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:100%">
 										<button name="roll_OSurface" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{OperateCharacteristic} + (-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Operate (Surface)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{OperateCharacteristic} + (-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{OperateCharacteristic} + (-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{OperateCharacteristic} + (-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Operate (Surface)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{OperateCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{OperateCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{OperateCharacteristic} + (-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{OperateCharacteristic} + (-20 + @{OSurface1} + @{OSurface2} + @{OSurface3} + @{OSurface4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Surface</label>
 										</button>
 									</div>
@@ -1005,7 +1005,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:100%">
 										<button name="roll_Voidship" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{OperateCharacteristic} + (-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Operate (Voidship)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{OperateCharacteristic} + (-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{OperateCharacteristic} + (-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{OperateCharacteristic} + (-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Operate (Voidship)}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{OperateCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{OperateCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{OperateCharacteristic} + (-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{OperateCharacteristic} + (-20 + @{Voidship1} + @{Voidship2} + @{Voidship3} + @{Voidship4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Voidship</label>
 										</button>
 									</div>
@@ -1022,7 +1022,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Parry" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ParryCharacteristic} + (-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Parry}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ParryCharacteristic} + (-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ParryCharacteristic} + (-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ParryCharacteristic} + (-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Parry}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ParryCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ParryCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ParryCharacteristic} + (-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ParryCharacteristic} + (-20 + @{Parry1} + @{Parry2} + @{Parry3} + @{Parry4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Parry</label>
 										</button>
 									</div>
@@ -1044,7 +1044,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Psyniscience" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{PsyniscienceCharacteristic} + (-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Psyniscience}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{PsyniscienceCharacteristic} + (-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{PsyniscienceCharacteristic} + (-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{PsyniscienceCharacteristic} + (-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Psyniscience}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{PsyniscienceCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{PsyniscienceCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{PsyniscienceCharacteristic} + (-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{PsyniscienceCharacteristic} + (-20 + @{Psyniscience1} + @{Psyniscience2} + @{Psyniscience3} + @{Psyniscience4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Psyniscience</label>
 										</button>
 									</div>
@@ -1067,7 +1067,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Scrutiny" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScrutinyCharacteristic} + (-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Scrutiny}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ScrutinyCharacteristic} + (-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScrutinyCharacteristic} + (-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScrutinyCharacteristic} + (-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Scrutiny}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ScrutinyCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ScrutinyCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ScrutinyCharacteristic} + (-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScrutinyCharacteristic} + (-20 + @{Scrutiny1} + @{Scrutiny2} + @{Scrutiny3} + @{Scrutiny4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Scrutiny</label>
 										</button>
 									</div>
@@ -1090,7 +1090,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Security" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{SecurityCharacteristic} + (-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Security}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{SecurityCharacteristic} + (-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{SecurityCharacteristic} + (-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{SecurityCharacteristic} + (-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Security}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{SecurityCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{SecurityCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{SecurityCharacteristic} + (-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{SecurityCharacteristic} + (-20 + @{Security1} + @{Security2} + @{Security3} + @{Security4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Security</label>
 										</button>
 									</div>
@@ -1113,7 +1113,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_SleightOfHand" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{SleightOfHandCharacteristic} + (-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Sleight of Hand}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{SleightOfHandCharacteristic} + (-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{SleightOfHandCharacteristic} + (-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{SleightOfHandCharacteristic} + (-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Sleight of Hand}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{SleightOfHandCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{SleightOfHandCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{SleightOfHandCharacteristic} + (-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{SleightOfHandCharacteristic} + (-20 + @{SleightOfHand1} + @{SleightOfHand2} + @{SleightOfHand3} + @{SleightOfHand4}) + [[?{Modifier|+0}]]]]}}">
 											<label>SleightOfHand</label>
 										</button>
 									</div>
@@ -1136,7 +1136,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Stealth" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{StealthCharacteristic} + (-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Stealth}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{StealthCharacteristic} + (-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{StealthCharacteristic} + (-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{StealthCharacteristic} + (-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Stealth}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{StealthCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{StealthCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{StealthCharacteristic} + (-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{StealthCharacteristic} + (-20 + @{Stealth1} + @{Stealth2} + @{Stealth3} + @{Stealth4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Stealth</label>
 										</button>
 									</div>
@@ -1159,7 +1159,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_Survival" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{SurvivalCharacteristic} + (-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Survival}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{SurvivalCharacteristic} + (-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{SurvivalCharacteristic} + (-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{SurvivalCharacteristic} + (-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Survival}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{SurvivalCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{SurvivalCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{SurvivalCharacteristic} + (-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{SurvivalCharacteristic} + (-20 + @{Survival1} + @{Survival2} + @{Survival3} + @{Survival4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Survival</label>
 										</button>
 									</div>
@@ -1183,7 +1183,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:55%">
 										<button name="roll_TechUse" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{TechUseCharacteristic} + (-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Tech-Use}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{TechUseCharacteristic} + (-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TechUseCharacteristic} + (-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{TechUseCharacteristic} + (-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=Tech-Use}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{TechUseCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{TechUseCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{TechUseCharacteristic} + (-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TechUseCharacteristic} + (-20 + @{TechUse1} + @{TechUse2} + @{TechUse3} + @{TechUse4}) + [[?{Modifier|+0}]]]]}}">
 											<label>Tech-Use</label>
 										</button>
 									</div>
@@ -1226,7 +1226,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_1stLanguage" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{LinguisticsCharacteristic} + (-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stLanguage}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{LinguisticsCharacteristic} + (-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LinguisticsCharacteristic} + (-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{LinguisticsCharacteristic} + (-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stLanguage}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{LinguisticsCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{LinguisticsCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{LinguisticsCharacteristic} + (-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LinguisticsCharacteristic} + (-20 + @{1stLanguage1} + @{1stLanguage2} + @{1stLanguage3} + @{1stLanguage4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1245,7 +1245,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_2ndLanguage" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{LinguisticsCharacteristic} + (-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndLanguage}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{LinguisticsCharacteristic} + (-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LinguisticsCharacteristic} + (-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{LinguisticsCharacteristic} + (-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndLanguage}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{LinguisticsCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{LinguisticsCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{LinguisticsCharacteristic} + (-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LinguisticsCharacteristic} + (-20 + @{2ndLanguage1} + @{2ndLanguage2} + @{2ndLanguage3} + @{2ndLanguage4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1264,7 +1264,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_3rdLanguage" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{LinguisticsCharacteristic} + (-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdLanguage}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{LinguisticsCharacteristic} + (-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LinguisticsCharacteristic} + (-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{LinguisticsCharacteristic} + (-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdLanguage}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{LinguisticsCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{LinguisticsCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{LinguisticsCharacteristic} + (-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{LinguisticsCharacteristic} + (-20 + @{3rdLanguage1} + @{3rdLanguage2} + @{3rdLanguage3} + @{3rdLanguage4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1299,7 +1299,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_1stTrade" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{TradeCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{TradeCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{1stTrade1} + @{1stTrade2} + @{1stTrade3} + @{1stTrade4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1318,7 +1318,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_2ndTrade" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{TradeCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{TradeCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{2ndTrade1} + @{2ndTrade2} + @{2ndTrade3} + @{2ndTrade4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1337,7 +1337,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_3rdTrade" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{TradeCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{TradeCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{3rdTrade1} + @{3rdTrade2} + @{3rdTrade3} + @{3rdTrade4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1356,7 +1356,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_4thTrade" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{TradeCharacteristic} + (-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thTrade}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{TradeCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{TradeCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{TradeCharacteristic} + (-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{TradeCharacteristic} + (-20 + @{4thTrade1} + @{4thTrade2} + @{4thTrade3} + @{4thTrade4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1392,7 +1392,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_1stCommon" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{1stCommon1} + @{1stCommon2} + @{1stCommon3} + @{1stCommon4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1411,7 +1411,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_2ndCommon" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{2ndCommon1} + @{2ndCommon2} + @{2ndCommon3} + @{2ndCommon4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1430,7 +1430,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_3rdCommon" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{3rdCommon1} + @{3rdCommon2} + @{3rdCommon3} + @{3rdCommon4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1449,7 +1449,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_4thCommon" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{CommonLoreCharacteristic} + (-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thCommon}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{CommonLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{CommonLoreCharacteristic} + (-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{CommonLoreCharacteristic} + (-20 + @{4thCommon1} + @{4thCommon2} + @{4thCommon3} + @{4thCommon4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1481,7 +1481,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_1stScholastic" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{1stScholastic1} + @{1stScholastic2} + @{1stScholastic3} + @{1stScholastic4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1499,7 +1499,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_2ndScholastic" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{2ndScholastic1} + @{2ndScholastic2} + @{2ndScholastic3} + @{2ndScholastic4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1517,7 +1517,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_3rdScholastic" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{3rdScholastic1} + @{3rdScholastic2} + @{3rdScholastic3} + @{3rdScholastic4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1535,7 +1535,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_4thScholastic" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{4thScholastic1} + @{4thScholastic2} + @{4thScholastic3} + @{4thScholastic4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1553,7 +1553,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_5thScholastic" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{5thScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{5thScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{5thScholastic1} + @{5thScholastic2} + @{5thScholastic3} + @{5thScholastic4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1571,7 +1571,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_6thScholastic" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{6thScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ScholasticLoreCharacteristic} + (-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{6thScholastic}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ScholasticLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ScholasticLoreCharacteristic} + (-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ScholasticLoreCharacteristic} + (-20 + @{6thScholastic1} + @{6thScholastic2} + @{6thScholastic3} + @{6thScholastic4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1603,7 +1603,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_1stForbidden" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{1stForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{1stForbidden1} + @{1stForbidden2} + @{1stForbidden3} + @{1stForbidden4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1621,7 +1621,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_2ndForbidden" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{2ndForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{2ndForbidden1} + @{2ndForbidden2} + @{2ndForbidden3} + @{2ndForbidden4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1639,7 +1639,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_3rdForbidden" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{3rdForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{3rdForbidden1} + @{3rdForbidden2} + @{3rdForbidden3} + @{3rdForbidden4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1657,7 +1657,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_4thForbidden" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{4thForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{4thForbidden1} + @{4thForbidden2} + @{4thForbidden3} + @{4thForbidden4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1675,7 +1675,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_5thForbidden" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{5thForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{5thForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{5thForbidden1} + @{5thForbidden2} + @{5thForbidden3} + @{5thForbidden4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -1693,7 +1693,7 @@
 								<div class="sheet-row">
 									<div class="sheet-item" style="width:20%">
 										<button name="roll_6thForbidden" type="roll"
-											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{6thForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4}) + [[?{Modifier|+0}]]]]}}">
+											value="@{whisper}&{template:dh2ed}[[[[floor((@{ForbiddenLoreCharacteristic} + (-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4}) +[[?{Modifier|+0}]])/10))]]-[[floor([[1d100]]/10)]]]] {{name=@{6thForbidden}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[@{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{successdegrees=[[$[[4]] + @{ForbiddenLoreCharacteristicUnnaturalDegrees}]]}}{{skill=[[@{ForbiddenLoreCharacteristic} + (-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4})]]}} {{modifier=?{Modifier|+0} }} {{target=[[@{ForbiddenLoreCharacteristic} + (-20 + @{6thForbidden1} + @{6thForbidden2} + @{6thForbidden3} + @{6thForbidden4}) + [[?{Modifier|+0}]]]]}}">
 										</button>
 									</div>
 									<div class="sheet-item" style="width:80%">
@@ -2520,7 +2520,7 @@
 							<div class="sheet-item" style="width: 6%;"><input name="attr_Rangedweaponclip_max" type="text" value="0" /></div>
 							<div class="sheet-item" style="width: 15%;"><label>Reload:</label></div>
 							<div class="sheet-item" style="width: 15%;"><input name="attr_Rangedweaponreload" type="text" /></div>
-							<div class="sheet-item" style="width: 16%;"><button name="roll_Rangedhit" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{BallisticSkill}+@{Rangedweaponaccuracy}?{Aim | No aim (+0),+0 | Half aim (+10),+10| Full aim (+20),+20}+ ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30}+ ?{Rate of Fire/Attack Type| Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20}+ [[?{Modifier|0}]])/10))]]-[[floor([[1d100cs<1cf>100]]/10)]]]]{{name=@{Rangedweaponname}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=@{BallisticSkill}}}{{aim=?{Aim | No aim (+0),+0 | Half aim (+10),+10 | Full aim (+20),+20} }}{{range= ?{Range | Standard range (+0),Standard range +0 | Short Range (+10),+10 | Point Blank (+30),+30 | Long Range (-10),-10 | Extreme Range (-30),-30}}}{{attacktype=?{Rate of Fire/Attack Type| Semi auto (+0),+0 | Standard (+10),+10 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20}}}{{modifier=?{Modifier|+0}}}{{target=[[@{BallisticSkill}+@{Rangedweaponaccuracy}+[[?{Aim | No aim (+0),0 | Half aim (+10),10 | Full aim (+20),20} + ?{Range | Standard range (+0),Standard range +0 | Short Range (+10),+10 | Point Blank (+30),+30 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type| Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + [[?{Modifier|0}]]]]]]}}"> <label>Hit</label> </button></div>
+							<div class="sheet-item" style="width: 16%;"><button name="roll_Rangedhit" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{BallisticSkill}+@{Rangedweaponaccuracy}+?{Aim | No aim (+0),+0 | Half aim (+10),+10| Full aim (+20),+20}+ ?{Range | Point Blank (+30),+30 | Short Range (+10),+10 | Standard range (+0),+0 | Long Range (-10),-10 | Extreme Range (-30),-30}+ ?{Rate of Fire/Attack Type| Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20}+ [[?{Modifier|0}]])/10))]]-[[floor([[1d100cs<1cf>100]]/10)]]]]{{name=@{Rangedweaponname}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[floor((@{UnBS}+1)/2)]]}}{{successdegrees=[[$[[4]] + floor((@{UnBS}+1)/2)]]}}{{skill=@{BallisticSkill}}}{{aim=?{Aim | No aim (+0),+0 | Half aim (+10),+10 | Full aim (+20),+20} }}{{range= ?{Range | Standard range (+0),Standard range +0 | Short Range (+10),+10 | Point Blank (+30),+30 | Long Range (-10),-10 | Extreme Range (-30),-30}}}{{attacktype=?{Rate of Fire/Attack Type| Semi auto (+0),+0 | Standard (+10),+10 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20}}}{{modifier=?{Modifier|+0}}}{{target=[[@{BallisticSkill}+@{Rangedweaponaccuracy}+[[?{Aim | No aim (+0),0 | Half aim (+10),10 | Full aim (+20),20} + ?{Range | Standard range (+0),Standard range +0 | Short Range (+10),+10 | Point Blank (+30),+30 | Long Range (-10),-10 | Extreme Range (-30),-30} + ?{Rate of Fire/Attack Type| Standard (+10),+10 | Semi auto (+0),+0 | Full Auto (-10),-10 | Called Shot (-20),-20 | Suppressing Fire (-20),-20} + [[?{Modifier|0}]]]]]]}}"> <label>Hit</label> </button></div>
 						</div>
 						<div class="sheet-row">
 							<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
@@ -2552,7 +2552,7 @@
 							<div class="sheet-item" style="width: 18%;"><input name="attr_meleeweapontype" type="text" /></div>
 							<div class="sheet-item" style="width: 10%;"><label>Pen:</label></div>
 							<div class="sheet-item" style="width: 10%;"><input name="attr_meleeweaponpen" type="text" value="0" /></div>
-							<div class="sheet-item" style="width: 16%;"><button name="roll_meleehit" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{WeaponSkill}+@{meleeweaponaccuracy}+ ?{Aim | No aim (+0),+0 | Half aim (+10),+10 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + [[?{Modifier|+0}]])/10))]]-[[floor([[1d100cs<1cf>100]]/10)]]]] {{name=@{meleeweaponname}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{skill=@{WeaponSkill}}}{{aim=?{Aim | No aim (+0),+0 | Half aim (+10),+10 | Full aim (+20),+20} }}{{attacktype= ?{Attack Type | All out (+30),+30 Allout| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),0 | Lighting (-10),-10}}} {{modifier=?{Modifier|+0} }} {{target=[[@{WeaponSkill}+@{meleeweaponaccuracy}+ [[?{Aim | No aim (+0),0 | Half aim (+10),10 | Full aim (+20),20} + ?{Attack Type | All out (+30),30| Charge (+20),20 |Standard (+10),10 | Swift Attack (+0),0 | Lighting (-10),-10} + [[?{Modifier|0}]]]]]]}}"> <label>Hit</label> </button></div>
+							<div class="sheet-item" style="width: 16%;"><button name="roll_meleehit" type="roll" value="@{whisper}&{template:dh2ed}[[[[floor((@{WeaponSkill}+@{meleeweaponaccuracy}+ ?{Aim | No aim (+0),+0 | Half aim (+10),+10 | Full aim (+20),+20} + ?{Attack Type | All out (+30),+30| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),+0 | Lighting (-10),-10} + [[?{Modifier|+0}]])/10))]]-[[floor([[1d100cs<1cf>100]]/10)]]]] {{name=@{meleeweaponname}}}{{roll= $[[2]] }}{{degrees=$[[4]]}}{{unnaturaldegrees=[[floor((@{UnWS}+1)/2)]]}}{{successdegrees=[[$[[4]] + floor((@{UnWS}+1)/2)]]}}{{skill=@{WeaponSkill}}}{{aim=?{Aim | No aim (+0),+0 | Half aim (+10),+10 | Full aim (+20),+20} }}{{attacktype= ?{Attack Type | All out (+30),+30 Allout| Charge (+20),+20 |Standard (+10),+10 | Swift Attack (+0),0 | Lighting (-10),-10}}} {{modifier=?{Modifier|+0} }} {{target=[[@{WeaponSkill}+@{meleeweaponaccuracy}+ [[?{Aim | No aim (+0),0 | Half aim (+10),10 | Full aim (+20),20} + ?{Attack Type | All out (+30),30| Charge (+20),20 |Standard (+10),10 | Swift Attack (+0),0 | Lighting (-10),-10} + [[?{Modifier|0}]]]]]]}}"> <label>Hit</label> </button></div>
 						</div>
 							<div class="sheet-row">
 							<div class="sheet-item" style="width: 15%;"><label>Special:</label></div>
@@ -3071,10 +3071,18 @@
 		{{#rollGreater() degrees 0}}
 		<tr class="sheet-success">
 			<th colspan="2">
+				{{#rollGreater() unnaturaldegrees 0}}
 				<span>Success</span> <span>with </span>
-				{{#successdegrees}}{{successdegrees}}{{/successdegrees}}
-				{{^successdegrees}}{{degrees}}{{/successdegrees}}
+				{{degrees}}
+				<span> additional degrees, plus </span>
+				{{unnaturaldegrees}}
+				<span> additional degreees from Unnatural Characteristics</span>
+				{{/rollGreater() unnaturaldegrees 0}}
+				{{#^rollGreater() unnaturaldegrees 0}}
+				<span>Success</span> <span>with </span>
+				{{degrees}}
 				<span> additional degrees</span>
+				{{/^rollGreater() unnaturaldegrees 0}}
 			</th>
 		</tr>
 		{{/rollGreater() degrees 0}}
@@ -3083,15 +3091,19 @@
 		{{#^rollLess() target roll}}
 		<tr class="sheet-success">
 			<th colspan="2">
-				{{#successdegrees}}
+				{{#rollGreater() unnaturaldegrees 0}}
 				<span>Success</span> <span>with </span>
-				{{successdegrees}}
-				<span> additional degrees</span>
-				{{/successdegrees}}
+				{{degrees}}
+				<span> additional degrees, plus </span>
+				{{unnaturaldegrees}}
+				<span> additional degreees from Unnatural Characteristics</span>
+				{{/rollGreater() unnaturaldegrees 0}}
 
-				{{^successdegrees}}
-				<span>Success</span>
-				{{/successdegrees}}
+				{{#^rollGreater() unnaturaldegrees 0}}
+				<span>Success</span> <span>with </span>
+				{{degrees}}
+				<span> additional degrees</span>
+				{{/^rollGreater() unnaturaldegrees 0}}
 			</th>
 		</tr>
 		{{/^rollLess() target roll}}
@@ -3865,6 +3877,92 @@ on('change:repeating_ShipEssentialComponents',function(){
 on('change:repeating_ShipSupplementalComponents',function(){
     TAS.repeatingSimpleSum('ShipSupplementalComponents','ShipSupplementalComponentSpace','ShipSupplementalComponentsSpaceTotal');
 });
+
+var skillCharacteristicAttrs = [
+	'AcrobaticsCharacteristic',
+	'AthleticsCharacteristic',
+	'AwarenessCharacteristic',
+	'CharmCharacteristic',
+	'CommandCharacteristic',
+	'CommerceCharacteristic',
+	'DeceiveCharacteristic',
+	'DodgeCharacteristic',
+	'InquiryCharacteristic',
+	'InterrogationCharacteristic',
+	'IntimidateCharacteristic',
+	'LogicCharacteristic',
+	'MedicaeCharacteristic',
+	'NavigateCharacteristic',
+	'OperateCharacteristic',
+	'ParryCharacteristic',
+	'PsyniscienceCharacteristic',
+	'ScrutinyCharacteristic',
+	'SecurityCharacteristic',
+	'SleightOfHandCharacteristic',
+	'StealthCharacteristic',
+	'SurvivalCharacteristic',
+	'TechUseCharacteristic',
+	'LinguisticsCharacteristic',
+	'TradeCharacteristic',
+	'CommonLoreCharacteristic',
+	'ScholasticLoreCharacteristic',
+	'ForbiddenLoreCharacteristic'
+];
+
+var unnaturalSourceByCharacteristic = {
+	'@{WeaponSkill}': 'UnWS',
+	'@{BallisticSkill}': 'UnBS',
+	'@{Strength}': 'UnS',
+	'@{Toughness}': 'UnT',
+	'@{Agility}': 'UnAg',
+	'@{Intelligence}': 'UnInt',
+	'@{Perception}': 'UnPer',
+	'@{Willpower}': 'UnWP',
+	'@{Fellowship}': 'UnFel',
+	'@{Influence}': 'UnInf'
+};
+
+var unnaturalSourceAttrs = [
+	'UnWS',
+	'UnBS',
+	'UnS',
+	'UnT',
+	'UnAg',
+	'UnInt',
+	'UnPer',
+	'UnWP',
+	'UnFel',
+	'UnInf'
+];
+
+var skillUnnaturalWatcher = skillCharacteristicAttrs
+	.map(function(attr) { return 'change:' + attr; })
+	.concat(unnaturalSourceAttrs.map(function(attr) { return 'change:' + attr; }))
+	.join(' ');
+
+var updateSkillUnnaturalDegrees = function() {
+	getAttrs(skillCharacteristicAttrs.concat(unnaturalSourceAttrs), function(values) {
+		var updates = {};
+
+		skillCharacteristicAttrs.forEach(function(characteristicAttr) {
+			var selectedCharacteristic = (values[characteristicAttr] || '').trim();
+			var unnaturalSourceAttr = unnaturalSourceByCharacteristic[selectedCharacteristic];
+			var rawUnnatural = unnaturalSourceAttr ? parseInt(values[unnaturalSourceAttr], 10) : 0;
+
+			if (isNaN(rawUnnatural)) {
+				rawUnnatural = 0;
+			}
+
+			updates[characteristicAttr + 'UnnaturalDegrees'] = Math.ceil(rawUnnatural / 2);
+		});
+
+		setAttrs(updates);
+	});
+};
+
+on(skillUnnaturalWatcher, updateSkillUnnaturalDegrees);
+on('sheet:opened', updateSkillUnnaturalDegrees);
+
 on("change:whispertab", function() {
     // Check the current value of the hidden attribute.
     getAttrs(["whispertab"], function(v) {


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

## New Sheet Details

Please complete this section if you are adding a new sheet to the repository.

If you are submitting a new sheet to the repository, please fill in any empty spaces indicated by [  ].

- The name of this game is: [   ]  
  > _(e.g. Dungeons & Dragons 5th Edition, The Dresden Files RPG)_
- The publisher of this game is: [   ]  
  > _(e.g. Wizards of the Coast, Evil Hat)_
- The name of this game system/family is: [   ]  
  > _(e.g. Dungeons & Dragons, FATE)_
- The rules for this game can be found at the following location: [   ]
  > _(e.g. a link to purchase, ISBN, Half-Price Books)_

- [ ] I have followed the [Character Sheets Standards](https://wiki.roll20.net/Building_Character_Sheets#Roll20_Character_Sheets_Repository) when building this sheet.
- [ ] I have authorization from the game's publisher to make this an official sheet on Roll20 with their name attached.
- [ ] (Official Sheets Only) The game's publisher has reached out to [licensing@roll20.net](mailto:licensing@roll20.net) to confirm they are aware of and supporting this sheet as an official sheet with their name attached.

Select EXACTLY One:
- [ ] This game is a traditionally published game.
- [ ] This game is not a traditionally published game.
- [ ] This sheet is for an unofficial fan game, modification to an existing game, or a homebrew system. [  ADD DETAILS HERE  ]

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->

#15219 introduced bad output formatting for the roll tables in Dark Heresy 2 by spilling macro text into the output:
<img width="285" height="419" alt="image" src="https://github.com/user-attachments/assets/1768e53e-aa6a-4b9d-890e-5b55eca75312" />

They also failed to implement the bonus for unnatural characteristics for skill checks. only characteristics.

This PR addresses four things: Characteristic checks, skill checks, attack rolls, and better output formatting

## Characteristic Checks

Now, when rolling a characteristic check, if you have an Unnatural Characteristic, the sheet correctly adds and displays the additional degrees of success from said characteristic. Eg:
<img width="194" height="104" alt="image" src="https://github.com/user-attachments/assets/18dffff7-bb18-4382-9b6f-36f7ce053413" />
Rolling Weapon Skill yields this:
<img width="273" height="242" alt="image" src="https://github.com/user-attachments/assets/8dd76848-2915-4ad4-aa39-1583aee135b6" />

## Skill Checks
Similarly, skill checks derive their base value from their associated characteristic, and now inherit the unnatural degrees of success (in this example, Parry uses Weapon Skill):
<img width="275" height="242" alt="image" src="https://github.com/user-attachments/assets/49521372-6d81-4b0f-a5d3-9b3a06a169d9" />

## Attack Rolls
Attack rolls also now benefit from unnatural weapon skill/ballistic skill:
<img width="202" height="189" alt="image" src="https://github.com/user-attachments/assets/f28cdb0b-3e18-4273-86f8-1629edb96054" />
<img width="279" height="303" alt="image" src="https://github.com/user-attachments/assets/ae1e56c3-2072-4a51-b4ef-ce8054e9967d" />
<img width="273" height="281" alt="image" src="https://github.com/user-attachments/assets/1dbb940d-73c0-4ada-affe-2db8404779a6" />

## Better Output Formatting
The output formatting is now smart enough to hide the "additional degrees from Unnatural Characteristics" if the unnatural characteristic in question is 0
<img width="198" height="100" alt="image" src="https://github.com/user-attachments/assets/4b77e869-8ab1-4ca9-ba8b-857e98a91a4c" />
<img width="277" height="205" alt="image" src="https://github.com/user-attachments/assets/7b5459f1-650a-42c4-b51e-c047fb7ef3fe" />

