### PR TITLE
Shadowrun6th-German: fix gear bonuses ignored / perk bonuses double-counted

### DIFF
--- a/Shadowrun6th-German/sheet-compiled.html
+++ b/Shadowrun6th-German/sheet-compiled.html
@@ -10345,8 +10345,8 @@ function countStates(){
             getAttributes(cids,"repeating_cyberware",allids,attrArray);
             getSectionIDs("repeating_perks", pids=>{
                 getAttributes(pids,"repeating_perks",allids,attrArray);
-                getSectionIDs("repeating_perks", pids=>{
-                    getAttributes(pids,"repeating_perks",allids,attrArray);
+                getSectionIDs("repeating_gear", gids=>{
+                    getAttributes(gids,"repeating_gear",allids,attrArray);
                     getSectionIDs("repeating_focus", pids=>{
                         getAttributes(pids,"repeating_focus",allids,attrArray);
                         getSectionIDs("repeating_adeptpowers", pids=>{
@@ -12255,7 +12255,3 @@ for (var i = 0; i < data["longRangeWeapons"].length; i++) {
 };    
     
 </script>
-
-
-
-

--- a/Shadowrun6th-German/views/script/bonusmodifier.js
+++ b/Shadowrun6th-German/views/script/bonusmodifier.js
@@ -46,8 +46,8 @@ function countStates(){
             getAttributes(cids,"repeating_cyberware",allids,attrArray);
             getSectionIDs("repeating_perks", pids=>{
                 getAttributes(pids,"repeating_perks",allids,attrArray);
-                getSectionIDs("repeating_perks", pids=>{
-                    getAttributes(pids,"repeating_perks",allids,attrArray);
+                getSectionIDs("repeating_gear", gids=>{
+                    getAttributes(gids,"repeating_gear",allids,attrArray);
                     getSectionIDs("repeating_focus", pids=>{
                         getAttributes(pids,"repeating_focus",allids,attrArray);
                         getSectionIDs("repeating_adeptpowers", pids=>{


### PR DESCRIPTION
## Summary
- `countStates()` in `Shadowrun6th-German/views/script/bonusmodifier.js` queried `repeating_perks` twice in a row instead of `repeating_perks` then `repeating_gear`.
- This meant any bonus configured on a gear item (active/attribute/bonus fields, same shape as perks/cyberware/focus) was never applied, even though the sheet's event listener explicitly re-runs `countStates()` on `change:repeating_gear`/`remove:repeating_gear`.
- It also meant every active perk's bonus was applied twice (its ID was pushed into the accumulator arrays twice).
- Fix: the duplicated inner `repeating_perks` lookup now correctly queries `repeating_gear`.
- `sheet-compiled.html` regenerated via `node app.js` per the project's own workflow.

## Test plan
- [x] Confirmed the bug live in a test Roll20 game before the fix: a perk with a +1 Agility bonus produced +2, and a gear item with a +1 Agility bonus produced +0.
- [ ] Live re-verification of the fix requires a Roll20 Pro subscription (Custom Character Sheet editor) — not available on this account, so verification here is by code inspection (the section lookup chain in `countStates()` now matches the sections listed in the `on(...)` handler exactly once each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)