### PR TITLE
[GURPS] - Version 2.31.0: 3 bugfixes, 2 new features, 2 enhancements

### DIFF
--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -4270,6 +4270,7 @@ button.sheet-positive-action {
     background: var(--highlight-text);
     border-radius: 3px;
     font-weight: bold;
+    width: 135px;
 }
 
 .sheet-view-resync-settings {

--- a/GURPS/gurps.css
+++ b/GURPS/gurps.css
@@ -4270,6 +4270,13 @@ button.sheet-positive-action {
     background: var(--highlight-text);
     border-radius: 3px;
     font-weight: bold;
+}
+
+.sheet-reset button.sheet-reset.sheet-small-width {
+    width: 60px;
+}
+
+.sheet-reset button.sheet-reset.sheet-medium-width {
     width: 135px;
 }
 

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -4387,7 +4387,7 @@
 					<input type="text" name="attr_announcement_version" readonly="readonly" value="0" title="GURPS Character Sheet Version" />
 				</h4>
 
-				<!-- current version notes: 2.30.1 -->
+				<!-- current version notes: 2.31.0 -->
 				<div>
 					Dated: <span name="attr_latest_changes"></span>
 				</div>
@@ -4397,7 +4397,8 @@
 				</h4>
 
 				<div>
-					<b>FIX:</b> Remove residual references to the selected token macro.<br />
+					<b>NEW:</b> Added Demolition calculations based on High-tech rules.<br />
+					<b>FIX:</b> Update style for resync button widths.<br />
 				</div>
 
 				<div style="margin: 10px 0 10px 0;">
@@ -13732,7 +13733,7 @@ visualize what it will look like in chat.
 											</span>	
 										</div>
 										<div class="cell">
-											<input type="number" class="inline" name="attr_weapon_weight" value="3" title="Macro: @{NAME|repeating_melee_$[row #]_weapon_weight}" />
+											<input type="number" class="inline" name="attr_weapon_weight" value="1" title="Macro: @{NAME|repeating_melee_$[row #]_weapon_weight}" />
 										</div>
 									</div> <!-- .row -->
 
@@ -28134,9 +28135,17 @@ For more information, see B409.
 				<p>If there are others that are working on or wish to work on this sheet, lets coordinate using the Roll20 forum for now - perhaps later we can use GitHub.</p>
 			</ul>
 			
-			<!-- current version notes: 2.30.1 -->
+			<!-- current version notes: 2.31.0 -->
 			<h4>Version: <span name="attr_announcement_version"></span></h4>
 			<p>Pull Request: <span name="attr_latest_changes"></span></p>
+			<div>
+				<b>NEW:</b> Added Demolition calculations based on High-tech rules.<br />
+				<b>FIX:</b> Update style for resync button widths.<br />
+			</div>
+			
+			<h4>Version: 2.30.1</h4>
+			<p>Pull Request: 8/10/2026</p>
+			
 			<div>
 				<b>FIX:</b> Remove residual references to the selected token macro.<br />
 			</div>
@@ -34052,9 +34061,9 @@ See notes for the weapon.
 	
 	const noop = function () { }; // do nothing callback function.
 	
-	const version = "2.30.1";
+	const version = "2.31.0";
 	
-	const latestChangesDate = "8/20/2026";
+	const latestChangesDate = "8/31/2026";
 	
 	let modCascade = true;
 	

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -4397,6 +4397,9 @@
 				</h4>
 
 				<div>
+					<b>NEW:</b> Settings Icon > Rules Tab > Added <b>Reset Damage Notes</b> button.<br />
+					<b>ENHANCEMENT:</b> Added High-Tech rules for Demolition Damage Notes.<br />
+					<b>ACTIONS:</b> To get the updated High-Tech rules, use the <b>Reset Damage Notes</b> button.<br />
 					<b>NEW:</b> Added Demolition calculations based on High-tech rules.<br />
 					<b>FIX:</b> Update style for resync button widths.<br />
 					<b>FIX:</b> Newly added records for skills, spells, ranged, melee, defense, and techniques did not display the correct macro names. Added fix to update Macro names when expanding the tool box.<br />
@@ -28140,6 +28143,9 @@ For more information, see B409.
 			<h4>Version: <span name="attr_announcement_version"></span></h4>
 			<p>Pull Request: <span name="attr_latest_changes"></span></p>
 			<div>
+				<b>NEW:</b> Settings Icon > Rules Tab > Added <b>Reset Damage Notes</b> button.<br />
+				<b>ENHANCEMENT:</b> Added High-Tech rules for Demolition Damage Notes.<br />
+				<b>ACTIONS:</b> To get the updated High-Tech rules, use the <b>Reset Damage Notes</b> button.<br />
 				<b>NEW:</b> Added Demolition calculations based on High-tech rules.<br />
 				<b>FIX:</b> Update style for resync button widths.<br />
 				<b>FIX:</b> Newly added records for skills, spells, ranged, melee, defense, and techniques did not display the correct macro names. Added fix to update Macro names when expanding the tool box.<br />

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -4399,6 +4399,7 @@
 				<div>
 					<b>NEW:</b> Added Demolition calculations based on High-tech rules.<br />
 					<b>FIX:</b> Update style for resync button widths.<br />
+					<b>FIX:</b> Newly added records for skills, spells, ranged, melee, defense, and techniques did not display the correct macro names. Added fix to update Macro names when expanding the tool box.<br />
 				</div>
 
 				<div style="margin: 10px 0 10px 0;">
@@ -28141,6 +28142,7 @@ For more information, see B409.
 			<div>
 				<b>NEW:</b> Added Demolition calculations based on High-tech rules.<br />
 				<b>FIX:</b> Update style for resync button widths.<br />
+				<b>FIX:</b> Newly added records for skills, spells, ranged, melee, defense, and techniques did not display the correct macro names. Added fix to update Macro names when expanding the tool box.<br />
 			</div>
 			
 			<h4>Version: 2.30.1</h4>
@@ -36911,37 +36913,26 @@ See notes for the weapon.
 
 	}
 	
-	// if toggle is clicked, update the display id.
+	// if toggle is clicked, update the display id and macro names (needed when a new row is added)
 	// event = {sourceAttribute, sourceType, triggerName, sourceAttribute, previousValue, newValue}
-	on("change:repeating_spells:spell_toggle_notes change:repeating_skills:skill_toggle_notes change:repeating_techniquesrevised:technique_revised_toggle_notes change:repeating_melee:melee_toggle_notes change:repeating_item:item_toggle_notes", event => {
+	on("change:repeating_spells:spell_toggle_notes change:repeating_skills:skill_toggle_notes change:repeating_techniquesrevised:technique_revised_toggle_notes change:repeating_melee:melee_toggle_notes change:repeating_ranged:ranged_toggle_notes change:repeating_item:item_toggle_notes change:repeating_defense:defense_toggle_notes", event => {
 	
 		if (event.triggerName) {
 
 			let row = event.triggerName;
 	
 			let [section, rowId, fieldName] = getSectionRowIdFromChangeEvent(event);
-		
-			switch (section) {
-				case "repeating_spells":
-					updateRowIdDisplay(section, rowId);
-					break;
-		
-				case "repeating_skills":
-					updateRowIdDisplay(section, rowId);
-					break;
-		
-				case "repeating_techniquesrevised":
-					updateRowIdDisplay(section, rowId);
-					break;
-		
-				case "repeating_melee":
-					updateRowIdDisplay(section, rowId);
-					break;
 
-				case "repeating_item":
-					updateRowIdDisplay(section, rowId);
-					break;
+			if (section === "repeating_defense" || section === "repeating_ranged") {
+				updateMacroNames(section, rowId);
+				return;
 			}
+
+			const callback = () => {
+				updateMacroNames(section, rowId);
+			};
+
+			updateRowIdDisplay(section, rowId, callback);
 		}
 		
 	});
@@ -36967,6 +36958,37 @@ See notes for the weapon.
 		// update the field values
 		setAttrs(items, { silent: true }, callback);
 	
+	}
+
+	function updateMacroNames(section, rowId, callback = noop) {
+		
+		// get all the macro names
+		let fields = [
+			"custom_skill_macro_one_name",
+			"custom_skill_macro_two_name",
+			"custom_skill_macro_three_name",
+			"custom_skill_macro_four_name",
+			"custom_skill_macro_five_name",
+			"custom_skill_macro_six_name"
+		];
+
+		getAttrs(fields, function(values) {
+			
+			// Update the macro names based on the retrieved values
+			// for the section and rowid
+			let keyValues = {};
+			
+			keyValues[`${section}_${rowId}_macro_one_name`] = values["custom_skill_macro_one_name"];
+			keyValues[`${section}_${rowId}_macro_two_name`] = values["custom_skill_macro_two_name"];
+			keyValues[`${section}_${rowId}_macro_three_name`] = values["custom_skill_macro_three_name"];
+			keyValues[`${section}_${rowId}_macro_four_name`] = values["custom_skill_macro_four_name"];
+			keyValues[`${section}_${rowId}_macro_five_name`] = values["custom_skill_macro_five_name"];
+			keyValues[`${section}_${rowId}_macro_six_name`] = values["custom_skill_macro_six_name"];
+
+			setAttrs(keyValues, { silent: true }, callback);
+
+		});
+
 	}
 	
 	// Update the total cost of Techniques

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -30868,6 +30868,15 @@ For more information, see B409.
 				<div class="option-column">
 				
 					<div class="option-container collision-falling-options">
+
+						<div>
+							<button type="action" name="act_damage_notes_reset" class="reset" style="width: 130px;">
+								<span data-i18n="reset-damage-notes-button-label">Reset Damage Notes</span>
+							</button>
+							<br />
+							<span data-i18n="damage-notes-button-description">If you modified a note, you will not see the most recent rule updates. Press the button to get the recent rules. <b>NOTE:</b> this will replace any notes you made.</span>
+						</div>
+
 						<h4>
 							<span data-i18n="falling-damage-notes-label">Falling Damage Notes B431</span>
 						</h4>
@@ -30905,7 +30914,18 @@ For more information, see B409.
 * If the explosion has an armor divisor, do NOT apply to "collateral damage.
 * Explosions are considered incendiary. see Catching Fire B434.
 * Can use Dodge and Drop (B377) to avoid collateral damage.
-* See B414</textarea>
+* See B414
+
+High-Tech 181-182
+HT Roll. 
+-1 per 5 points of penetrating damage.
++1 earplugs
++5 Protected Hearing
+Fail, stunned roll vs HT per turn to recover.
+Fail, tinnitus for 20-HT minutes. (Minimum 1 minute). Hearing penalty equal to margin of failure
+Critical Fail, deafness for 20-HT minutes. (Minimum 1 minute)
+Afterwards, roll HT per turn to recover from tinnitus or deafness.
+Critical Failure on a recovery roll results in permanent tinnitus or deafness.</textarea>
 					</div><!-- end option-container -->
 				
 					<div class="option-container collision-falling-options">
@@ -44644,6 +44664,52 @@ See notes for the weapon.
 		const deathCheckCriticalFailureNotes = `You died! When a PC or important NPC is killed in any but the most sudden and thorough fashion, the GM should allow a "dying action." If this is a final blow to the enemy, it should take no more than a turn. (B423)
 		**On a Failure of only 1 or 2:** you don't drop dead, but suffer a "mortal wound."" This is a wound so severe that your internal injuries might kill you even after you stop bleeding. (See Mortal Wounds B423)`;
 
+		/** DAMAGE NOTES **/
+		const fallingDamageNotes = `**Immovable Objects:** Inflict damage on both objects. If immovable is breakable, moving object can't inflict/take more damage than immovable's (HP + DR). 
+
+**Immovable Soft Object:** Add DR 2 (feather bed) to DR 10 (safety net).
+
+**Striking Water:** Swimming or Vehicle Skill Roll minus Speed Penalty from Size and Speed/Range Table B550 to avoid all damage.
+
+**Armor:** ALL armor counts as flexible armor. If DR blocks all damage, moving object suffers 1 HP per 5 points of falling damage.
+
+**Falling Damage**: If using hit locations, roll randomly. If extremity/limb, do not ignore injury in excess of crippling damage. Instead, subtract the full amount from HP! If crippled limb, roll 1d. On 5-6, all limbs of that type are crippled, although there is no extra injury.`;
+
+		const collisionDamageNotes = `**Immovable Objects:** Inflict damage on both objects. If immovable is breakable, moving object can't inflict/take more damage than immovable's (HP + DR). 
+
+**Immovable Soft Object:** Add DR 2 (feather bed) to DR 10 (safety net).
+
+**Striking Water:** Swimming or Vehicle Skill Roll minus Speed Penalty from Size and Speed/Range Table B550 to avoid all damage.
+
+**Armor:** ALL armor counts as flexible armor. If DR blocks all damage, moving object suffers 1 HP per 5 points of falling damage.`;
+
+		const demolitionDamageNotes = `Explosion damage. Targets struck directly takes listed damage. Apply "collateral damage" of Damage / (3 x distance from center of blast) rounded down.
+
+* Use torso armor to determine DR against explosion.
+* If the explosion has an armor divisor, do NOT apply to "collateral damage.
+* Explosions are considered incendiary. see Catching Fire B434.
+* Can use Dodge and Drop (B377) to avoid collateral damage.
+* See B414
+
+High-Tech 181-182
+HT Roll. 
+-1 per 5 points of penetrating damage.
++1 earplugs
++5 Protected Hearing
+Fail, stunned roll vs HT per turn to recover.
+Fail, tinnitus for 20-HT minutes. (Minimum 1 minute). Hearing penalty equal to margin of failure
+Critical Fail, deafness for 20-HT minutes. (Minimum 1 minute)
+Afterwards, roll HT per turn to recover from tinnitus or deafness.
+Critical Failure on a recovery roll results in permanent tinnitus or deafness.`;
+		
+		const fragmentationSkillNotes = `For every three points by which the attack roll succeeds, one additional fragment strikes the target.
+
+The only active defense against fragments is to dive away from the explosion that produced them; see Dodge and Drop and Diving for Cober (B377).
+
+For each hit, roll hit location randomly. If that location is behind cover, the fragment hits cover.`;
+		
+		const fragmentationDamageNotes = `Fragmentation damage is cutting. Note that if an explosive attack has an armor divisor, this does not apply to the fragments it produces.`;
+
 	    const notes = [
 			{ code: "dodge_success_notes", value: dodgeSuccessNotes },
 			{ code: "dodge_critical_success_notes", value: dodgeCriticalSuccessNotes },
@@ -44699,7 +44765,12 @@ See notes for the weapon.
 			{ code: "unconscious_check_success_notes", value: unconsciousCheckSuccessNotes },
 			{ code: "unconscious_check_fail_notes", value: unconsciousCheckFailNotes },
 			{ code: "unconscious_check_critical_success_notes", value: unconsciousCheckCriticalSuccessNotes }, 
-			{ code: "unconscious_check_critical_failure_notes", value: unconsciousCheckCriticalFailureNotes }
+			{ code: "unconscious_check_critical_failure_notes", value: unconsciousCheckCriticalFailureNotes },
+			{ code: "falling_damage_notes", value: fallingDamageNotes },
+			{ code: "collision_damage_notes", value: collisionDamageNotes },
+			{ code: "demolition_damage_notes", value: demolitionDamageNotes },
+			{ code: "fragmentation_skill_notes", value: fragmentationSkillNotes },
+			{ code: "fragmentation_damage_notes", value: fragmentationDamageNotes }
 		];
 	
 		return notes;
@@ -53062,6 +53133,38 @@ See notes for the weapon.
 			spell_critical_success_notes: spellCriticalSuccessNotes,
 			spell_fail_notes: spellFailNotes,
 			spell_critical_failure_notes: spellCriticalFailureNotes
+		}
+
+		setAttrs(notesToUpdate);
+		
+	}
+
+	// reset notes for damage descriptions
+	// when button is clicked, show the updates tab
+	on("clicked:damage_notes_reset", event => {
+
+		resetDamageRollNotes();
+
+	});
+
+	const resetDamageRollNotes = () => {
+
+		const fallingDamageNotes = getNotesByCode("falling_damage_notes");
+
+		const collisionDamageNotes = getNotesByCode("collision_damage_notes");
+
+		const demolitionDamageNotes = getNotesByCode("demolition_damage_notes");
+
+		const fragmentationSkillNotes = getNotesByCode("fragmentation_skill_notes");
+
+		const fragmentationDamageNotes = getNotesByCode("fragmentation_damage_notes");
+
+		const notesToUpdate = {
+			falling_damage_notes: fallingDamageNotes,
+			collision_damage_notes: collisionDamageNotes,
+			demolition_damage_notes: demolitionDamageNotes,
+			fragmentation_skill_notes: fragmentationSkillNotes,
+			fragmentation_damage_notes: fragmentationDamageNotes
 		}
 
 		setAttrs(notesToUpdate);

--- a/GURPS/gurps.html
+++ b/GURPS/gurps.html
@@ -16437,7 +16437,7 @@ Slam uses either DX, Brawling, or Sumo Wrestling. Note that the -4 to hit and ef
 											<label>
 												<span data-i18n="base-skill-label">Base Skill</span>:
 											</label>
-											<input type="number" value="15" step="1" name="attr_fragmentation_skill" title=""Macro: @{NAME|fragmentation_skill}" />
+											<input type="number" value="15" step="1" name="attr_fragmentation_skill" title=""Macro: @{NAME|fragmentation_skill}" class="medium-width" />
 										</div>
 										<div class="grid-item container-label-input">
 											<label>
@@ -16449,7 +16449,7 @@ Slam uses either DX, Brawling, or Sumo Wrestling. Note that the -4 to hit and ef
 												</div>
 											</label>
 											<input type="hidden" name="attr_fragmentation_range_modifier" value="0" />
-											<input type="number" value="0" name="attr_fragmentation_range" title="Macro: @{NAME|fragmentation_range}" />
+											<input type="number" value="0" name="attr_fragmentation_range" title="Macro: @{NAME|fragmentation_range}" class="medium-width" />
 										</div>
 										<div class="grid-item container-label-input">
 											<label>
@@ -16473,7 +16473,7 @@ Slam uses either DX, Brawling, or Sumo Wrestling. Note that the -4 to hit and ef
 											<label>
 												<span data-i18n="size-modifier-label">Size Modifier</span>:
 											</label>
-											<input type="number" value="0" name="attr_fragmentation_size_modifier" title="Macro: @{NAME|fragmentation_size_modifier}" />
+											<input type="number" value="0" name="attr_fragmentation_size_modifier" title="Macro: @{NAME|fragmentation_size_modifier}" class="medium-width" />
 										</div>
 									</div>
 								</div>
@@ -30704,7 +30704,7 @@ For more information, see B409.
 						</h4>
 						<div class="reset resync">
 							<input type="hidden" name="attr_resync_state" value="normal" />
-							<button type="action" name="act_resync" class="reset">
+							<button type="action" name="act_resync" class="reset medium-width">
 								<span data-i18n="resync-tables-label">Resync Tables</span>
 							</button>
 							<div class="resync-tooltip">
@@ -30718,7 +30718,7 @@ For more information, see B409.
 						</div>
 						<div class="reset resync">
 							<input type="hidden" name="attr_resync_via_attributes_state" value="normal" />
-							<button type="action" name="act_resync_via_attributes" class="reset">
+							<button type="action" name="act_resync_via_attributes" class="reset medium-width">
 								<span data-i18n="resync-via-attributes-label">Resync via Attributes</span>
 							</button>
 							<div class="resync-tooltip">

--- a/GURPS/translation.json
+++ b/GURPS/translation.json
@@ -1359,6 +1359,8 @@
   "wound-notes-button-description": "If you modified a note, you will not see the most recent rule updates. Press the button to get the recent rules. <b>NOTE:</b> this will replace any notes you made.",
   "reset-spell-notes-button-label": "Reset Spell Notes",
   "spell-notes-button-description": "If you modified a note, you will not see the most recent rule updates. Press the button to get the recent rules. <b>NOTE:</b> this will replace any notes you made.",
+  "reset-damage-notes-button-label": "Reset Damage Notes",
+  "damage-notes-button-description": "If you modified a note, you will not see the most recent rule updates. Press the button to get the recent rules. <b>NOTE:</b> this will replace any notes you made.",
   "reset-fright-check-button-label": "Reset Fright Check Notes",
   "fright-check-notes-button-description": "If you modified a note, you will not see the most recent rule updates. Press the button to get the recent rules. <b>NOTE:</b> this will replace any notes you made.",
   "fright-check-success-notes-label": "Fright Check Success Notes",


### PR DESCRIPTION
## Title

Format: `[Sheet Name] Change Type: Description` — e.g. `[D&D5e] Bugfix: Fix spell slot rollover`

## Checklist (all required)

- [x] Title follows the format above
- [x] Changes are limited to a single sheet folder
- [x] No changes to `translations/*.json` (the sheet's own `translation.json` is fine)
- [x] No publisher IP (logos, art, rules text) without documented permission

## Description

FIX: Combat Tab > Tools > Demolition Section: Corrected the calculation for How Much? weight.
NEW: Settings Icon > Rules Tab > Added Reset Damage Notes button.
ENHANCEMENT: Added High-Tech rules for Demolition Damage Notes.
ACTIONS: To get the updated High-Tech rules, use the Reset Damage Notes button.
ENHANCEMENT: Added explosion types from High-Tech rules.
NEW: Combat > Tools tab > Added Material Destruction calculations based on High-Tech rules, page 180-181.
FIX: Update style for resync button widths.
FIX: Newly added records for skills, spells, ranged, melee, defense, and techniques did not display the correct macro names. Added fix to update Macro names when expanding the tool box.
