### PR TITLE
[CyberpunkRED_raycw] Bugfix: Typo HP to SP

### DIFF
--- a/CyberpunkRED_raycw/cyberpunkred-raycw.html
+++ b/CyberpunkRED_raycw/cyberpunkred-raycw.html
@@ -159,11 +159,11 @@
 							<div class="sheet-bg-yellow sheet-take-damage-preview"><input type="text" name="attr_take_damage_preview_hp" readonly /></div>
 						</div>
 						<div class="sheet-flex-table">
-							<div class="sheet-bg-yellow sheet-take-damage-preview-label">New Head HP</div>
+							<div class="sheet-bg-yellow sheet-take-damage-preview-label">New Head SP</div>
 							<div class="sheet-bg-yellow sheet-take-damage-preview"><input type="text" name="attr_take_damage_preview_head_sp" readonly /></div>
 						</div>
 						<div class="sheet-flex-table">
-							<div class="sheet-bg-yellow sheet-take-damage-preview-label">New Body HP</div>
+							<div class="sheet-bg-yellow sheet-take-damage-preview-label">New Body SP</div>
 							<div class="sheet-bg-yellow sheet-take-damage-preview"><input type="text" name="attr_take_damage_preview_body_sp" readonly /></div>
 						</div>
 						<div class="take-damage-main-buttons">


### PR DESCRIPTION
## Title

Format: `[Sheet Name] Change Type: Description` — e.g. `[D&D5e] Bugfix: Fix spell slot rollover`

## Checklist (all required)

- [x] Title follows the format above
- [x] Changes are limited to a single sheet folder
- [x] No changes to `translations/*.json` (the sheet's own `translation.json` is fine)
- [x] No publisher IP (logos, art, rules text) without documented permission

## Description

<!-- What changed and why. Link related issues/PRs. -->

Fixed typo of HP to SP in take damage form.