### PR TITLE
[Skeleton 1st Edition] Update: Changed melee default to 1d4

### DIFF
--- a/Skeleton 1st Edition/sheet.json
+++ b/Skeleton 1st Edition/sheet.json
@@ -5,5 +5,5 @@
   "roll20userid": "5432360",
   "preview": "skeleton_character_sheet_v1.41.png",
   "instructions": "**Links:**\n\nhttps://linktr.ee/WarlockPrivateer\n\nFunctionality:**\n\nAll attributes and skills can be assigned a d4-d12 dice value which is then used in all roll buttons to roll dice.There are sections for extra items, weapons, boons and curses which can be edited. The descriptions/resources for extra items, boons and curses can be accessed through the checkboxes which toggle them on/off.The configuration section only has two options currently, but there are more possible config options which can be added as needed.",
-  "legacy": true
+  "legacy": false
 }

--- a/Skeleton 1st Edition/skeletonsheet.html
+++ b/Skeleton 1st Edition/skeletonsheet.html
@@ -30,7 +30,7 @@
         
         <div class="sheet-weapon-content">
             <input class="sheet-input-center-aligned" type="text" name="attr_unarmed_weapon" title="@{unarmed}" value="Unarmed" disabled="true" style="width: 200px; height: 28px;"/>
-            <input class="sheet-input-center-aligned" type="text" name="attr_unarmed_damage" title="@{unarmed_damage}" value="1d6" placeholder="1d6" style="width: 50px; height: 28px;"/>
+            <input class="sheet-input-center-aligned" type="text" name="attr_unarmed_damage" title="@{unarmed_damage}" value="1d4" placeholder="1d4" style="width: 50px; height: 28px;"/>
             <!--There is no way (yet) to allow the options to be variable, so the custom skills are put as generic names, this could be changed to a "select-like" thing using radio inputs and labels at some point-->
             <select name="attr_unarmed_damage_ability" title="@{unarmed_damage_ability}" class="sheet-weapon-damagedie" style="width: 100px;" value="None">
                 <option value="1d0">None</option>


### PR DESCRIPTION
> [!NOTE]
> Unsure about something? Open a **Draft PR** and ask — we'd rather help than reject.
>
> Adding a **new sheet**? Use the new-sheet template instead: run `gh pr create --template new_sheet.md`, or append `?template=new_sheet.md` to the compare URL.

## Title

Format: `[Sheet Name] Change Type: Description` — e.g. `[D&D5e] Bugfix: Fix spell slot rollover`

## Checklist (all required)

- [x] Title follows the format above
- [x] Changes are limited to a single sheet folder
- [x] No changes to `translations/*.json` (the sheet's own `translation.json` is fine)
- [x] No publisher IP (logos, art, rules text) without documented permission

## Description

Changed melee default to 1d4 and made sheet non-legacy again since I think that caused some issues with text sizes.
