### PR TITLE
[Aria] Bugfix: Remove custom critical success and failure from weapon damage

### DIFF
--- a/Aria/Aria.html
+++ b/Aria/Aria.html
@@ -104,7 +104,7 @@
                     <div class="titre">Vivre ou survivre</div>
                     <fieldset class="repeating_weapon">
                         <div class="margin-bottom weaponcontainer">
-                            <button class="btn-min" type="roll" value="@{privaterolls}&{template:aria1} {{name=Attaque}} {{character_name=[@{nameinrolls}](http://journal.roll20.net/character/@{character_id})}} {{body=@{arme} (@{degats})}} {{roll=[[@{degats}cf<0cs<0]]}}"></button>
+                            <button class="btn-min" type="roll" value="@{privaterolls}&{template:aria1} {{name=Attaque}} {{character_name=[@{nameinrolls}](http://journal.roll20.net/character/@{character_id})}} {{body=@{arme} (@{degats})}} {{roll=[[@{degats}]]}}"></button>
                             <div class="weaponinput">
                                 <input name="attr_arme" type="text">
                                 <span>Arme</span>
@@ -203,7 +203,7 @@
                     </div> 
                     <fieldset class="repeating_weapon">
                         <div class="margin-bottom weaponcontainer">
-                            <button class="btn-min" type="roll" name="roll_attaque" value="@{privaterolls}&{template:aria1} {{name=Attaque}} {{character_name=[@{nameinrolls}](http://journal.roll20.net/character/@{character_id})}} {{body=@{arme} (@{degats}+@{bonusDegats})}} {{roll=[[@{degats}cf<0cs<0+@{bonusDegats}]]}}"></button>
+                            <button class="btn-min" type="roll" name="roll_attaque" value="@{privaterolls}&{template:aria1} {{name=Attaque}} {{character_name=[@{nameinrolls}](http://journal.roll20.net/character/@{character_id})}} {{body=@{arme} (@{degats}+@{bonusDegats})}} {{roll=[[@{degats}+@{bonusDegats}]]}}"></button>
                             <div class="weaponinput">
                                 <input name="attr_arme" type="text">
                                 <span>Arme</span>


### PR DESCRIPTION
<!-- ATTENTION: This Pull Request template changed on 2025 04 03. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist

> [!WARNING]
> Submission Checklist
> Failure to complete this checklist in its entirety will result in your Pull Request being dismissed. _Deleting parts of this template (except the new sheet section for existing sheets) counts as failure to complete it_. If you have any questions, please feel free to create an issue.

> [!NOTE]
> Draft Pull Requests
> If you are unclear about any of the rules regarding the creation of character sheets, or need assistance from the Roll20 team, please feel free to create a Draft PR and request feedback. We'd much rather provide assistance than reject a PR.

<!-- Check these off by replacing the empty space with an 'x' in each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

## Pull Request Title

Please format your pull request in the following way: `[Sheet Name] Change Type: Description`. For example: `[D&D5e] New Feature: Adding dragons to dungeons`. 

- [x] The pull request title clearly contains the name of the sheet I am editing.
- [x] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).

## Pull Request Content

- [x] The pull request makes changes to files in only one sub-folder.
- [x] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)
- [x] The pull request does not, _without express prior permission from affected parties_, include any material that could be considered to infringe on a Publisher's intellectual property rights, such as logos, images, rules text or other rules content.

# Changes / Description

<!-- This is an optional step, but detailing the nature of the changes makes it easier for other contributors to track down bugs and fix issues -->
Weapon rolls were having a custom critical success / critical failure threshold, but if the weapon damage was "1d6+3", it would roll `1d6+3cf<0cs<0`, which would not have the intended effect. Thus, we are just removing it from the roll.

Moreover having a roll doing `1d6+3cf<0cs<0+5` would ignore the latest `+5`